### PR TITLE
Fixed loop index

### DIFF
--- a/src/model-base-ekf-flex-estimator-imu.cpp
+++ b/src/model-base-ekf-flex-estimator-imu.cpp
@@ -387,7 +387,7 @@ namespace stateObservation
             contactPositions_.clear();
             for (unsigned j = 0; j<functor_.getContactsNumber() ; ++j)
             {
-              contactPositions_.push_back(getInput().segment<3>(42 + 12*i));
+              contactPositions_.push_back(getInput().segment<3>(42 + 12*j));
             }
             ekf_.getEstimatedState(i);
 


### PR DESCRIPTION
Loop index is ``j`` there, but ``i`` is also defined as the outer loop index so this may try to access memory outside of the input vector.