### PR TITLE
Setup and enforce clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,106 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^(<mc_[a-z]*/)'
+    Priority:        1
+  - Regex:           '^(<Tasks/)'
+    Priority:        2
+  - Regex:           '^(<mc_rbdyn_urdf/)'
+    Priority:        3
+  - Regex:           '^(<RBDyn/)'
+    Priority:        4
+  - Regex:           '^(<SpaceVecAlg/)'
+    Priority:        5
+  - Regex:           '^(<sch-core/)'
+    Priority:        6
+  - Regex:           '^(<boost/)'
+    Priority:        7
+  - Regex:           '^(<(nanomsg|geos|.*_msgs|ros|tf2.*)/)'
+    Priority:        8
+  - Regex:           '.*'
+    Priority:        9
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     2
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 150
+PenaltyReturnTypeOnItsOwnLine: 300
+PointerAlignment: Middle
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        2
+UseTab:          Never
+...
+

--- a/.clang-format-check.sh
+++ b/.clang-format-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+readonly this_dir=`cd $(dirname $0); pwd`
+cd $this_dir
+source .clang-format-common.sh
+
+out=0
+tmpfile=$(mktemp /tmp/clang-format-check.XXXXXX)
+for f in ${src_files}; do
+  $clang_format -style=file $f > $tmpfile
+  if ! [[ -z `diff $tmpfile $f` ]]; then
+    echo "Wrong formatting in $f"
+    out=1
+  fi
+done
+rm -f $tmpfile
+if [[ $out -eq 1 ]]; then
+  echo "You can run ./.clang-format-fix.sh to fix the issues locally, then commit/push again"
+fi
+exit $out

--- a/.clang-format-common.sh
+++ b/.clang-format-common.sh
@@ -1,0 +1,14 @@
+# This script is meant to be sourced from other scripts
+
+# Check for clang-format, prefer 6.0 if available
+if [[ -x "$(command -v clang-format-6.0)" ]]; then
+  clang_format=clang-format-6.0
+elif [[ -x "$(command -v clang-format)" ]]; then
+  clang_format=clang-format
+else
+  echo "clang-format or clang-format-6.0 must be installed"
+  exit 1
+fi
+
+# Find all source files in the project minus those that are auto-generated or we do not maintain
+src_files=`find src include misc-tools unit-testings -name '*.cpp' -or -name '*.h' -or -name '*.hpp'`

--- a/.clang-format-fix.sh
+++ b/.clang-format-fix.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+readonly this_dir=`cd $(dirname $0); pwd`
+cd $this_dir
+source .clang-format-common.sh
+
+for f in ${src_files}; do
+  $clang_format -style=file -i $f
+done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,22 @@ jobs:
     - name: Run cmake-format-check
       run: |
         ./.cmake-format-check.sh
-  build:
+  clang-format:
     needs: cmake-format
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install clang-format-6.0
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get -qq update
+        sudo apt-get -qq remove clang-6.0 libclang1-6.0 libclang-common-6.0-dev libllvm6.0
+        sudo apt-get -qq install clang-format-6.0 clang-format
+    - name: Run clang-format-check
+      run: |
+        ./.clang-format-check.sh
+  build:
+    needs: clang-format
     strategy:
       fail-fast: false
       matrix:

--- a/include/state-observation/dynamical-system/bidim-elastic-inv-pendulum-dyn-sys.hpp
+++ b/include/state-observation/dynamical-system/bidim-elastic-inv-pendulum-dyn-sys.hpp
@@ -16,79 +16,75 @@
 #include <state-observation/api.h>
 #include <state-observation/dynamical-system/dynamical-system-functor-base.hpp>
 #include <state-observation/noise/noise-base.hpp>
-#include <state-observation/api.h>
 
 namespace stateObservation
 {
 
-     /**
-    * \class  BidimElasticInvPendulum
-    * \brief  The class is an implementation of the dynamical system defined by
-    *         a 2D inverted pendulum with an elastic joint. The input is the
-    *         horizontal acceleration.
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI BidimElasticInvPendulum : public DynamicalSystemFunctorBase
-    {
-    public:
-        ///The constructor
-        BidimElasticInvPendulum();
+/**
+ * \class  BidimElasticInvPendulum
+ * \brief  The class is an implementation of the dynamical system defined by
+ *         a 2D inverted pendulum with an elastic joint. The input is the
+ *         horizontal acceleration.
+ *
+ */
+class STATE_OBSERVATION_DLLAPI BidimElasticInvPendulum : public DynamicalSystemFunctorBase
+{
+public:
+  /// The constructor
+  BidimElasticInvPendulum();
 
-        ///The virtual destructor
-        virtual ~BidimElasticInvPendulum();
+  /// The virtual destructor
+  virtual ~BidimElasticInvPendulum();
 
-        ///Description of the state dynamics
-        virtual Vector stateDynamics
-        (const Vector& x, const Vector& u, TimeIndex k);
+  /// Description of the state dynamics
+  virtual Vector stateDynamics(const Vector & x, const Vector & u, TimeIndex k);
 
-        ///Description of the sensor's dynamics
-        virtual Vector measureDynamics
-        (const Vector& x, const Vector& u, TimeIndex k);
+  /// Description of the sensor's dynamics
+  virtual Vector measureDynamics(const Vector & x, const Vector & u, TimeIndex k);
 
-        ///Sets a noise which disturbs the state dynamics
-        virtual void setProcessNoise( NoiseBase * );
-        ///Removes the process noise
-        virtual void resetProcessNoise();
-        ///Gets the process noise
-        virtual NoiseBase * getProcessNoise() const;
+  /// Sets a noise which disturbs the state dynamics
+  virtual void setProcessNoise(NoiseBase *);
+  /// Removes the process noise
+  virtual void resetProcessNoise();
+  /// Gets the process noise
+  virtual NoiseBase * getProcessNoise() const;
 
-        ///Sets a noise which disturbs the measurements
-        virtual void setMeasurementNoise( NoiseBase * );
-        ///Removes the measurement noise
-        virtual void resetMeasurementNoise();
-        ///Gets a pointer on the measurement noise
-        virtual NoiseBase * getMeasurementNoise() const;
+  /// Sets a noise which disturbs the measurements
+  virtual void setMeasurementNoise(NoiseBase *);
+  /// Removes the measurement noise
+  virtual void resetMeasurementNoise();
+  /// Gets a pointer on the measurement noise
+  virtual NoiseBase * getMeasurementNoise() const;
 
-        ///Set the period of the time discretization
-        virtual void setSamplingPeriod(double dt);
+  /// Set the period of the time discretization
+  virtual void setSamplingPeriod(double dt);
 
-        ///Gets the state size
-        virtual Index getStateSize() const;
-        ///Gets the input size
-        virtual Index getInputSize() const;
-        ///Gets the measurement size
-        virtual Index getMeasurementSize() const;
+  /// Gets the state size
+  virtual Index getStateSize() const;
+  /// Gets the input size
+  virtual Index getInputSize() const;
+  /// Gets the measurement size
+  virtual Index getMeasurementSize() const;
 
-        /// set the height of the com of the pendulum
-        void setHeight(const double & h);
-        /// set the mass of the pendulum
-        void setMass(const double &m);
-        /// set the elasticity of the pendulum
-        void setElasticity(const double &k);
+  /// set the height of the com of the pendulum
+  void setHeight(const double & h);
+  /// set the mass of the pendulum
+  void setMass(const double & m);
+  /// set the elasticity of the pendulum
+  void setElasticity(const double & k);
 
-    protected:
+protected:
+  double k_;
+  double m_;
+  double h_;
 
-        double k_;
-        double m_;
-        double h_;
+  NoiseBase * processNoise_;
 
-        NoiseBase * processNoise_;
+  double dt_;
 
-        double dt_;
-
-        static const Index stateSize_=4;
-        static const Index inputSize_=1;
-        static const Index measurementSize_=0;
-    };
-}
+  static const Index stateSize_ = 4;
+  static const Index inputSize_ = 1;
+  static const Index measurementSize_ = 0;
+};
+} // namespace stateObservation
 #endif // BIDIM_ELASTIC_INV_PENDULUM

--- a/include/state-observation/dynamical-system/dynamical-system-functor-base.hpp
+++ b/include/state-observation/dynamical-system/dynamical-system-functor-base.hpp
@@ -19,62 +19,59 @@
 namespace stateObservation
 {
 
-    /**
-    * \class  DynamicsFunctorBase
-    * \brief
-    *        This is the base class of any functor that describes the dynamics
-    *        of the state and the measurement.
-    *        This class is to be derived in order to be given
-    *        to the Extended Kalman Filter.
-    *
-    */
+/**
+ * \class  DynamicsFunctorBase
+ * \brief
+ *        This is the base class of any functor that describes the dynamics
+ *        of the state and the measurement.
+ *        This class is to be derived in order to be given
+ *        to the Extended Kalman Filter.
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI DynamicalSystemFunctorBase
-    {
-    public:
-        DynamicalSystemFunctorBase();
-        virtual ~DynamicalSystemFunctorBase();
+class STATE_OBSERVATION_DLLAPI DynamicalSystemFunctorBase
+{
+public:
+  DynamicalSystemFunctorBase();
+  virtual ~DynamicalSystemFunctorBase();
 
-        ///The function to oberload to describe the dynamics of the state
-        virtual Vector stateDynamics
-        (const Vector& x, const Vector& u, TimeIndex k)=0;
+  /// The function to oberload to describe the dynamics of the state
+  virtual Vector stateDynamics(const Vector & x, const Vector & u, TimeIndex k) = 0;
 
-        ///The function to overload to describe the dynamics of the sensor (measurements)
-        virtual Vector measureDynamics
-        (const Vector& x, const Vector& u, TimeIndex k)=0;
+  /// The function to overload to describe the dynamics of the sensor (measurements)
+  virtual Vector measureDynamics(const Vector & x, const Vector & u, TimeIndex k) = 0;
 
-        ///The method to overload if the functor needs to be reset when the
-        ///Exteded Kalman filter is reset itself
-        virtual void reset(){}
+  /// The method to overload if the functor needs to be reset when the
+  /// Exteded Kalman filter is reset itself
+  virtual void reset() {}
 
-        ///gets the state size
-        virtual Index getStateSize()const =0 ;
-        ///gets the input size
-        virtual Index getInputSize()const =0 ;
-        ///gets the measurements size
-        virtual Index getMeasurementSize() const=0;
+  /// gets the state size
+  virtual Index getStateSize() const = 0;
+  /// gets the input size
+  virtual Index getInputSize() const = 0;
+  /// gets the measurements size
+  virtual Index getMeasurementSize() const = 0;
 
-        ///Gives a boolean answer on whether or not the vector is correctly sized to be a state vector
-        virtual bool checkStateVector(const Vector &);
-        ///Gives a boolean answer on whether or not the vector is correctly sized to be an input vector
-        virtual bool checkInputvector(const Vector &);
+  /// Gives a boolean answer on whether or not the vector is correctly sized to be a state vector
+  virtual bool checkStateVector(const Vector &);
+  /// Gives a boolean answer on whether or not the vector is correctly sized to be an input vector
+  virtual bool checkInputvector(const Vector &);
 
-    protected:
+protected:
+  inline void assertStateVector_(const Vector & v)
+  {
+    (void)v; // avoid warning
+    BOOST_ASSERT(checkStateVector(v) && "ERROR: The state vector has the wrong size");
+  }
+  inline void assertInputVector_(const Vector & v)
+  {
+    (void)v; // avoid warning
+    BOOST_ASSERT(checkInputvector(v) && "ERROR: The input vector has the wrong size");
+  }
 
-        inline void assertStateVector_(const Vector & v)
-        {
-            (void)v;//avoid warning
-            BOOST_ASSERT(checkStateVector(v) && "ERROR: The state vector has the wrong size");
-        }
-        inline void assertInputVector_(const Vector & v)
-        {
-            (void)v;//avoid warning
-            BOOST_ASSERT(checkInputvector(v) && "ERROR: The input vector has the wrong size");
-        }
+private:
+};
 
-    private:
-    };
-
-}
+} // namespace stateObservation
 
 #endif // STATEOBSERVERDYNAMICSYSTEMFUNCTORBASE_H

--- a/include/state-observation/dynamical-system/dynamical-system-simulator.hpp
+++ b/include/state-observation/dynamical-system/dynamical-system-simulator.hpp
@@ -20,86 +20,83 @@
 
 namespace stateObservation
 {
-    /**
-    * \class  DynamicalSystemSimulator
-    * \brief
-    *        The class gives a small encapsulation of the dynamics functor,
-    *       which enables the simulation of the dynamics and the storage of
-    *       states, inputs and measurements.
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI DynamicalSystemSimulator
-    {
-    public:
-        ///Constructor
-        DynamicalSystemSimulator();
+/**
+ * \class  DynamicalSystemSimulator
+ * \brief
+ *        The class gives a small encapsulation of the dynamics functor,
+ *       which enables the simulation of the dynamics and the storage of
+ *       states, inputs and measurements.
+ *
+ */
+class STATE_OBSERVATION_DLLAPI DynamicalSystemSimulator
+{
+public:
+  /// Constructor
+  DynamicalSystemSimulator();
 
-        ///Virtual destructor
-        virtual ~DynamicalSystemSimulator();
+  /// Virtual destructor
+  virtual ~DynamicalSystemSimulator();
 
-        ///Sets a pointer to the dynamics Functor (the class does not destroy
-        ///the Functor when the class is destroyed.)
-        virtual void setDynamicsFunctor(DynamicalSystemFunctorBase * );
+  /// Sets a pointer to the dynamics Functor (the class does not destroy
+  /// the Functor when the class is destroyed.)
+  virtual void setDynamicsFunctor(DynamicalSystemFunctorBase *);
 
-        ///Sets the state value at instant k
-        virtual void setState( const Vector & x, TimeIndex k);
+  /// Sets the state value at instant k
+  virtual void setState(const Vector & x, TimeIndex k);
 
-        ///Set the value of the input at instant k
-        ///If no value of the input is available when simulating the system
-        ///the previous input value is automatically set.
-        virtual void setInput( const Vector & u, TimeIndex k);
+  /// Set the value of the input at instant k
+  /// If no value of the input is available when simulating the system
+  /// the previous input value is automatically set.
+  virtual void setInput(const Vector & u, TimeIndex k);
 
-        ///Gets the state of the current time
-        virtual Vector getCurrentState() const;
+  /// Gets the state of the current time
+  virtual Vector getCurrentState() const;
 
-        ///Gets the current time
-        virtual TimeIndex getCurrentTime() const;
+  /// Gets the current time
+  virtual TimeIndex getCurrentTime() const;
 
-        ///Runs one loop of the dynamics simulation
-        virtual void simulateDynamics();
+  /// Runs one loop of the dynamics simulation
+  virtual void simulateDynamics();
 
-        ///Runs the simulation until a given time index
-        virtual void simulateDynamicsTo(TimeIndex k);
+  /// Runs the simulation until a given time index
+  virtual void simulateDynamicsTo(TimeIndex k);
 
-        ///Gets the input of a given time index,
-        ///if the Input is not available the previous input is provided
-        virtual Vector getInput(TimeIndex k) const;
+  /// Gets the input of a given time index,
+  /// if the Input is not available the previous input is provided
+  virtual Vector getInput(TimeIndex k) const;
 
-        ///Gets the measurement value at a given time index
-        ///if the value is not available, the dynamics is simulated
-        ///to the time k
-        virtual Vector getMeasurement( TimeIndex k );
+  /// Gets the measurement value at a given time index
+  /// if the value is not available, the dynamics is simulated
+  /// to the time k
+  virtual Vector getMeasurement(TimeIndex k);
 
-        ///Gets the state value at a given time index
-        ///if the value is not available, the dynamics is simulated
-        ///to the time k
-        virtual Vector getState( TimeIndex k );
+  /// Gets the state value at a given time index
+  /// if the value is not available, the dynamics is simulated
+  /// to the time k
+  virtual Vector getState(TimeIndex k);
 
-        ///Gives a IndexedVectorArray of the measurements starting at startingTime
-        ///and having the given  duration
-        virtual IndexedVectorArray getMeasurementArray
-                    (TimeIndex startingTime, TimeSize duration);
+  /// Gives a IndexedVectorArray of the measurements starting at startingTime
+  /// and having the given  duration
+  virtual IndexedVectorArray getMeasurementArray(TimeIndex startingTime, TimeSize duration);
 
-        ///Gives a IndexedVectorArray of the states starting at startingTime
-        ///and having the given  duration
-        virtual IndexedVectorArray getStateArray
-                    (TimeIndex startingTime, TimeSize duration);
+  /// Gives a IndexedVectorArray of the states starting at startingTime
+  /// and having the given  duration
+  virtual IndexedVectorArray getStateArray(TimeIndex startingTime, TimeSize duration);
 
-        ///resets all the states, the measurements and the inputs
-        virtual void resetDynamics();
+  /// resets all the states, the measurements and the inputs
+  virtual void resetDynamics();
 
-        ///resets all the simulator with even the dynamics functor
-        virtual void resetSimulator();
+  /// resets all the simulator with even the dynamics functor
+  virtual void resetSimulator();
 
-    protected:
-        DynamicalSystemFunctorBase * f_;
+protected:
+  DynamicalSystemFunctorBase * f_;
 
-        IndexedVectorArray x_;
+  IndexedVectorArray x_;
 
-        IndexedVectorArray y_;
+  IndexedVectorArray y_;
 
-        std::map<TimeIndex, Vector> u_;
-
-    };
-}
+  std::map<TimeIndex, Vector> u_;
+};
+} // namespace stateObservation
 #endif // STATEOBSERVATIONDYNAMICALSYSTEMSIMULATOR_H

--- a/include/state-observation/dynamical-system/imu-dynamical-system.hpp
+++ b/include/state-observation/dynamical-system/imu-dynamical-system.hpp
@@ -15,85 +15,82 @@
 
 #include <state-observation/api.h>
 #include <state-observation/dynamical-system/dynamical-system-functor-base.hpp>
-#include <state-observation/tools/rigid-body-kinematics.hpp>
-#include <state-observation/sensors-simulation/accelerometer-gyrometer.hpp>
 #include <state-observation/noise/noise-base.hpp>
+#include <state-observation/sensors-simulation/accelerometer-gyrometer.hpp>
+#include <state-observation/tools/rigid-body-kinematics.hpp>
 
 namespace stateObservation
 {
 
-     /**
-    * \class  IMUDynamicalSystem
-    * \brief  The class is an implementation of the dynamical system defined by
-    *         an inertial measurement unit (IMU) fixed on a rigid body. The state
-    *         is the position velocity and acceleration and the orientaion and rotation
-    *         velocity and acceleration. The sensors are the accelerometer and the gyrometer
-    *
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI IMUDynamicalSystem : public DynamicalSystemFunctorBase
-    {
-    public:
-        ///The constructor
-        IMUDynamicalSystem();
+/**
+ * \class  IMUDynamicalSystem
+ * \brief  The class is an implementation of the dynamical system defined by
+ *         an inertial measurement unit (IMU) fixed on a rigid body. The state
+ *         is the position velocity and acceleration and the orientaion and rotation
+ *         velocity and acceleration. The sensors are the accelerometer and the gyrometer
+ *
+ *
+ */
+class STATE_OBSERVATION_DLLAPI IMUDynamicalSystem : public DynamicalSystemFunctorBase
+{
+public:
+  /// The constructor
+  IMUDynamicalSystem();
 
-        ///The virtual destructor
-        virtual ~IMUDynamicalSystem();
+  /// The virtual destructor
+  virtual ~IMUDynamicalSystem();
 
-        ///Description of the state dynamics
-        virtual Vector stateDynamics
-        (const Vector& x, const Vector& u, TimeIndex k);
+  /// Description of the state dynamics
+  virtual Vector stateDynamics(const Vector & x, const Vector & u, TimeIndex k);
 
-        ///Description of the sensor's dynamics
-        virtual Vector measureDynamics
-        (const Vector& x, const Vector& u, TimeIndex k);
+  /// Description of the sensor's dynamics
+  virtual Vector measureDynamics(const Vector & x, const Vector & u, TimeIndex k);
 
-        ///Sets a noise which disturbs the state dynamics
-        virtual void setProcessNoise( NoiseBase * );
-        ///Removes the process noise
-        virtual void resetProcessNoise();
-        ///Gets the process noise
-        virtual NoiseBase * getProcessNoise() const;
+  /// Sets a noise which disturbs the state dynamics
+  virtual void setProcessNoise(NoiseBase *);
+  /// Removes the process noise
+  virtual void resetProcessNoise();
+  /// Gets the process noise
+  virtual NoiseBase * getProcessNoise() const;
 
-        ///Sets a noise which disturbs the measurements
-        virtual void setMeasurementNoise( NoiseBase * );
-        ///Removes the measurement noise
-        virtual void resetMeasurementNoise();
-        ///Gets a pointer on the measurement noise
-        virtual NoiseBase * getMeasurementNoise() const;
+  /// Sets a noise which disturbs the measurements
+  virtual void setMeasurementNoise(NoiseBase *);
+  /// Removes the measurement noise
+  virtual void resetMeasurementNoise();
+  /// Gets a pointer on the measurement noise
+  virtual NoiseBase * getMeasurementNoise() const;
 
-        ///Set the period of the time discretization
-        virtual void setSamplingPeriod(double dt);
+  /// Set the period of the time discretization
+  virtual void setSamplingPeriod(double dt);
 
-        ///Gets the state size
-        virtual Index getStateSize() const;
-        ///Gets the input size
-        virtual Index getInputSize() const;
-        ///Gets the measurement size
-        virtual Index getMeasurementSize() const;
+  /// Gets the state size
+  virtual Index getStateSize() const;
+  /// Gets the input size
+  virtual Index getInputSize() const;
+  /// Gets the measurement size
+  virtual Index getMeasurementSize() const;
 
-    protected:
-        typedef kine::indexes<kine::rotationVector> indexes;
+protected:
+  typedef kine::indexes<kine::rotationVector> indexes;
 
-        AccelerometerGyrometer sensor_;
+  AccelerometerGyrometer sensor_;
 
-        NoiseBase * processNoise_;
+  NoiseBase * processNoise_;
 
-        double dt_;
+  double dt_;
 
-        Vector3Unaligned orientationVector_;
-        QuaternionUnaligned quaternion_;
+  Vector3Unaligned orientationVector_;
+  QuaternionUnaligned quaternion_;
 
-        Quaternion computeQuaternion_(const Vector3 & x);
+  Quaternion computeQuaternion_(const Vector3 & x);
 
-        static const Index stateSize_=18;
-        static const Index inputSize_=6;
-        static const Index measurementSize_=6;
+  static const Index stateSize_ = 18;
+  static const Index inputSize_ = 6;
+  static const Index measurementSize_ = 6;
 
-    private:
-
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    };
-}
+private:
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+} // namespace stateObservation
 #endif // IMU-DYNAMICAL-SYSTEM_HPP

--- a/include/state-observation/dynamical-system/imu-magnetometer-dynamical-system.hpp
+++ b/include/state-observation/dynamical-system/imu-magnetometer-dynamical-system.hpp
@@ -16,88 +16,83 @@
 
 #include <state-observation/api.h>
 #include <state-observation/dynamical-system/dynamical-system-functor-base.hpp>
-#include <state-observation/tools/rigid-body-kinematics.hpp>
-#include <state-observation/sensors-simulation/accelerometer-gyrometer-magnetometer.hpp>
 #include <state-observation/noise/noise-base.hpp>
+#include <state-observation/sensors-simulation/accelerometer-gyrometer-magnetometer.hpp>
+#include <state-observation/tools/rigid-body-kinematics.hpp>
 
 namespace stateObservation
 {
 
-     /**
-    * \class  IMUMagnetometerDynamicalSystem
-    * \brief  The class is an implementation of the dynamical system defined by
-    *         an inertial measurement unit (IMU) fixed on a rigid body. The state
-    *         is the position velocity and acceleration and the orientation and rotation
-    *         velocity and acceleration. The sensors are the accelerometer, the gyrometer
-    *         and the magnetometer
-    *
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI IMUMagnetometerDynamicalSystem : public DynamicalSystemFunctorBase
-    {
-    public:
-        ///The constructor
-        IMUMagnetometerDynamicalSystem();
+/**
+ * \class  IMUMagnetometerDynamicalSystem
+ * \brief  The class is an implementation of the dynamical system defined by
+ *         an inertial measurement unit (IMU) fixed on a rigid body. The state
+ *         is the position velocity and acceleration and the orientation and rotation
+ *         velocity and acceleration. The sensors are the accelerometer, the gyrometer
+ *         and the magnetometer
+ *
+ *
+ */
+class STATE_OBSERVATION_DLLAPI IMUMagnetometerDynamicalSystem : public DynamicalSystemFunctorBase
+{
+public:
+  /// The constructor
+  IMUMagnetometerDynamicalSystem();
 
-        ///The virtual destructor
-        virtual ~IMUMagnetometerDynamicalSystem();
+  /// The virtual destructor
+  virtual ~IMUMagnetometerDynamicalSystem();
 
-        ///Description of the state dynamics
-        virtual Vector stateDynamics
-        (const Vector& x, const Vector& u, TimeIndex k);
+  /// Description of the state dynamics
+  virtual Vector stateDynamics(const Vector & x, const Vector & u, TimeIndex k);
 
-        ///Description of the sensor's dynamics
-        virtual Vector measureDynamics
-        (const Vector& x, const Vector& u, TimeIndex k);
+  /// Description of the sensor's dynamics
+  virtual Vector measureDynamics(const Vector & x, const Vector & u, TimeIndex k);
 
-        ///Sets a noise which disturbs the state dynamics
-        virtual void setProcessNoise( NoiseBase * );
-        ///Removes the process noise
-        virtual void resetProcessNoise();
-        ///Gets the process noise
-        virtual NoiseBase * getProcessNoise() const;
+  /// Sets a noise which disturbs the state dynamics
+  virtual void setProcessNoise(NoiseBase *);
+  /// Removes the process noise
+  virtual void resetProcessNoise();
+  /// Gets the process noise
+  virtual NoiseBase * getProcessNoise() const;
 
-        ///Sets a noise which disturbs the measurements
-        virtual void setMeasurementNoise( NoiseBase * );
-        ///Removes the measurement noise
-        virtual void resetMeasurementNoise();
-        ///Gets a pointer on the measurement noise
-        virtual NoiseBase * getMeasurementNoise() const;
+  /// Sets a noise which disturbs the measurements
+  virtual void setMeasurementNoise(NoiseBase *);
+  /// Removes the measurement noise
+  virtual void resetMeasurementNoise();
+  /// Gets a pointer on the measurement noise
+  virtual NoiseBase * getMeasurementNoise() const;
 
-        ///Set the period of the time discretization
-        virtual void setSamplingPeriod(double dt);
+  /// Set the period of the time discretization
+  virtual void setSamplingPeriod(double dt);
 
-        ///Gets the state size
-        virtual Index getStateSize() const;
-        ///Gets the input size
-        virtual Index getInputSize() const;
-        ///Gets the measurement size
-        virtual Index getMeasurementSize() const;
+  /// Gets the state size
+  virtual Index getStateSize() const;
+  /// Gets the input size
+  virtual Index getInputSize() const;
+  /// Gets the measurement size
+  virtual Index getMeasurementSize() const;
 
-    protected:
+protected:
+  typedef kine::indexes<kine::rotationVector> indexes;
 
-        typedef kine::indexes<kine::rotationVector> indexes;
+  AccelerometerGyrometerMagnetometer sensor_;
 
-        AccelerometerGyrometerMagnetometer sensor_;
+  NoiseBase * processNoise_;
 
-        NoiseBase * processNoise_;
+  double dt_;
 
-        double dt_;
+  Vector3Unaligned orientationVector_;
+  QuaternionUnaligned quaternion_;
 
-        Vector3Unaligned orientationVector_;
-        QuaternionUnaligned quaternion_;
+  Quaternion computeQuaternion_(const Vector3 & x);
 
-        Quaternion computeQuaternion_(const Vector3 & x);
+  static const Index stateSize_ = 18;
+  static const Index inputSize_ = 0;
+  static const Index measurementSize_ = 9;
 
-        static const Index stateSize_=18;
-        static const Index inputSize_=0;
-        static const Index measurementSize_=9;
-
-
-    private:
-
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    };
-}
+private:
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+} // namespace stateObservation
 #endif // IMU-DYNAMICAL-SYSTEM_HPP

--- a/include/state-observation/dynamical-system/imu-mltpctive-dynamical-system.hpp
+++ b/include/state-observation/dynamical-system/imu-mltpctive-dynamical-system.hpp
@@ -15,119 +15,109 @@
 
 #include <state-observation/api.h>
 #include <state-observation/dynamical-system/dynamical-system-functor-base.hpp>
-#include <state-observation/tools/state-vector-arithmetics.hpp>
-#include <state-observation/tools/rigid-body-kinematics.hpp>
-#include <state-observation/sensors-simulation/accelerometer-gyrometer.hpp>
 #include <state-observation/noise/noise-base.hpp>
+#include <state-observation/sensors-simulation/accelerometer-gyrometer.hpp>
+#include <state-observation/tools/rigid-body-kinematics.hpp>
+#include <state-observation/tools/state-vector-arithmetics.hpp>
 
 namespace stateObservation
 {
 
-     /**
-    * \class  IMUDynamicalSystem
-    * \brief  The class is an implementation of the dynamical system defined by
-    *         an inertial measurement unit (IMU) fixed on a rigid body. The state
-    *         is the position velocity and acceleration and the orientaion and rotation
-    *         velocity and acceleration. The sensors are the accelerometer and the gyrometer
-    *
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI IMUMltpctiveDynamicalSystem :
-      public DynamicalSystemFunctorBase,
-      public StateVectorArithmetics
+/**
+ * \class  IMUDynamicalSystem
+ * \brief  The class is an implementation of the dynamical system defined by
+ *         an inertial measurement unit (IMU) fixed on a rigid body. The state
+ *         is the position velocity and acceleration and the orientaion and rotation
+ *         velocity and acceleration. The sensors are the accelerometer and the gyrometer
+ *
+ *
+ */
+class STATE_OBSERVATION_DLLAPI IMUMltpctiveDynamicalSystem : public DynamicalSystemFunctorBase,
+                                                             public StateVectorArithmetics
+{
+public:
+  /// The constructor
+  IMUMltpctiveDynamicalSystem();
+
+  /// The virtual destructor
+  virtual ~IMUMltpctiveDynamicalSystem();
+
+  /// Description of the state dynamics
+  virtual Vector stateDynamics(const Vector & x, const Vector & u, TimeIndex k);
+
+  /// Description of the sensor's dynamics
+  virtual Vector measureDynamics(const Vector & x, const Vector & u, TimeIndex k);
+
+  /// Sets a noise which disturbs the state dynamics
+  virtual void setProcessNoise(NoiseBase *);
+  /// Removes the process noise
+  virtual void resetProcessNoise();
+  /// Gets the process noise
+  virtual NoiseBase * getProcessNoise() const;
+
+  /// Sets a noise which disturbs the measurements
+  virtual void setMeasurementNoise(NoiseBase *);
+  /// Removes the measurement noise
+  virtual void resetMeasurementNoise();
+  /// Gets a pointer on the measurement noise
+  virtual NoiseBase * getMeasurementNoise() const;
+
+  /// Set the period of the time discretization
+  virtual void setSamplingPeriod(double dt);
+
+  virtual Matrix getAMatrix(const Vector & xh);
+  virtual Matrix getCMatrix(const Vector & xp);
+
+  /// Gets the state size
+  virtual Index getStateSize() const;
+  /// Gets the input size
+  virtual Index getInputSize() const;
+  /// Gets the measurement size
+  virtual Index getMeasurementSize() const;
+
+  void stateSum(const Vector & stateVector, const Vector & tangentVector, Vector & sum);
+
+  void stateDifference(const Vector & stateVector1, const Vector & stateVector2, Vector & difference);
+
+protected:
+  static const Index stateSize_ = 19;
+  static const Index stateTangentSize_ = 18;
+  static const Index inputSize_ = 6;
+  static const Index measurementSize_ = 6;
+  typedef kine::indexes<kine::quaternion> indexes;
+  typedef kine::indexes<kine::rotationVector> indexesTangent;
+
+  struct opt
+  {
+    /// containers for Jacobians
+    Matrix3 jRR, jRv;
+
+    Vector3 deltaR;
+
+    Matrix AJacobian;
+    Matrix CJacobian;
+
+    Matrix3 Rt;
+
+    opt(int stateSize, int measurementSize) : AJacobian(stateSize, stateSize), CJacobian(measurementSize, stateSize)
     {
-    public:
-        ///The constructor
-        IMUMltpctiveDynamicalSystem();
+      AJacobian.setZero();
+      AJacobian.block<3, 3>(indexesTangent::pos, indexesTangent::pos).setIdentity();
+      AJacobian.block<6, 6>(indexesTangent::linVel, indexesTangent::linVel).setIdentity();
 
-        ///The virtual destructor
-        virtual ~IMUMltpctiveDynamicalSystem();
+      CJacobian.setZero();
+    }
+  } opt_;
 
-        ///Description of the state dynamics
-        virtual Vector stateDynamics
-        (const Vector& x, const Vector& u, TimeIndex k);
+  AccelerometerGyrometer sensor_;
 
-        ///Description of the sensor's dynamics
-        virtual Vector measureDynamics
-        (const Vector& x, const Vector& u, TimeIndex k);
+  NoiseBase * processNoise_;
 
-        ///Sets a noise which disturbs the state dynamics
-        virtual void setProcessNoise( NoiseBase * );
-        ///Removes the process noise
-        virtual void resetProcessNoise();
-        ///Gets the process noise
-        virtual NoiseBase * getProcessNoise() const;
+  double dt_;
 
-        ///Sets a noise which disturbs the measurements
-        virtual void setMeasurementNoise( NoiseBase * );
-        ///Removes the measurement noise
-        virtual void resetMeasurementNoise();
-        ///Gets a pointer on the measurement noise
-        virtual NoiseBase * getMeasurementNoise() const;
-
-        ///Set the period of the time discretization
-        virtual void setSamplingPeriod(double dt);
-
-        virtual Matrix getAMatrix(const Vector &xh);
-        virtual Matrix getCMatrix(const Vector &xp);
-
-        ///Gets the state size
-        virtual Index getStateSize() const;
-        ///Gets the input size
-        virtual Index getInputSize() const;
-        ///Gets the measurement size
-        virtual Index getMeasurementSize() const;
-
-        void stateSum(const  Vector& stateVector, const Vector& tangentVector, Vector& sum);
-
-        void stateDifference(const  Vector& stateVector1, const Vector& stateVector2, Vector& difference);
-
-    protected:
-        static const Index stateSize_=19;
-        static const Index stateTangentSize_=18;
-        static const Index inputSize_=6;
-        static const Index measurementSize_=6;
-        typedef kine::indexes<kine::quaternion> indexes;
-        typedef kine::indexes<kine::rotationVector> indexesTangent;
-
-        struct opt
-        {
-          ///containers for Jacobians
-          Matrix3 jRR, jRv;
-
-          Vector3 deltaR;
-
-          Matrix AJacobian;
-          Matrix CJacobian;
-
-          Matrix3 Rt;
-
-          opt(int stateSize, int measurementSize):
-          AJacobian(stateSize,stateSize),
-          CJacobian(measurementSize,stateSize)
-          {
-            AJacobian.setZero();
-            AJacobian.block<3,3>(indexesTangent::pos,indexesTangent::pos).setIdentity();
-            AJacobian.block<6,6>(indexesTangent::linVel,indexesTangent::linVel).setIdentity();
-
-
-            CJacobian.setZero();
-          }
-        } opt_;
-
-
-        AccelerometerGyrometer sensor_;
-
-        NoiseBase * processNoise_;
-
-        double dt_;
-
-
-
-    private:
-
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    };
-}
+private:
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+} // namespace stateObservation
 #endif // IMU_MULTIPLICATIVE_DYNAMICAL_SYSTEM_HPP

--- a/include/state-observation/dynamics-estimators/kinetics-observer.hpp
+++ b/include/state-observation/dynamics-estimators/kinetics-observer.hpp
@@ -18,725 +18,688 @@
 #include <boost/utility.hpp>
 
 #include <state-observation/api.h>
-#include <state-observation/tools/definitions.hpp>
+#include <state-observation/dynamical-system/dynamical-system-functor-base.hpp>
+#include <state-observation/noise/noise-base.hpp>
 #include <state-observation/observer/extended-kalman-filter.hpp>
+#include <state-observation/sensors-simulation/accelerometer-gyrometer.hpp>
+#include <state-observation/tools/definitions.hpp>
 #include <state-observation/tools/rigid-body-kinematics.hpp>
 #include <state-observation/tools/state-vector-arithmetics.hpp>
-#include <state-observation/dynamical-system/dynamical-system-functor-base.hpp>
-#include <state-observation/sensors-simulation/accelerometer-gyrometer.hpp>
-#include <state-observation/noise/noise-base.hpp>
-
-
-
 
 namespace stateObservation
 {
 
-   /**
-    * \class  EKFFlexibilityEstimatorBase
-    * \brief  This class is the base class of the flexibility estimators that
-    *         use an extended Kalman Filter. Several methods require to be overloaded
-    *         to derive an implementation from this base class.
-    *
-    */
-
-    class STATE_OBSERVATION_DLLAPI KineticsObserver:
-        protected DynamicalSystemFunctorBase,
-        protected StateVectorArithmetics
-    {
-    public:
-        typedef kine::Kinematics Kinematics;
-        typedef kine::Orientation Orientation;
-
-        /// The constructor.
-        ///  \li maxContacts : maximum number of contacts,
-        ///  \li maxNumberOfIMU : the maximumnumber of IMUs
-        KineticsObserver(unsigned maxContacts=4, unsigned maxNumberOfIMU = 1);
-
-        ///virtual destructor
-        virtual ~KineticsObserver();
-
-        ///Gets the state size
-        Index getStateSize() const;
-
-        ///Gets the measurement size
-        Index getMeasurementSize() const;
-
-        /// ///////////////////////////////////////////////////////////
-        /// Getting, setting the current time and running the estimation
-        /// //////////////////////////////////////////////////////////
-
-        /// gets the sampling time
-        double getSamplingTime() const;
-
-        /// sets the sampling time
-        void setSamplingTime(double) ;
-
-         /// this function triggers the estimation itself
-        Vector update();
-
-        /// ////////////////////////////////
-        /// Getting and setting the state
-        /// ////////////////////////////////
-
-        /// Gets an estimation of the state in the form of a state vector $\hat{x_{k+1}}$
-        Vector getStateVector() const;
-
-        /// Gets the internal sample time of the state vector
-        stateObservation::TimeIndex getStateVectorSampleTime() const;
-
-        /// Get the Kinematics of the observed frams
-        Kinematics getKinematics() const;
-
-        /// Get the kinematics of a given frame
-        Kinematics getKinematicsOf(const Kinematics & localKinematics) const;
-        Kinematics getKinematicsOf(const Kinematics & localKinematics);
-        Kinematics getKinematicsOf(Kinematics & localKinematics) const;
-        Kinematics getKinematicsOf(Kinematics & localKinematics);
-
-        ///get the contact force provided by the estimator
-        /// which is different from a contact sensor measurement
-        Vector6 getContactWrench(int contactNbr) const;
-        Kinematics getContactPosition(int contactNbr) const;
-
-        /// gets the external unmodeled forces
-        Vector6 getUnmodeledWrench() const;
-
-        ///This function allows to estimate the acceleration
-        /// it returns a Kinemactis
-        Kinematics estimateAccelerations();
-
-        ///Sets a value for the kinematics part of the state
-        /// if resetForces is set to true the forces are set to zero
-        ///
-        void setStateKinematics(const Kinematics &, bool resetContactWrenches=true,
-                                   bool resetCovariance=true);
-
-        /// Allows to initializa the value of the gyro bias of the IMU
-        /// corresponding to the numberOfIMU
-        /// reset Covariance allows to reinitialize the gyro bias
-        void setGyroBias(const Vector3 &, unsigned numberOfIMU = 1,  bool resetCovariance=true);
-
-        ///if only force or torque is available, set the unavailable value to zero
-        void setStateUnmodeledWrench(const Vector6 &, bool resetCovariance=true);
-
-        ///Sets a value of the state x_k provided from another source
-        /// can be used for initialization of the estimator
-        void setStateVector(const Vector &,bool resetCovariance=true);
-
-        /// Getters for the indexes of the state Vector
-        inline unsigned kineIndex() const;
-        inline unsigned posIndex() const;
-        inline unsigned oriIndex() const;
-        inline unsigned linVelIndex() const;
-        inline unsigned angVelIndex() const;
-        inline unsigned gyroBiasIndex(unsigned IMUNumber) const;
-        inline unsigned unmodeledWrenchIndex() const;
-        inline unsigned unmodeledForceIndex() const;
-        inline unsigned unmodeledTorqueIndex() const;
-        inline unsigned contactsIndex() const;
-        inline unsigned contactIndex(unsigned contactNbr) const;
-        inline unsigned contactKineIndex(unsigned contactNbr) const;
-        inline unsigned contactPosIndex(unsigned contactNbr) const;
-        inline unsigned contactOriIndex(unsigned contactNbr) const;
-        inline unsigned contactForceIndex(unsigned contactNbr) const;
-        inline unsigned contactTorqueIndex(unsigned contactNbr) const;
-        inline unsigned contactWrenchIndex(unsigned contactNbr) const;
-
-        /// Getters for the indexes of the state Vector
-        inline unsigned kineIndexTangent() const;
-        inline unsigned posIndexTangent() const;
-        inline unsigned oriIndexTangent() const;
-        inline unsigned linVelIndexTangent() const;
-        inline unsigned angVelIndexTangent() const;
-        inline unsigned gyroBiasIndexTangent(unsigned IMUNumber) const;
-        inline unsigned unmodeledWrenchIndexTangent() const;
-        inline unsigned unmodeledForceIndexTangent() const;
-        inline unsigned unmodeledTorqueIndexTangent() const;
-        inline unsigned contactsIndexTangent() const;
-        inline unsigned contactIndexTangent(unsigned contactNbr) const;
-        inline unsigned contactKineIndexTangent(unsigned contactNbr) const;
-        inline unsigned contactPosIndexTangent(unsigned contactNbr) const;
-        inline unsigned contactOriIndexTangent(unsigned contactNbr) const;
-        inline unsigned contactForceIndexTangent(unsigned contactNbr) const;
-        inline unsigned contactTorqueIndexTangent(unsigned contactNbr) const;
-        inline unsigned contactWrenchIndexTangent(unsigned contactNbr) const;
-
-
-
-        /// /////////////////////////////////////////////////////
-        /// Setting and getting the state of the estimation
-        /// ////////////////////////////////////////////////////
-        void setWithUnmodeledWrench(bool b = true);
-
-        ///Sets if the update() function estimates also the accelerations
-        void setWithAccelerationEstimation(bool b = true);
-
-        void setWithGyroBias(bool b = true);
-
-        /// ///////////////////////////////////////////////
-        /// Getting and setting input data and measurements
-        /// /////////////////////////////////////////////
-
-        /// sets the measurement of the IMU (gyrometer, accelerometer, kinematics and number of the IMU)
-        /// accelero and gyrometer are the measurement
-        /// localKine gets the kinematics of the IMU expressed in the observed frame
-        /// the best is to provide the position, the orientation,
-        /// the angular and linear velocities and the linear acceleration
-        /// Nevertheless if velocities or accelerations are not available they will be
-        /// automatically computed through finite differences
-        /// the acceleroCov and the gyroCov are the covariance matrices of the sensors
-        int setIMU(const Vector3 & accelero, const  Vector3 & gyrometer, const Kinematics &localKine, int num=-1);
-        int setIMU(const Vector3 & accelero, const  Vector3 & gyrometer, const Matrix3& acceleroCov,
-                                                        const Matrix3 gyroCov, const Kinematics &localKine, int num=-1);
-
-        void setIMUDefaultCovarianceMatrix(const Matrix3& acceleroCov, const Matrix3 &gyroCov);
-
-        ////////// Contact stters, these are MANDATORY for every contact at every iteration ///
-        /// if the contact is equipped with wrench sensor call setContactWrenchSensor
-        /// otherwise calls etContactWithoutSensor
-
-        /// sets the measurements of a force/torque sensor of the contact numbered contactNumber
-        /// wrenchMeasurement is the measurment vector composed with 3D forces and 3D torques
-        /// localKine sets the kinematics of the contact expressed in the observed frame
-        /// the best is to provide the position , the orientation,
-        /// the angular and the linear velocities.
-
-        void setContactWrenchSensor(const Vector6& wrenchMeasurement, const Kinematics &localKine, unsigned contactNumber);
-        void setContactWrenchSensor(const Vector6& wrenchMeasurement, const Matrix6 & wrenchCovMatrix,
-                                                                                    const Kinematics &localKine, unsigned contactNumber);
-
-        void setContactWrenchSensorDefaultCovarianceMatrix(const Matrix6 & wrenchSensorCovMat);
-
-        /// sets the the kinematics of the contact expressed in the observed frame
-        /// the best is to provide the position, the orientation, the angular and the linear velocities.
-        /// otherwise they will be automatically computed
-        void setContactWithNoSensor(const Kinematics &localKine, unsigned contactNumber);
-
-        /// Set a measurement of the pose. The input is the Measured kinematics
-        /// namely position and orientation.
-        void setAbsolutePoseSensor(const Kinematics &);
-        void setAbsolutePoseSensor(const Kinematics &, const Matrix6 & CovarianceMatrix);
-
-        ///TODO
-        //void setVelocityGuess(const Kinematics)
-
-        void setAbsolutePoseSensorDefaultCovarianceMatrix(const Matrix6 &);
-
-        ///////////////////////////////////////////////
-        /// Setting inputs to the dynamical system
-        //////////////////////////////////////////////////
-        /// Add known external forces and moments which are not due to contact
-        /// they must be expressed in the same frame as the kinematic root
-        void setAdditionalWrench(const Vector3& force, const Vector3& torque );
-
-        /// sets the mass of the robot
-        void setMass(double);
-
-        ///Sets the 3x3 inertia matrix expressed in the local frame and  optionally
-        ///  its time derivative (computed with finite differences otherwise)
-        ///the Vector6 version is a vector containing the diagonal and the three non
-        /// diagonal values concatenated
-        /// it is highly recommended to update these values at every iteration
-        void setInertiaMatrix(const Matrix3& I, const Matrix3& I_dot);
-        void setInertiaMatrix(const Matrix3& I);
-        void setInertiaMatrix(const Vector6& I, const Vector6& I_dot);
-        void setInertiaMatrix(const Vector6& I);
-
-        ///Sets the center of mass position expressed in the local frame
-        /// and optionally its first and second order time derivarives
-        /// computed through finite differences otherwise.
-        /// it is highly recommended to update these values at every iteration
-        void setCenterOfMass(const Vector3& com, const Vector3& com_dot, const Vector3& com_dot_dot);
-        void setCenterOfMass(const Vector3& com, const Vector3& com_dot);
-        void setCenterOfMass(const Vector3& com);
-
-        ///Sets the angular momentum expressed in the local frame
-        /// and optionally its time derivarive
-        /// computed through finite differences otherwise.
-        /// it is highly recommended to update these values at every iteration
-        void setAngularMomentum (const Vector3& sigma, const Vector3& sigma_dot);
-        void setAngularMomentum (const Vector3& sigma);
-
-        ///////////////////////////////
-        /// Contact management
-        ///////////////////////////////
-        /// Set a new contact
-        /// -pose is the initial guess on the position of the contact. Only position
-        /// and orientation are enough
-        /// -initialCovarianceMatrix is the covariance matrix expressing the
-        ///  uncertainty of the initial guess (if no initial guess is available
-        ///  give a rough position with a high initial covariance matrix)
-        /// -processCovarianceMatrix is the covariance matrix expressing the
-        ///  rate at which the contact slides (set to zero for no sliding)
-        /// -linear, angular stiffness and damping set the flexibility model
-        ///  of the contact
-        /// set contactNumber to -1 in order to set the number automatically
-        /// returns the number of this contact
-        int addContact(const Kinematics & pose,
-                            const Matrix12 & initialCovarianceMatrix, const Matrix12 & processCovarianceMatrix,
-                            const Matrix3 & linearStiffness,  const Matrix3 & linearDamping,
-                            const Matrix3 & angularStiffness, const Matrix3 & angularDamping,
-                            int contactNumber=-1);
-        /// version with default stiffness and damping
-        /// use when the contact parameters are known
-        int addContact(const Kinematics & pose,
-                            const Matrix12 & initialCovarianceMatrix, const Matrix12 & processCovarianceMatrix,
-                            int contactNumber=-1);
-        /// version when the contact position is perfectly known
-        int addContact(const Kinematics & pose,
-                            const Matrix3 & linearStiffness,  const Matrix3 & linearDamping,
-                            const Matrix3 & angularStiffness, const Matrix3 & angularDamping,
-                            int contactNumber=-1);
-        /// version when the position is perfectly known but not the stiffness and damping
-        int addContact(const Kinematics & pose, int contactNumber=-1);
-
-        void removeContact(int contactnbr);
-
-        void clearContacts();
-
-        Index getNumberOfContacts() const;
-
-        std::vector<int> getListOfContacts() const;
-
-        ///Sets the covariance matrix of the flexibility Guess
-        void setStateCovariance(const Matrix & P);
-
-        void setKinematicsStateCovariance(const Matrix & );
-        void setKinematicsInitCovarianceDefault(const Matrix & );
-        void setKinematicsProcessCovariance(const Matrix & );
-
-        void setGyroBiasStateCovariance(const Matrix3 & covMat, unsigned imuNumber);
-        void setGyroBiasInitCovarianceDefault(const Matrix3 & covMat);
-        void setGyroBiasProcessCovariance(const Matrix3 & covMat, unsigned imuNumber);
-
-        void setUnmodeledWrenchStateCovMat(const Matrix6 & currentCovMat);
-        void setUnmodeledWrenchIniCovMatDefault(const Matrix6 & initCovMat);
-        void setUnmodeledWrenchProcessCovMat(const Matrix6 & processCovMat);
-
-        void setContactStateCovMat(int contactNbr, const Matrix12 & contactCovMat);
-        void setContactInitCovMatDefault(const Matrix12 & contactCovMat);
-        void setContactProcessCovMat(int contactNbr, const Matrix12 & contactCovMat);
-
-        ///Gets the covariance matrix of the flexibility
-        Matrix getStateCovariance() const;
-
-        ///Sets/gets the covariance matrices for the process noises
-        /// \li Q process noise
-        void setProcessNoiseCovariance(const Matrix & Q);
-
-        ///gets the measurement vector
-        Vector getMeasurementVector();
-
-        /// Gets a const reference on the extended Kalman filter
-        const ExtendedKalmanFilter & getEKF() const;
-
-        /// Gets a reference on the extended Kalman filter
-        /// modifying this object may lead to instabilities
-        ExtendedKalmanFilter & getEKF();
-
-        ///Resets the covariance matrices to their original values
-        void resetStateCovarianceMat();
-        void resetStateKinematicsCovMat();
-        void resetStateGyroBiasCovMat( unsigned i);
-        void resetStateUnmodeledWrenchCovMat();
-        void resetStateContactsCovMat();
-        void resetStateContactCovMat(unsigned contactNbr);
-
-        void resetProcessCovarianceMat();
-        void resetProcessKinematicsCovMat();
-        void resetProcessGyroBiasCovMat( unsigned i);
-        void resetProcessUnmodeledWrenchCovMat();
-        void resetProcessContactsCovMat();
-        void resetProcessContactCovMat(unsigned contactNbr);
-
-        ///Reset the default values for the covariance matrix
-        void resetSensorsDefaultCovMat();
-
-        ///to reset all the sensor inputs and provided contact positions but keeps the contacts
-        void resetInputs();
-    protected:
-
-        struct Sensor
-        {
-            Sensor(int signalSize):size(signalSize), time(0) {}
-            virtual ~Sensor(){}
-            int measIndex;
-            int size;
-            TimeIndex time;
-
-            inline Vector extractFromVector(const Vector & v){return v.segment(size,measIndex);}
-        };
-
-        struct IMU:
-        public Sensor
-        {
-            virtual ~IMU(){}
-            IMU():Sensor(sizeIMUSignal){}
-            Kinematics kinematics;
-            Vector6 acceleroGyro;
-            Matrix3 covMatrixAccelero;
-            Matrix3 covMatrixGyro;
-
-            static int currentNumber;
-
-            EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-        };
-
-        typedef std::vector<IMU, Eigen::aligned_allocator< IMU > > VectorIMU;
-        typedef VectorIMU::iterator VectorIMUIterator;
-        typedef VectorIMU::const_iterator VectorIMUConstIterator;
-
-        struct Contact:
-        public Sensor
-        {
-            Contact():Sensor(sizeWrench),isSet(false),withRealSensor(false),
-                        stateIndex(-1),stateIndexTangent(-1){}
-            virtual ~Contact(){}
-
-
-
-            Kinematics absPose;
-            Vector6 wrench;
-            CheckedMatrix6 sensorCovMatrix;
-
-            Matrix3 linearStiffness;
-            Matrix3 linearDamping;
-            Matrix3 angularStiffness;
-            Matrix3 angularDamping;
-
-            bool isSet;
-            bool withRealSensor;
-            int stateIndex;
-            int stateIndexTangent;
-
-            Kinematics localKine; ///describes the kinematics of the contact point in the local frame
-            static const Kinematics::Flags::Byte localKineFlags = ///flags for the components of the kinematics
-                            Kinematics::Flags::position |
-                            Kinematics::Flags::orientation |
-                            Kinematics::Flags::linVel |
-                            Kinematics::Flags::angVel;
-
-            static int numberOfRealSensors;
-
-            EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-        };
-
-        typedef std::vector < Contact, Eigen::aligned_allocator < Contact > > VectorContact;
-        typedef VectorContact::iterator VectorContactIterator;
-        typedef VectorContact::const_iterator VectorContactConstIterator;
-
-        struct AbsolutePoseSensor:
-        public Sensor
-        {
-            AbsolutePoseSensor():Sensor(sizePose){}
-
-            Kinematics pose;
-            CheckedMatrix6 covMatrix;
-        };
+/**
+ * \class  EKFFlexibilityEstimatorBase
+ * \brief  This class is the base class of the flexibility estimators that
+ *         use an extended Kalman Filter. Several methods require to be overloaded
+ *         to derive an implementation from this base class.
+ *
+ */
+
+class STATE_OBSERVATION_DLLAPI KineticsObserver : protected DynamicalSystemFunctorBase, protected StateVectorArithmetics
+{
+public:
+  typedef kine::Kinematics Kinematics;
+  typedef kine::Orientation Orientation;
+
+  /// The constructor.
+  ///  \li maxContacts : maximum number of contacts,
+  ///  \li maxNumberOfIMU : the maximumnumber of IMUs
+  KineticsObserver(unsigned maxContacts = 4, unsigned maxNumberOfIMU = 1);
+
+  /// virtual destructor
+  virtual ~KineticsObserver();
+
+  /// Gets the state size
+  Index getStateSize() const;
+
+  /// Gets the measurement size
+  Index getMeasurementSize() const;
+
+  /// ///////////////////////////////////////////////////////////
+  /// Getting, setting the current time and running the estimation
+  /// //////////////////////////////////////////////////////////
+
+  /// gets the sampling time
+  double getSamplingTime() const;
+
+  /// sets the sampling time
+  void setSamplingTime(double);
+
+  /// this function triggers the estimation itself
+  Vector update();
+
+  /// ////////////////////////////////
+  /// Getting and setting the state
+  /// ////////////////////////////////
+
+  /// Gets an estimation of the state in the form of a state vector $\hat{x_{k+1}}$
+  Vector getStateVector() const;
+
+  /// Gets the internal sample time of the state vector
+  stateObservation::TimeIndex getStateVectorSampleTime() const;
+
+  /// Get the Kinematics of the observed frams
+  Kinematics getKinematics() const;
+
+  /// Get the kinematics of a given frame
+  Kinematics getKinematicsOf(const Kinematics & localKinematics) const;
+  Kinematics getKinematicsOf(const Kinematics & localKinematics);
+  Kinematics getKinematicsOf(Kinematics & localKinematics) const;
+  Kinematics getKinematicsOf(Kinematics & localKinematics);
+
+  /// get the contact force provided by the estimator
+  /// which is different from a contact sensor measurement
+  Vector6 getContactWrench(int contactNbr) const;
+  Kinematics getContactPosition(int contactNbr) const;
+
+  /// gets the external unmodeled forces
+  Vector6 getUnmodeledWrench() const;
+
+  /// This function allows to estimate the acceleration
+  /// it returns a Kinemactis
+  Kinematics estimateAccelerations();
+
+  /// Sets a value for the kinematics part of the state
+  /// if resetForces is set to true the forces are set to zero
+  ///
+  void setStateKinematics(const Kinematics &, bool resetContactWrenches = true, bool resetCovariance = true);
+
+  /// Allows to initializa the value of the gyro bias of the IMU
+  /// corresponding to the numberOfIMU
+  /// reset Covariance allows to reinitialize the gyro bias
+  void setGyroBias(const Vector3 &, unsigned numberOfIMU = 1, bool resetCovariance = true);
+
+  /// if only force or torque is available, set the unavailable value to zero
+  void setStateUnmodeledWrench(const Vector6 &, bool resetCovariance = true);
+
+  /// Sets a value of the state x_k provided from another source
+  /// can be used for initialization of the estimator
+  void setStateVector(const Vector &, bool resetCovariance = true);
+
+  /// Getters for the indexes of the state Vector
+  inline unsigned kineIndex() const;
+  inline unsigned posIndex() const;
+  inline unsigned oriIndex() const;
+  inline unsigned linVelIndex() const;
+  inline unsigned angVelIndex() const;
+  inline unsigned gyroBiasIndex(unsigned IMUNumber) const;
+  inline unsigned unmodeledWrenchIndex() const;
+  inline unsigned unmodeledForceIndex() const;
+  inline unsigned unmodeledTorqueIndex() const;
+  inline unsigned contactsIndex() const;
+  inline unsigned contactIndex(unsigned contactNbr) const;
+  inline unsigned contactKineIndex(unsigned contactNbr) const;
+  inline unsigned contactPosIndex(unsigned contactNbr) const;
+  inline unsigned contactOriIndex(unsigned contactNbr) const;
+  inline unsigned contactForceIndex(unsigned contactNbr) const;
+  inline unsigned contactTorqueIndex(unsigned contactNbr) const;
+  inline unsigned contactWrenchIndex(unsigned contactNbr) const;
+
+  /// Getters for the indexes of the state Vector
+  inline unsigned kineIndexTangent() const;
+  inline unsigned posIndexTangent() const;
+  inline unsigned oriIndexTangent() const;
+  inline unsigned linVelIndexTangent() const;
+  inline unsigned angVelIndexTangent() const;
+  inline unsigned gyroBiasIndexTangent(unsigned IMUNumber) const;
+  inline unsigned unmodeledWrenchIndexTangent() const;
+  inline unsigned unmodeledForceIndexTangent() const;
+  inline unsigned unmodeledTorqueIndexTangent() const;
+  inline unsigned contactsIndexTangent() const;
+  inline unsigned contactIndexTangent(unsigned contactNbr) const;
+  inline unsigned contactKineIndexTangent(unsigned contactNbr) const;
+  inline unsigned contactPosIndexTangent(unsigned contactNbr) const;
+  inline unsigned contactOriIndexTangent(unsigned contactNbr) const;
+  inline unsigned contactForceIndexTangent(unsigned contactNbr) const;
+  inline unsigned contactTorqueIndexTangent(unsigned contactNbr) const;
+  inline unsigned contactWrenchIndexTangent(unsigned contactNbr) const;
+
+  /// /////////////////////////////////////////////////////
+  /// Setting and getting the state of the estimation
+  /// ////////////////////////////////////////////////////
+  void setWithUnmodeledWrench(bool b = true);
+
+  /// Sets if the update() function estimates also the accelerations
+  void setWithAccelerationEstimation(bool b = true);
+
+  void setWithGyroBias(bool b = true);
+
+  /// ///////////////////////////////////////////////
+  /// Getting and setting input data and measurements
+  /// /////////////////////////////////////////////
+
+  /// sets the measurement of the IMU (gyrometer, accelerometer, kinematics and number of the IMU)
+  /// accelero and gyrometer are the measurement
+  /// localKine gets the kinematics of the IMU expressed in the observed frame
+  /// the best is to provide the position, the orientation,
+  /// the angular and linear velocities and the linear acceleration
+  /// Nevertheless if velocities or accelerations are not available they will be
+  /// automatically computed through finite differences
+  /// the acceleroCov and the gyroCov are the covariance matrices of the sensors
+  int setIMU(const Vector3 & accelero, const Vector3 & gyrometer, const Kinematics & localKine, int num = -1);
+  int setIMU(const Vector3 & accelero,
+             const Vector3 & gyrometer,
+             const Matrix3 & acceleroCov,
+             const Matrix3 gyroCov,
+             const Kinematics & localKine,
+             int num = -1);
+
+  void setIMUDefaultCovarianceMatrix(const Matrix3 & acceleroCov, const Matrix3 & gyroCov);
+
+  ////////// Contact stters, these are MANDATORY for every contact at every iteration ///
+  /// if the contact is equipped with wrench sensor call setContactWrenchSensor
+  /// otherwise calls etContactWithoutSensor
+
+  /// sets the measurements of a force/torque sensor of the contact numbered contactNumber
+  /// wrenchMeasurement is the measurment vector composed with 3D forces and 3D torques
+  /// localKine sets the kinematics of the contact expressed in the observed frame
+  /// the best is to provide the position , the orientation,
+  /// the angular and the linear velocities.
+
+  void setContactWrenchSensor(const Vector6 & wrenchMeasurement, const Kinematics & localKine, unsigned contactNumber);
+  void setContactWrenchSensor(const Vector6 & wrenchMeasurement,
+                              const Matrix6 & wrenchCovMatrix,
+                              const Kinematics & localKine,
+                              unsigned contactNumber);
+
+  void setContactWrenchSensorDefaultCovarianceMatrix(const Matrix6 & wrenchSensorCovMat);
+
+  /// sets the the kinematics of the contact expressed in the observed frame
+  /// the best is to provide the position, the orientation, the angular and the linear velocities.
+  /// otherwise they will be automatically computed
+  void setContactWithNoSensor(const Kinematics & localKine, unsigned contactNumber);
+
+  /// Set a measurement of the pose. The input is the Measured kinematics
+  /// namely position and orientation.
+  void setAbsolutePoseSensor(const Kinematics &);
+  void setAbsolutePoseSensor(const Kinematics &, const Matrix6 & CovarianceMatrix);
+
+  /// TODO
+  // void setVelocityGuess(const Kinematics)
+
+  void setAbsolutePoseSensorDefaultCovarianceMatrix(const Matrix6 &);
+
+  ///////////////////////////////////////////////
+  /// Setting inputs to the dynamical system
+  //////////////////////////////////////////////////
+  /// Add known external forces and moments which are not due to contact
+  /// they must be expressed in the same frame as the kinematic root
+  void setAdditionalWrench(const Vector3 & force, const Vector3 & torque);
+
+  /// sets the mass of the robot
+  void setMass(double);
+
+  /// Sets the 3x3 inertia matrix expressed in the local frame and  optionally
+  ///  its time derivative (computed with finite differences otherwise)
+  /// the Vector6 version is a vector containing the diagonal and the three non
+  /// diagonal values concatenated
+  /// it is highly recommended to update these values at every iteration
+  void setInertiaMatrix(const Matrix3 & I, const Matrix3 & I_dot);
+  void setInertiaMatrix(const Matrix3 & I);
+  void setInertiaMatrix(const Vector6 & I, const Vector6 & I_dot);
+  void setInertiaMatrix(const Vector6 & I);
+
+  /// Sets the center of mass position expressed in the local frame
+  /// and optionally its first and second order time derivarives
+  /// computed through finite differences otherwise.
+  /// it is highly recommended to update these values at every iteration
+  void setCenterOfMass(const Vector3 & com, const Vector3 & com_dot, const Vector3 & com_dot_dot);
+  void setCenterOfMass(const Vector3 & com, const Vector3 & com_dot);
+  void setCenterOfMass(const Vector3 & com);
+
+  /// Sets the angular momentum expressed in the local frame
+  /// and optionally its time derivarive
+  /// computed through finite differences otherwise.
+  /// it is highly recommended to update these values at every iteration
+  void setAngularMomentum(const Vector3 & sigma, const Vector3 & sigma_dot);
+  void setAngularMomentum(const Vector3 & sigma);
+
+  ///////////////////////////////
+  /// Contact management
+  ///////////////////////////////
+  /// Set a new contact
+  /// -pose is the initial guess on the position of the contact. Only position
+  /// and orientation are enough
+  /// -initialCovarianceMatrix is the covariance matrix expressing the
+  ///  uncertainty of the initial guess (if no initial guess is available
+  ///  give a rough position with a high initial covariance matrix)
+  /// -processCovarianceMatrix is the covariance matrix expressing the
+  ///  rate at which the contact slides (set to zero for no sliding)
+  /// -linear, angular stiffness and damping set the flexibility model
+  ///  of the contact
+  /// set contactNumber to -1 in order to set the number automatically
+  /// returns the number of this contact
+  int addContact(const Kinematics & pose,
+                 const Matrix12 & initialCovarianceMatrix,
+                 const Matrix12 & processCovarianceMatrix,
+                 const Matrix3 & linearStiffness,
+                 const Matrix3 & linearDamping,
+                 const Matrix3 & angularStiffness,
+                 const Matrix3 & angularDamping,
+                 int contactNumber = -1);
+  /// version with default stiffness and damping
+  /// use when the contact parameters are known
+  int addContact(const Kinematics & pose,
+                 const Matrix12 & initialCovarianceMatrix,
+                 const Matrix12 & processCovarianceMatrix,
+                 int contactNumber = -1);
+  /// version when the contact position is perfectly known
+  int addContact(const Kinematics & pose,
+                 const Matrix3 & linearStiffness,
+                 const Matrix3 & linearDamping,
+                 const Matrix3 & angularStiffness,
+                 const Matrix3 & angularDamping,
+                 int contactNumber = -1);
+  /// version when the position is perfectly known but not the stiffness and damping
+  int addContact(const Kinematics & pose, int contactNumber = -1);
+
+  void removeContact(int contactnbr);
+
+  void clearContacts();
+
+  Index getNumberOfContacts() const;
+
+  std::vector<int> getListOfContacts() const;
+
+  /// Sets the covariance matrix of the flexibility Guess
+  void setStateCovariance(const Matrix & P);
+
+  void setKinematicsStateCovariance(const Matrix &);
+  void setKinematicsInitCovarianceDefault(const Matrix &);
+  void setKinematicsProcessCovariance(const Matrix &);
+
+  void setGyroBiasStateCovariance(const Matrix3 & covMat, unsigned imuNumber);
+  void setGyroBiasInitCovarianceDefault(const Matrix3 & covMat);
+  void setGyroBiasProcessCovariance(const Matrix3 & covMat, unsigned imuNumber);
+
+  void setUnmodeledWrenchStateCovMat(const Matrix6 & currentCovMat);
+  void setUnmodeledWrenchIniCovMatDefault(const Matrix6 & initCovMat);
+  void setUnmodeledWrenchProcessCovMat(const Matrix6 & processCovMat);
+
+  void setContactStateCovMat(int contactNbr, const Matrix12 & contactCovMat);
+  void setContactInitCovMatDefault(const Matrix12 & contactCovMat);
+  void setContactProcessCovMat(int contactNbr, const Matrix12 & contactCovMat);
+
+  /// Gets the covariance matrix of the flexibility
+  Matrix getStateCovariance() const;
+
+  /// Sets/gets the covariance matrices for the process noises
+  /// \li Q process noise
+  void setProcessNoiseCovariance(const Matrix & Q);
+
+  /// gets the measurement vector
+  Vector getMeasurementVector();
+
+  /// Gets a const reference on the extended Kalman filter
+  const ExtendedKalmanFilter & getEKF() const;
+
+  /// Gets a reference on the extended Kalman filter
+  /// modifying this object may lead to instabilities
+  ExtendedKalmanFilter & getEKF();
+
+  /// Resets the covariance matrices to their original values
+  void resetStateCovarianceMat();
+  void resetStateKinematicsCovMat();
+  void resetStateGyroBiasCovMat(unsigned i);
+  void resetStateUnmodeledWrenchCovMat();
+  void resetStateContactsCovMat();
+  void resetStateContactCovMat(unsigned contactNbr);
+
+  void resetProcessCovarianceMat();
+  void resetProcessKinematicsCovMat();
+  void resetProcessGyroBiasCovMat(unsigned i);
+  void resetProcessUnmodeledWrenchCovMat();
+  void resetProcessContactsCovMat();
+  void resetProcessContactCovMat(unsigned contactNbr);
+
+  /// Reset the default values for the covariance matrix
+  void resetSensorsDefaultCovMat();
+
+  /// to reset all the sensor inputs and provided contact positions but keeps the contacts
+  void resetInputs();
 
 protected:
-        ///////////// DYNAMICAL SYSTEM IMPLEMENTATION
-        virtual Vector stateDynamics(const Vector &x, const Vector &u, TimeIndex k);
+  struct Sensor
+  {
+    Sensor(int signalSize) : size(signalSize), time(0) {}
+    virtual ~Sensor() {}
+    int measIndex;
+    int size;
+    TimeIndex time;
 
-        virtual Vector measureDynamics(const Vector &x, const Vector &u, TimeIndex k);
+    inline Vector extractFromVector(const Vector & v)
+    {
+      return v.segment(size, measIndex);
+    }
+  };
 
+  struct IMU : public Sensor
+  {
+    virtual ~IMU() {}
+    IMU() : Sensor(sizeIMUSignal) {}
+    Kinematics kinematics;
+    Vector6 acceleroGyro;
+    Matrix3 covMatrixAccelero;
+    Matrix3 covMatrixGyro;
 
-        void addUnmodeledAndContactWrench_(const Vector &stateVector, Vector3 & force, Vector3 & torque);
+    static int currentNumber;
 
-        void computeAccelerations_( Kinematics & stateKine, const Vector3& totalForceLocal,
-                                const Vector3& totalMomentLocal, Vector3 & linAcc, Vector3& angAcc);
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  };
 
-        ///the kinematics is not const to allow more optimized non const operators to work
-        void computeContactForces_( VectorContactIterator i, Kinematics &stateKine,
-                                            Kinematics &contactPose , Vector3 & Force, Vector3 torque) ;
+  typedef std::vector<IMU, Eigen::aligned_allocator<IMU>> VectorIMU;
+  typedef VectorIMU::iterator VectorIMUIterator;
+  typedef VectorIMU::const_iterator VectorIMUConstIterator;
 
-        ///Sets a noise which disturbs the state dynamics
-        virtual void setProcessNoise(NoiseBase *);
+  struct Contact : public Sensor
+  {
+    Contact() : Sensor(sizeWrench), isSet(false), withRealSensor(false), stateIndex(-1), stateIndexTangent(-1) {}
+    virtual ~Contact() {}
 
-        ///Removes the process noise
-        virtual void resetProcessNoise();
-        ///Gets the process noise
-        virtual NoiseBase *getProcessNoise() const;
+    Kinematics absPose;
+    Vector6 wrench;
+    CheckedMatrix6 sensorCovMatrix;
 
-        ///Sets a noise which disturbs the measurements
-        virtual void setMeasurementNoise(NoiseBase *);
-        ///Removes the measurement noise
-        virtual void resetMeasurementNoise();
-        ///Gets a pointer on the measurement noise
-        virtual NoiseBase *getMeasurementNoise() const;
+    Matrix3 linearStiffness;
+    Matrix3 linearDamping;
+    Matrix3 angularStiffness;
+    Matrix3 angularDamping;
 
-        ///Gets the input size
-        virtual Index getInputSize() const;
+    bool isSet;
+    bool withRealSensor;
+    int stateIndex;
+    int stateIndexTangent;
+
+    Kinematics localKine; /// describes the kinematics of the contact point in the local frame
+    static const Kinematics::Flags::Byte localKineFlags = /// flags for the components of the kinematics
+        Kinematics::Flags::position | Kinematics::Flags::orientation | Kinematics::Flags::linVel
+        | Kinematics::Flags::angVel;
+
+    static int numberOfRealSensors;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  };
+
+  typedef std::vector<Contact, Eigen::aligned_allocator<Contact>> VectorContact;
+  typedef VectorContact::iterator VectorContactIterator;
+  typedef VectorContact::const_iterator VectorContactConstIterator;
+
+  struct AbsolutePoseSensor : public Sensor
+  {
+    AbsolutePoseSensor() : Sensor(sizePose) {}
+
+    Kinematics pose;
+    CheckedMatrix6 covMatrix;
+  };
+
+protected:
+  ///////////// DYNAMICAL SYSTEM IMPLEMENTATION
+  virtual Vector stateDynamics(const Vector & x, const Vector & u, TimeIndex k);
+
+  virtual Vector measureDynamics(const Vector & x, const Vector & u, TimeIndex k);
+
+  void addUnmodeledAndContactWrench_(const Vector & stateVector, Vector3 & force, Vector3 & torque);
+
+  void computeAccelerations_(Kinematics & stateKine,
+                             const Vector3 & totalForceLocal,
+                             const Vector3 & totalMomentLocal,
+                             Vector3 & linAcc,
+                             Vector3 & angAcc);
+
+  /// the kinematics is not const to allow more optimized non const operators to work
+  void computeContactForces_(VectorContactIterator i,
+                             Kinematics & stateKine,
+                             Kinematics & contactPose,
+                             Vector3 & Force,
+                             Vector3 torque);
+
+  /// Sets a noise which disturbs the state dynamics
+  virtual void setProcessNoise(NoiseBase *);
+
+  /// Removes the process noise
+  virtual void resetProcessNoise();
+  /// Gets the process noise
+  virtual NoiseBase * getProcessNoise() const;
+
+  /// Sets a noise which disturbs the measurements
+  virtual void setMeasurementNoise(NoiseBase *);
+  /// Removes the measurement noise
+  virtual void resetMeasurementNoise();
+  /// Gets a pointer on the measurement noise
+  virtual NoiseBase * getMeasurementNoise() const;
+
+  /// Gets the input size
+  virtual Index getInputSize() const;
 
 public:
+  virtual void stateSum(const Vector & stateVector, const Vector & tangentVector, Vector & sum);
+  inline Vector stateSum(const Vector & stateVector, const Vector & tangentVector);
 
-        virtual void stateSum(const  Vector& stateVector, const Vector& tangentVector, Vector& sum);
-        inline Vector stateSum(const  Vector& stateVector, const Vector& tangentVector);
+  virtual void stateDifference(const Vector & stateVector1, const Vector & stateVector2, Vector & difference);
+  inline Vector stateDifference(const Vector & stateVector1, const Vector & stateVector2);
 
-        virtual void stateDifference(const Vector& stateVector1, const Vector& stateVector2, Vector& difference);
-        inline Vector stateDifference(const Vector& stateVector1, const Vector& stateVector2);
+  virtual void measurementDifference(const Vector & measureVector1, const Vector & measureVector2, Vector & difference);
+  ///////////////////////////////////////
 
-        virtual void measurementDifference(const Vector& measureVector1, const Vector& measureVector2, Vector& difference);
-        ///////////////////////////////////////
-
-        ////////////////////////////
-        virtual void setFiniteDifferenceStep(const Vector & dx);
-        virtual void useFiniteDifferencesJacobians(bool b=true);
-
-protected:
-        Vector stateNaNCorrection_();
-
-        ///updates stateKine_ from the stateVector
-        void updateKine_();
-
-
-
+  ////////////////////////////
+  virtual void setFiniteDifferenceStep(const Vector & dx);
+  virtual void useFiniteDifferencesJacobians(bool b = true);
 
 protected:
+  Vector stateNaNCorrection_();
 
-        unsigned maxContacts_;
-        unsigned maxImuNumber_;
+  /// updates stateKine_ from the stateVector
+  void updateKine_();
 
-        AbsolutePoseSensor absPoseSensor_;
-        VectorContact contacts_;
-        VectorIMU imuSensors_;
+protected:
+  unsigned maxContacts_;
+  unsigned maxImuNumber_;
 
-        Index stateSize_;
-        Index stateTangentSize_;
-        Index measurementSize_;
-        Index measurementTangentSize_;
+  AbsolutePoseSensor absPoseSensor_;
+  VectorContact contacts_;
+  VectorIMU imuSensors_;
 
-        Kinematics stateKinematics_;
+  Index stateSize_;
+  Index stateTangentSize_;
+  Index measurementSize_;
+  Index measurementTangentSize_;
 
-        Vector stateVector_;
-        Vector stateVectorDx_;
-        Vector oldStateVector_;
+  Kinematics stateKinematics_;
 
-        Vector3 additionalForce_;
-        Vector3 additionalTorque_;
+  Vector stateVector_;
+  Vector stateVectorDx_;
+  Vector oldStateVector_;
 
-        Vector measurementVector_;
-        Matrix measurementCovMatrix_;
+  Vector3 additionalForce_;
+  Vector3 additionalTorque_;
 
-        stateObservation::ExtendedKalmanFilter ekf_;
-        bool finiteDifferencesJacobians_;
-        bool withGyroBias_;
-        bool withUnmodeledWrench_;
-        bool withAccelerationEstimation_;
+  Vector measurementVector_;
+  Matrix measurementCovMatrix_;
 
-        IndexedVector3 com_, comd_, comdd_;
-        IndexedVector3 sigma_,sigmad_;
-        IndexedMatrix3 I_, Id_;
+  stateObservation::ExtendedKalmanFilter ekf_;
+  bool finiteDifferencesJacobians_;
+  bool withGyroBias_;
+  bool withUnmodeledWrench_;
+  bool withAccelerationEstimation_;
 
-        TimeIndex k_est_;
-        TimeIndex k_data_;
+  IndexedVector3 com_, comd_, comdd_;
+  IndexedVector3 sigma_, sigmad_;
+  IndexedMatrix3 I_, Id_;
 
-        double mass_;
+  TimeIndex k_est_;
+  TimeIndex k_data_;
 
-        double dt_;
+  double mass_;
 
-        NoiseBase * processNoise_;
-        NoiseBase * measurementNoise_;
+  double dt_;
 
+  NoiseBase * processNoise_;
+  NoiseBase * measurementNoise_;
 
+  /// function to call before adding any measurement
+  /// detects if there is a new estimation beginning and then
+  /// calls the reset of the iteration
+  void startNewIteration_();
 
-        ///function to call before adding any measurement
-        ///detects if there is a new estimation beginning and then
-        ///calls the reset of the iteration
-        void startNewIteration_();
+  virtual Matrix computeAMatrix_();
+  virtual Matrix computeCMatrix_();
 
+  /// Getters for the indexes of the state Vector using private types
+  inline unsigned contactIndex(VectorContactConstIterator i) const;
+  inline unsigned contactKineIndex(VectorContactConstIterator i) const;
+  inline unsigned contactPosIndex(VectorContactConstIterator i) const;
+  inline unsigned contactOriIndex(VectorContactConstIterator i) const;
+  inline unsigned contactForceIndex(VectorContactConstIterator i) const;
+  inline unsigned contactTorqueIndex(VectorContactConstIterator i) const;
+  inline unsigned contactWrenchIndex(VectorContactConstIterator i) const;
 
-        virtual Matrix computeAMatrix_();
-        virtual Matrix computeCMatrix_();
+  /// Getters for the indexes of the state Vector using private types
+  inline unsigned contactIndexTangent(VectorContactConstIterator i) const;
+  inline unsigned contactKineIndexTangent(VectorContactConstIterator i) const;
+  inline unsigned contactPosIndexTangent(VectorContactConstIterator i) const;
+  inline unsigned contactOriIndexTangent(VectorContactConstIterator i) const;
+  inline unsigned contactForceIndexTangent(VectorContactConstIterator i) const;
+  inline unsigned contactTorqueIndexTangent(VectorContactConstIterator i) const;
+  inline unsigned contactWrenchIndexTangent(VectorContactConstIterator i) const;
 
-        /// Getters for the indexes of the state Vector using private types
-        inline unsigned contactIndex(VectorContactConstIterator i) const;
-        inline unsigned contactKineIndex(VectorContactConstIterator i) const;
-        inline unsigned contactPosIndex(VectorContactConstIterator i) const;
-        inline unsigned contactOriIndex(VectorContactConstIterator i) const;
-        inline unsigned contactForceIndex(VectorContactConstIterator i) const;
-        inline unsigned contactTorqueIndex(VectorContactConstIterator i) const;
-        inline unsigned contactWrenchIndex(VectorContactConstIterator i) const;
+private:
+public:
+  ///////////SIZE OF VECTORS
+  static const unsigned sizeAcceleroSignal = 3;
+  static const unsigned sizeGyroSignal = 3;
+  static const unsigned sizeIMUSignal = sizeAcceleroSignal + sizeGyroSignal;
 
-        /// Getters for the indexes of the state Vector using private types
-        inline unsigned contactIndexTangent(VectorContactConstIterator i) const;
-        inline unsigned contactKineIndexTangent(VectorContactConstIterator i) const;
-        inline unsigned contactPosIndexTangent(VectorContactConstIterator i) const;
-        inline unsigned contactOriIndexTangent(VectorContactConstIterator i) const;
-        inline unsigned contactForceIndexTangent(VectorContactConstIterator i) const;
-        inline unsigned contactTorqueIndexTangent(VectorContactConstIterator i) const;
-        inline unsigned contactWrenchIndexTangent(VectorContactConstIterator i) const;
+  static const unsigned sizePos = 3;
+  static const unsigned sizeOri = 4;
+  static const unsigned sizeOriTangent = 3;
+  static const unsigned sizeLinVel = sizePos;
+  static const unsigned sizeAngVel = sizeOriTangent;
+  static const unsigned sizeGyroBias = sizeGyroSignal;
 
+  static const unsigned sizeForce = 3;
+  static const unsigned sizeTorque = 3;
 
-    private:
+  static const unsigned sizeWrench = sizeForce + sizeTorque;
 
-    public:
+  static const unsigned sizeStateKine = sizePos + sizeOri + sizeLinVel + sizeAngVel;
+  static const unsigned sizeStateBase = sizeStateKine + sizeForce + sizeTorque;
+  static const unsigned sizeStateKineTangent = sizePos + sizeOriTangent + sizeLinVel + sizeAngVel;
+  static const unsigned sizeStateTangentBase = sizeStateKineTangent + sizeForce + sizeTorque;
 
+  static const unsigned sizePose = sizePos + sizeOri;
+  static const unsigned sizePoseTangent = sizePos + sizeOriTangent;
 
-        ///////////SIZE OF VECTORS
-        static const unsigned sizeAcceleroSignal = 3;
-        static const unsigned sizeGyroSignal = 3;
-        static const unsigned sizeIMUSignal = sizeAcceleroSignal+sizeGyroSignal;
+  static const unsigned sizeContactKine = sizePose;
+  static const unsigned sizeContactKineTangent = sizePoseTangent;
 
-        static const unsigned sizePos = 3;
-        static const unsigned sizeOri = 4;
-        static const unsigned sizeOriTangent = 3;
-        static const unsigned sizeLinVel = sizePos;
-        static const unsigned sizeAngVel = sizeOriTangent;
-        static const unsigned sizeGyroBias = sizeGyroSignal;
+  static const unsigned sizeContact = sizeContactKine + sizeWrench;
+  static const unsigned sizeContactTangent = sizeContactKineTangent + sizeWrench;
 
-        static const unsigned sizeForce = 3;
-        static const unsigned sizeTorque = 3;
+  static const Kinematics::Flags::Byte flagsStateKine = Kinematics::Flags::position | Kinematics::Flags::orientation
+                                                        | Kinematics::Flags::linVel | Kinematics::Flags::angVel;
 
-        static const unsigned sizeWrench = sizeForce + sizeTorque;
+  static const Kinematics::Flags::Byte flagsContactKine = Kinematics::Flags::position | Kinematics::Flags::orientation;
 
+  static const Kinematics::Flags::Byte flagsPoseKine = Kinematics::Flags::position | Kinematics::Flags::orientation;
 
-        static const unsigned sizeStateKine =sizePos+
-                                             sizeOri+
-                                             sizeLinVel+
-                                             sizeAngVel;
-        static const unsigned sizeStateBase = sizeStateKine+
-                                              sizeForce+
-                                              sizeTorque;
-        static const unsigned sizeStateKineTangent =sizePos+
-                                                    sizeOriTangent+
-                                                    sizeLinVel+
-                                                    sizeAngVel;
-        static const unsigned sizeStateTangentBase =sizeStateKineTangent+
-                                                    sizeForce+
-                                                    sizeTorque;
+  static const Kinematics::Flags::Byte flagsIMUKine = Kinematics::Flags::position | Kinematics::Flags::orientation
+                                                      | Kinematics::Flags::linVel | Kinematics::Flags::angVel
+                                                      | Kinematics::Flags::linAcc;
 
-        static const unsigned sizePose = sizePos+
-                                        sizeOri;
-        static const unsigned sizePoseTangent = sizePos+
-                                        sizeOriTangent;
+  ////////////DEFAULT VALUES //////
+  static const double defaultMass;
 
-        static const unsigned sizeContactKine = sizePose;
-        static const unsigned sizeContactKineTangent = sizePoseTangent;
+  static const double statePoseInitVarianceDefault;
+  static const double stateOriInitVarianceDefault;
+  static const double stateLinVelInitVarianceDefault;
+  static const double stateAngVelInitVarianceDefault;
+  static const double gyroBiasInitVarianceDefault;
+  static const double unmodeledWrenchInitVarianceDefault;
+  static const double contactForceInitVarianceDefault;
+  static const double contactTorqueInitVarianceDefault;
 
-        static const unsigned sizeContact = sizeContactKine + sizeWrench;
-        static const unsigned sizeContactTangent = sizeContactKineTangent + sizeWrench;
+  static const double statePoseProcessVarianceDefault;
+  static const double stateOriProcessVarianceDefault;
+  static const double stateLinVelProcessVarianceDefault;
+  static const double stateAngVelProcessVarianceDefault;
+  static const double gyroBiasProcessVarianceDefault;
+  static const double unmodeledWrenchProcessVarianceDefault;
+  static const double contactPositionProcessVarianceDefault;
+  static const double contactOrientationProcessVarianceDefault;
+  static const double contactForceProcessVarianceDefault;
+  static const double contactTorqueProcessVarianceDefault;
 
+  static const double acceleroVarianceDefault;
+  static const double gyroVarianceDefault;
+  static const double forceSensorVarianceDefault;
+  static const double torqueSensorVarianceDefault;
+  static const double positionSensorVarianceDefault;
+  static const double orientationSensorVarianceDefault;
 
+  static const double linearStiffnessDefault;
+  static const double angularStiffnessDefault;
+  static const double linearDampingDefault;
+  static const double angularDampingDefault;
 
-        static const Kinematics::Flags::Byte flagsStateKine =  Kinematics::Flags::position |
-                                                               Kinematics::Flags::orientation |
-                                                               Kinematics::Flags::linVel |
-                                                               Kinematics::Flags::angVel;
+  ////////////
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-        static const Kinematics::Flags::Byte flagsContactKine =  Kinematics::Flags::position |
-                                                                 Kinematics::Flags::orientation;
+protected:
+  /// Default Stiffness and damping
+  Matrix3 linearStiffnessMatDefault_;
+  Matrix3 angularStiffnessMatDefault_;
+  Matrix3 linearDampingMatDefault_;
+  Matrix3 angularDampingMatDefault_;
 
-        static const Kinematics::Flags::Byte flagsPoseKine = Kinematics::Flags::position |
-                                                                Kinematics::Flags::orientation;
+  ////////////Sensor Covariance mnatrices
+  Matrix3 acceleroCovMatDefault_;
+  Matrix3 gyroCovMatDefault_;
+  Matrix6 contactWrenchSensorCovMatDefault_;
+  Matrix6 absPoseSensorCovMatDefault_;
 
-        static const Kinematics::Flags::Byte flagsIMUKine =  Kinematics::Flags::position |
-                                                               Kinematics::Flags::orientation |
-                                                               Kinematics::Flags::linVel |
-                                                               Kinematics::Flags::angVel |
-                                                               Kinematics::Flags::linAcc;
+  Matrix3 statePosInitCovMat_;
+  Matrix3 stateOriInitCovMat_;
+  Matrix3 stateLinVelInitCovMat_;
+  Matrix3 stateAngVelInitCovMat_;
+  Matrix3 gyroBiasInitCovMat_;
+  Matrix6 unmodeledWrenchInitCovMat_;
+  Matrix12 contactInitCovMat_;
 
-        ////////////DEFAULT VALUES //////
-        static const double defaultMass;
+  Matrix3 statePosProcessCovMat_;
+  Matrix3 stateOriProcessCovMat_;
+  Matrix3 stateLinVelProcessCovMat_;
+  Matrix3 stateAngVelProcessCovMat_;
+  Matrix3 gyroBiasProcessCovMat_;
+  Matrix6 unmodeledWrenchProcessCovMat_;
+  Matrix3 contactPositionProcessCovMat_;
+  Matrix3 contactOrientationProcessCovMat_;
+  Matrix3 contactForceProcessCovMat_;
+  Matrix3 contactTorqueProcessCovMat_;
+  Matrix12 contactProcessCovMat_;
 
-        static const double statePoseInitVarianceDefault ;
-        static const double stateOriInitVarianceDefault ;
-        static const double stateLinVelInitVarianceDefault ;
-        static const double stateAngVelInitVarianceDefault ;
-        static const double gyroBiasInitVarianceDefault ;
-        static const double unmodeledWrenchInitVarianceDefault ;
-        static const double contactForceInitVarianceDefault ;
-        static const double contactTorqueInitVarianceDefault ;
+  Matrix12 stateKinematicsInitCovMat_;
+  Matrix12 stateKinematicsProcessCovMat_;
 
-        static const double statePoseProcessVarianceDefault ;
-        static const double stateOriProcessVarianceDefault ;
-        static const double stateLinVelProcessVarianceDefault ;
-        static const double stateAngVelProcessVarianceDefault ;
-        static const double gyroBiasProcessVarianceDefault ;
-        static const double unmodeledWrenchProcessVarianceDefault ;
-        static const double contactPositionProcessVarianceDefault ;
-        static const double contactOrientationProcessVarianceDefault ;
-        static const double contactForceProcessVarianceDefault ;
-        static const double contactTorqueProcessVarianceDefault ;
+  /// default derivation steps
+  static const double defaultdx;
 
-        static const double acceleroVarianceDefault ;
-        static const double gyroVarianceDefault ;
-        static const double forceSensorVarianceDefault ;
-        static const double torqueSensorVarianceDefault ;
-        static const double positionSensorVarianceDefault ;
-        static const double orientationSensorVarianceDefault;
+  /// a structure to optimize computations
+  struct Opt
+  {
+    Opt() : kine(kine1), ori(kine.orientation), ori1(kine1.orientation), ori2(kine2.orientation) {}
 
-        static const double linearStiffnessDefault;
-        static const double angularStiffnessDefault;
-        static const double linearDampingDefault;
-        static const double angularDampingDefault;
-
-
-        ////////////
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-    protected:
-        /// Default Stiffness and damping
-        Matrix3 linearStiffnessMatDefault_;
-        Matrix3 angularStiffnessMatDefault_;
-        Matrix3 linearDampingMatDefault_;
-        Matrix3 angularDampingMatDefault_;
-
-        ////////////Sensor Covariance mnatrices
-        Matrix3 acceleroCovMatDefault_;
-        Matrix3 gyroCovMatDefault_;
-        Matrix6 contactWrenchSensorCovMatDefault_;
-        Matrix6 absPoseSensorCovMatDefault_;
-
-        Matrix3 statePosInitCovMat_;
-        Matrix3 stateOriInitCovMat_;
-        Matrix3 stateLinVelInitCovMat_;
-        Matrix3 stateAngVelInitCovMat_;
-        Matrix3 gyroBiasInitCovMat_;
-        Matrix6 unmodeledWrenchInitCovMat_;
-        Matrix12 contactInitCovMat_;
-
-        Matrix3 statePosProcessCovMat_;
-        Matrix3 stateOriProcessCovMat_;
-        Matrix3 stateLinVelProcessCovMat_;
-        Matrix3 stateAngVelProcessCovMat_;
-        Matrix3 gyroBiasProcessCovMat_;
-        Matrix6 unmodeledWrenchProcessCovMat_;
-        Matrix3 contactPositionProcessCovMat_;
-        Matrix3 contactOrientationProcessCovMat_;
-        Matrix3 contactForceProcessCovMat_;
-        Matrix3 contactTorqueProcessCovMat_;
-        Matrix12 contactProcessCovMat_;
-
-        Matrix12 stateKinematicsInitCovMat_;
-        Matrix12 stateKinematicsProcessCovMat_;
-
-        ///default derivation steps
-        static const double defaultdx;
-
-
-        /// a structure to optimize computations
-        struct Opt
-        {
-            Opt():
-                kine(kine1),
-                ori(kine.orientation),
-                ori1(kine1.orientation),
-                ori2(kine2.orientation)
-            {}
-
-            Kinematics kine1, kine2;
-            Kinematics & kine;
-            Orientation & ori;
-            Orientation & ori1;
-            Orientation & ori2;
-        } opt_;
-
-    };
+    Kinematics kine1, kine2;
+    Kinematics & kine;
+    Orientation & ori;
+    Orientation & ori1;
+    Orientation & ori2;
+  } opt_;
+};
 
 #include <state-observation/dynamics-estimators/kinetics-observer.hxx>
 
-}
+} // namespace stateObservation
 
 #endif /// KINETICSOBSERVER_HPP

--- a/include/state-observation/examples/imu-attitude-trajectory-reconstruction.hpp
+++ b/include/state-observation/examples/imu-attitude-trajectory-reconstruction.hpp
@@ -14,94 +14,87 @@
 #ifndef IMUATTITUDETRAJECTORYRECONTRUCTIONHPP
 #define IMUATTITUDETRAJECTORYRECONTRUCTIONHPP
 
-
 #include <state-observation/api.h>
-#include <state-observation/dynamical-system/imu-dynamical-system.hpp>
 #include <state-observation/dynamical-system/dynamical-system-simulator.hpp>
+#include <state-observation/dynamical-system/imu-dynamical-system.hpp>
 #include <state-observation/observer/extended-kalman-filter.hpp>
 #include <state-observation/tools/miscellaneous-algorithms.hpp>
 
 namespace stateObservation
 {
-    namespace examples
-    {
+namespace examples
+{
 
-        /*! \fn IndexedVectorArray imuAttitudeTrajectoryReconstruction(
-         *   const IndexedVectorArray & y,
-         *   const IndexedVectorArray & u,
-         *   const Vector & xh0,
-         *   const Matrix & p,
-         *   const Matrix & q,
-         *   const Matrix & r,
-         *   double dt);
-         *
-         *  \brief Provides the estimation of the state (mostly attitude) of an
-         *         IMU, given the measurements of the IMU and the input
-         *         (which provides the acceleration/jerk). This method uses
-         *         extended Kalman filtering, we need to provide it with an
-         *         initial guess, a covariance matrix of this initial guess
-         *         and covariance matrices of the state perturbations and
-         *         measurement noises.
-         *
-         *
-         *  \param y IMU measurements
-         *  \param u the inputs of the dynamical system
-         *  \param xh0 an initial guess of the state
-         *  \param p the covariance matrix of the error of the initial guess
-         *  \param q the covariance matrix of the process noise (state perturbation)
-         *  \param r the covariance matrix of the measurement noise
-         *  \param dt the time discretization period
-         */
+/*! \fn IndexedVectorArray imuAttitudeTrajectoryReconstruction(
+ *   const IndexedVectorArray & y,
+ *   const IndexedVectorArray & u,
+ *   const Vector & xh0,
+ *   const Matrix & p,
+ *   const Matrix & q,
+ *   const Matrix & r,
+ *   double dt);
+ *
+ *  \brief Provides the estimation of the state (mostly attitude) of an
+ *         IMU, given the measurements of the IMU and the input
+ *         (which provides the acceleration/jerk). This method uses
+ *         extended Kalman filtering, we need to provide it with an
+ *         initial guess, a covariance matrix of this initial guess
+ *         and covariance matrices of the state perturbations and
+ *         measurement noises.
+ *
+ *
+ *  \param y IMU measurements
+ *  \param u the inputs of the dynamical system
+ *  \param xh0 an initial guess of the state
+ *  \param p the covariance matrix of the error of the initial guess
+ *  \param q the covariance matrix of the process noise (state perturbation)
+ *  \param r the covariance matrix of the measurement noise
+ *  \param dt the time discretization period
+ */
 
-        IndexedVectorArray imuAttitudeTrajectoryReconstruction(
-            const IndexedVectorArray & y,
-            const IndexedVectorArray & u,
-            const Vector & xh0,
-            const Matrix & p,
-            const Matrix & q,
-            const Matrix & r,
-            double dt);
+IndexedVectorArray imuAttitudeTrajectoryReconstruction(const IndexedVectorArray & y,
+                                                       const IndexedVectorArray & u,
+                                                       const Vector & xh0,
+                                                       const Matrix & p,
+                                                       const Matrix & q,
+                                                       const Matrix & r,
+                                                       double dt);
 
-
-        /*! \fn IndexedVectorArray imuAttitudeTrajectoryReconstruction(
-         *   const IndexedVectorArray & y,
-         *   const Vector & xh0,
-         *   const Matrix & p,
-         *   const Matrix & q,
-         *   const Matrix & r,
-         *   double dt);
-         *
-         *  \brief Provides the estimation of the state (mostly attitude) of an
-         *         IMU, given the measurements of the IMU without knowing the input.
-         *         The input is assumed to be zero over the observation. This method uses
-         *         extended Kalman filtering, we need to provide it with an
-         *         initial guess, a covariance matrix of this initial guess
-         *         and covariance matrices of the state perturbations and
-         *         measurement noises.
-         *
-         *
-         *  \param y IMU measurements
-         *  \param xh0 an initial guess of the state
-         *  \param p the covariance matrix of the error of the initial guess
-         *  \param q the covariance matrix of the process noise (state perturbation)
-         *  \param r the covariance matrix of the measurement noise
-         *  \param dt the time discretization period
-         */
-        IndexedVectorArray imuAttitudeTrajectoryReconstruction(
-            const IndexedVectorArray & y,
-            const Vector & xh0,
-            const Matrix & p,
-            const Matrix & q,
-            const Matrix & r,
-            double dt);
-
-
-
+/*! \fn IndexedVectorArray imuAttitudeTrajectoryReconstruction(
+ *   const IndexedVectorArray & y,
+ *   const Vector & xh0,
+ *   const Matrix & p,
+ *   const Matrix & q,
+ *   const Matrix & r,
+ *   double dt);
+ *
+ *  \brief Provides the estimation of the state (mostly attitude) of an
+ *         IMU, given the measurements of the IMU without knowing the input.
+ *         The input is assumed to be zero over the observation. This method uses
+ *         extended Kalman filtering, we need to provide it with an
+ *         initial guess, a covariance matrix of this initial guess
+ *         and covariance matrices of the state perturbations and
+ *         measurement noises.
+ *
+ *
+ *  \param y IMU measurements
+ *  \param xh0 an initial guess of the state
+ *  \param p the covariance matrix of the error of the initial guess
+ *  \param q the covariance matrix of the process noise (state perturbation)
+ *  \param r the covariance matrix of the measurement noise
+ *  \param dt the time discretization period
+ */
+IndexedVectorArray imuAttitudeTrajectoryReconstruction(const IndexedVectorArray & y,
+                                                       const Vector & xh0,
+                                                       const Matrix & p,
+                                                       const Matrix & q,
+                                                       const Matrix & r,
+                                                       double dt);
 
 #include <state-observation/examples/imu-attitude-trajectory-reconstruction.hxx>
 
-    }
+} // namespace examples
 
-}
+} // namespace stateObservation
 
-#endif //IMUATTITUDETRAJECTORYRECONTRUCTIONHPP
+#endif // IMUATTITUDETRAJECTORYRECONTRUCTIONHPP

--- a/include/state-observation/examples/imu-multiplicative-attitude-reconstruction.hpp
+++ b/include/state-observation/examples/imu-multiplicative-attitude-reconstruction.hpp
@@ -15,92 +15,86 @@
 #define IMUMULTUPLICATIVEATTITUDETRAJECTORYRECONTRUCTIONHPP
 
 #include <state-observation/api.h>
-#include <state-observation/dynamical-system/imu-mltpctive-dynamical-system.hpp>
 #include <state-observation/dynamical-system/dynamical-system-simulator.hpp>
+#include <state-observation/dynamical-system/imu-mltpctive-dynamical-system.hpp>
 #include <state-observation/observer/extended-kalman-filter.hpp>
 #include <state-observation/tools/miscellaneous-algorithms.hpp>
 
 namespace stateObservation
 {
-    namespace examples
-    {
+namespace examples
+{
 
-        /*! \fn IndexedVectorArray imuMultiplicativeAttitudeReconstruction(
-         *   const IndexedVectorArray & y,
-         *   const IndexedVectorArray & u,
-         *   const Vector & xh0,
-         *   const Matrix & p,
-         *   const Matrix & q,
-         *   const Matrix & r,
-         *   double dt);
-         *
-         *  \brief Provides the estimation of the state (mostly attitude) of an
-         *         IMU, given the measurements of the IMU and the input
-         *         (which provides the acceleration/jerk). This method uses
-         *         multiplicative extended Kalman filtering, we need to provide
-         *         it with an initial guess, a covariance matrix of this initial
-         *         guess and covariance matrices of the state perturbations and
-         *         measurement noises.
-         *
-         *
-         *  \param y IMU measurements
-         *  \param u the inputs of the dynamical system
-         *  \param xh0 an initial guess of the state
-         *  \param p the covariance matrix of the error of the initial guess
-         *  \param q the covariance matrix of the process noise (state perturbation)
-         *  \param r the covariance matrix of the measurement noise
-         *  \param dt the time discretization period
-         */
+/*! \fn IndexedVectorArray imuMultiplicativeAttitudeReconstruction(
+ *   const IndexedVectorArray & y,
+ *   const IndexedVectorArray & u,
+ *   const Vector & xh0,
+ *   const Matrix & p,
+ *   const Matrix & q,
+ *   const Matrix & r,
+ *   double dt);
+ *
+ *  \brief Provides the estimation of the state (mostly attitude) of an
+ *         IMU, given the measurements of the IMU and the input
+ *         (which provides the acceleration/jerk). This method uses
+ *         multiplicative extended Kalman filtering, we need to provide
+ *         it with an initial guess, a covariance matrix of this initial
+ *         guess and covariance matrices of the state perturbations and
+ *         measurement noises.
+ *
+ *
+ *  \param y IMU measurements
+ *  \param u the inputs of the dynamical system
+ *  \param xh0 an initial guess of the state
+ *  \param p the covariance matrix of the error of the initial guess
+ *  \param q the covariance matrix of the process noise (state perturbation)
+ *  \param r the covariance matrix of the measurement noise
+ *  \param dt the time discretization period
+ */
 
-        IndexedVectorArray imuMultiplicativeAttitudeReconstruction(
-            const IndexedVectorArray & y,
-            const IndexedVectorArray & u,
-            const Vector & xh0,
-            const Matrix & p,
-            const Matrix & q,
-            const Matrix & r,
-            double dt);
+IndexedVectorArray imuMultiplicativeAttitudeReconstruction(const IndexedVectorArray & y,
+                                                           const IndexedVectorArray & u,
+                                                           const Vector & xh0,
+                                                           const Matrix & p,
+                                                           const Matrix & q,
+                                                           const Matrix & r,
+                                                           double dt);
 
-
-        /*! \fn IndexedVectorArray imuMultiplicativeAttitudeReconstruction(
-         *   const IndexedVectorArray & y,
-         *   const Vector & xh0,
-         *   const Matrix & p,
-         *   const Matrix & q,
-         *   const Matrix & r,
-         *   double dt);
-         *
-         *  \brief Provides the estimation of the state (mostly attitude) of an
-         *         IMU, given the measurements of the IMU without knowing the input.
-         *         The input is assumed to be zero over the observation. This method uses
-         *         multiplicative extended Kalman filtering, we need to provide it with an
-         *         initial guess, a covariance matrix of this initial guess
-         *         and covariance matrices of the state perturbations and
-         *         measurement noises.
-         *
-         *
-         *  \param y IMU measurements
-         *  \param xh0 an initial guess of the state
-         *  \param p the covariance matrix of the error of the initial guess
-         *  \param q the covariance matrix of the process noise (state perturbation)
-         *  \param r the covariance matrix of the measurement noise
-         *  \param dt the time discretization period
-         */
-        IndexedVectorArray imuMultiplicativeAttitudeReconstruction(
-            const IndexedVectorArray & y,
-            const Vector & xh0,
-            const Matrix & p,
-            const Matrix & q,
-            const Matrix & r,
-            double dt);
-
-
-
+/*! \fn IndexedVectorArray imuMultiplicativeAttitudeReconstruction(
+ *   const IndexedVectorArray & y,
+ *   const Vector & xh0,
+ *   const Matrix & p,
+ *   const Matrix & q,
+ *   const Matrix & r,
+ *   double dt);
+ *
+ *  \brief Provides the estimation of the state (mostly attitude) of an
+ *         IMU, given the measurements of the IMU without knowing the input.
+ *         The input is assumed to be zero over the observation. This method uses
+ *         multiplicative extended Kalman filtering, we need to provide it with an
+ *         initial guess, a covariance matrix of this initial guess
+ *         and covariance matrices of the state perturbations and
+ *         measurement noises.
+ *
+ *
+ *  \param y IMU measurements
+ *  \param xh0 an initial guess of the state
+ *  \param p the covariance matrix of the error of the initial guess
+ *  \param q the covariance matrix of the process noise (state perturbation)
+ *  \param r the covariance matrix of the measurement noise
+ *  \param dt the time discretization period
+ */
+IndexedVectorArray imuMultiplicativeAttitudeReconstruction(const IndexedVectorArray & y,
+                                                           const Vector & xh0,
+                                                           const Matrix & p,
+                                                           const Matrix & q,
+                                                           const Matrix & r,
+                                                           double dt);
 
 #include <state-observation/examples/imu-multiplicative-attitude-reconstruction.hxx>
 
-    }
+} // namespace examples
 
-}
+} // namespace stateObservation
 
-#endif //IMUMULTUPLICATIVEATTITUDETRAJECTORYRECONTRUCTIONHPP
+#endif // IMUMULTUPLICATIVEATTITUDETRAJECTORYRECONTRUCTIONHPP

--- a/include/state-observation/examples/offline-ekf-flexibility-estimation.hpp
+++ b/include/state-observation/examples/offline-ekf-flexibility-estimation.hpp
@@ -19,77 +19,74 @@
 
 namespace stateObservation
 {
-    namespace examples
-    {
+namespace examples
+{
 
-        /*! \fn IndexedVectorArray offlineEKFFlexibilityEstimation(
-         *   const stateObservation::IndexedVectorArray & y,
-         *   const stateObservation::IndexedVectorArray & u,
-         *   const Matrix & xh0,
-         *   unsigned numberOfContacts,
-         *   const std::vector<Vector3> & contactsPositions,
-         *   double dt);
-         *
-         *  \brief Provides the estimation of the flexibility of a robot
-         *         given the measurements of an IMU and the input
-         *         (which provides the reference trajectory of the IMU). This method uses
-         *         extended Kalman filtering, we need to provide it with an
-         *         initial guess, the number of contacts and their positions, and
-         *         the time sampling period.
-         *
-         *
-         *  \param y IMU measurements
-         *  \param u the inputs of the dynamical system
-         *  \param xh0 an initial guess of the state
-         *  \param numberOfContacts the number of contacts
-         *  \param contactsPositions a vector of positions of the vector
-         *  \param dt the time discretization period
-         */
-        stateObservation::IndexedVectorArray offlineEKFFlexibilityEstimation(
-            const stateObservation::IndexedVectorArray & y,
-            const stateObservation::IndexedVectorArray & u,
-            const Vector & xh0,
-            unsigned numberOfContacts,
-            const std::vector<Vector3, Eigen::aligned_allocator<Vector3> > & contactsPositions,
-            double dt,
-            IndexedVectorArray * ino=0x0,
-            IndexedVectorArray * premea = 0x0);
+/*! \fn IndexedVectorArray offlineEKFFlexibilityEstimation(
+ *   const stateObservation::IndexedVectorArray & y,
+ *   const stateObservation::IndexedVectorArray & u,
+ *   const Matrix & xh0,
+ *   unsigned numberOfContacts,
+ *   const std::vector<Vector3> & contactsPositions,
+ *   double dt);
+ *
+ *  \brief Provides the estimation of the flexibility of a robot
+ *         given the measurements of an IMU and the input
+ *         (which provides the reference trajectory of the IMU). This method uses
+ *         extended Kalman filtering, we need to provide it with an
+ *         initial guess, the number of contacts and their positions, and
+ *         the time sampling period.
+ *
+ *
+ *  \param y IMU measurements
+ *  \param u the inputs of the dynamical system
+ *  \param xh0 an initial guess of the state
+ *  \param numberOfContacts the number of contacts
+ *  \param contactsPositions a vector of positions of the vector
+ *  \param dt the time discretization period
+ */
+stateObservation::IndexedVectorArray offlineEKFFlexibilityEstimation(
+    const stateObservation::IndexedVectorArray & y,
+    const stateObservation::IndexedVectorArray & u,
+    const Vector & xh0,
+    unsigned numberOfContacts,
+    const std::vector<Vector3, Eigen::aligned_allocator<Vector3>> & contactsPositions,
+    double dt,
+    IndexedVectorArray * ino = 0x0,
+    IndexedVectorArray * premea = 0x0);
 
+/*! \fn IndexedVectorArray offlineEKFFlexibilityEstimation(
+ *   const stateObservation::IndexedVectorArray & y,
+ *   const stateObservation::IndexedVectorArray & u,
+ *   const Matrix & xh0,
+ *   unsigned numberOfContacts,
+ *   const std::vector<Vector3> & contactsPositions,
+ *   double dt);
+ *
+ *  \brief Provides the estimation of the flexibility of a robot
+ *         given the measurements of an IMU. This method uses
+ *         extended Kalman filtering, we need to provide it with an
+ *         initial guess, the number of contacts and their positions, and
+ *         the time sampling period.
+ *
+ *
+ *  \param y IMU measurements
+ *  \param xh0 an initial guess of the state
+ *  \param numberOfContacts the number of contacts
+ *  \param contactsPositions a vector of positions of the vector
+ *  \param dt the time discretization period
+ */
+stateObservation::IndexedVectorArray offlineEKFFlexibilityEstimation(
+    const stateObservation::IndexedVectorArray & y,
+    const Vector & xh0,
+    unsigned numberOfContacts,
+    const std::vector<Vector3, Eigen::aligned_allocator<Vector3>> & contactsPositions,
+    double dt);
 
-        /*! \fn IndexedVectorArray offlineEKFFlexibilityEstimation(
-         *   const stateObservation::IndexedVectorArray & y,
-         *   const stateObservation::IndexedVectorArray & u,
-         *   const Matrix & xh0,
-         *   unsigned numberOfContacts,
-         *   const std::vector<Vector3> & contactsPositions,
-         *   double dt);
-         *
-         *  \brief Provides the estimation of the flexibility of a robot
-         *         given the measurements of an IMU. This method uses
-         *         extended Kalman filtering, we need to provide it with an
-         *         initial guess, the number of contacts and their positions, and
-         *         the time sampling period.
-         *
-         *
-         *  \param y IMU measurements
-         *  \param xh0 an initial guess of the state
-         *  \param numberOfContacts the number of contacts
-         *  \param contactsPositions a vector of positions of the vector
-         *  \param dt the time discretization period
-         */
-        stateObservation::IndexedVectorArray offlineEKFFlexibilityEstimation(
-            const stateObservation::IndexedVectorArray & y,
-            const Vector & xh0,
-            unsigned numberOfContacts,
-            const std::vector<Vector3, Eigen::aligned_allocator<Vector3> > & contactsPositions,
-            double dt);
+#include <state-observation/examples/offline-ekf-flexibility-estimation.hxx>
 
+} // namespace examples
 
-
-# include <state-observation/examples/offline-ekf-flexibility-estimation.hxx>
-
-    }
-
-}
+} // namespace stateObservation
 
 #endif // FLEXIBILITYESTIMATION_OFFLINEEKFFLEXIBILITYESTIMATION_H

--- a/include/state-observation/examples/offline-model-base-flex-estimation.hpp
+++ b/include/state-observation/examples/offline-model-base-flex-estimation.hpp
@@ -20,65 +20,64 @@
 
 namespace stateObservation
 {
-    namespace examples
-    {
+namespace examples
+{
 
-        /*! \fn IndexedVectorArray offlineEKFFlexibilityEstimation(
-         *   const stateObservation::IndexedVectorArray & y,
-         *   const stateObservation::IndexedVectorArray & u,
-         *   const Matrix & xh0,
-         *   unsigned numberOfContacts,
-         *   const std::vector<Vector3> & contactsPositions,
-         *   double dt);
-         *
-         *  \brief Provides the estimation of the flexibility of a robot
-         *         given the measurements of an IMU and the input
-         *         (which provides the reference trajectory of the IMU). This method uses
-         *         extended Kalman filtering, we need to provide it with an
-         *         initial guess, the number of contacts and their positions, and
-         *         the time sampling period.
-         *
-         *
-         *  \param y IMU measurements
-         *  \param u the inputs of the dynamical system
-         *  \param xh0 an initial guess of the state
-         *  \param numberOfContacts the number of contacts
-         *  \param contactsPositions a vector of positions of the vector
-         *  \param dt the time discretization period
-         *  \param mass the mass of the robot
-         *  \param Q process noise covariance matrix
-         *          It is an indexed Matrix array, when its size is zero it is ignored
-         *          when its size is 1 the matrix is set to constant
-         *          when its size is bigger than it is the value of the covariance matrix
-         *          for every time sample.
-         *  \param R measurement noise covariance matrix. Size interpretation is the same
-         *         as for Q.
-         */
-        stateObservation::IndexedVectorArray offlineModelBaseFlexEstimation(
-            const stateObservation::IndexedVectorArray & y,
-            const stateObservation::IndexedVectorArray & u,
-            const Matrix & xh0,
-            const stateObservation::IndexedVectorArray numberOfContacts,
-            double dt,
-            double mass,
-            bool withForce,
-            const stateObservation::IndexedMatrixArray & Q = stateObservation::IndexedMatrixArray(),
-            const stateObservation::IndexedMatrixArray & R = stateObservation::IndexedMatrixArray(),
-            const Matrix3 & kfe = Matrix3::Zero(),
-            const Matrix3 & kfv = Matrix3::Zero(),
-            const Matrix3 & kte = Matrix3::Zero(),
-            const Matrix3 & ktv = Matrix3::Zero(),
-            IndexedVectorArray * prediction=0x0,
-            IndexedVectorArray * inovation=0x0,
-            IndexedVectorArray * predictedMeasurements = 0x0,
-            IndexedVectorArray * simulatedMeasurements = 0x0,
-            int verbose=0x0);
+/*! \fn IndexedVectorArray offlineEKFFlexibilityEstimation(
+ *   const stateObservation::IndexedVectorArray & y,
+ *   const stateObservation::IndexedVectorArray & u,
+ *   const Matrix & xh0,
+ *   unsigned numberOfContacts,
+ *   const std::vector<Vector3> & contactsPositions,
+ *   double dt);
+ *
+ *  \brief Provides the estimation of the flexibility of a robot
+ *         given the measurements of an IMU and the input
+ *         (which provides the reference trajectory of the IMU). This method uses
+ *         extended Kalman filtering, we need to provide it with an
+ *         initial guess, the number of contacts and their positions, and
+ *         the time sampling period.
+ *
+ *
+ *  \param y IMU measurements
+ *  \param u the inputs of the dynamical system
+ *  \param xh0 an initial guess of the state
+ *  \param numberOfContacts the number of contacts
+ *  \param contactsPositions a vector of positions of the vector
+ *  \param dt the time discretization period
+ *  \param mass the mass of the robot
+ *  \param Q process noise covariance matrix
+ *          It is an indexed Matrix array, when its size is zero it is ignored
+ *          when its size is 1 the matrix is set to constant
+ *          when its size is bigger than it is the value of the covariance matrix
+ *          for every time sample.
+ *  \param R measurement noise covariance matrix. Size interpretation is the same
+ *         as for Q.
+ */
+stateObservation::IndexedVectorArray offlineModelBaseFlexEstimation(
+    const stateObservation::IndexedVectorArray & y,
+    const stateObservation::IndexedVectorArray & u,
+    const Matrix & xh0,
+    const stateObservation::IndexedVectorArray numberOfContacts,
+    double dt,
+    double mass,
+    bool withForce,
+    const stateObservation::IndexedMatrixArray & Q = stateObservation::IndexedMatrixArray(),
+    const stateObservation::IndexedMatrixArray & R = stateObservation::IndexedMatrixArray(),
+    const Matrix3 & kfe = Matrix3::Zero(),
+    const Matrix3 & kfv = Matrix3::Zero(),
+    const Matrix3 & kte = Matrix3::Zero(),
+    const Matrix3 & ktv = Matrix3::Zero(),
+    IndexedVectorArray * prediction = 0x0,
+    IndexedVectorArray * inovation = 0x0,
+    IndexedVectorArray * predictedMeasurements = 0x0,
+    IndexedVectorArray * simulatedMeasurements = 0x0,
+    int verbose = 0x0);
 
+#include <state-observation/examples/offline-model-base-flex-estimation.hxx>
 
-# include <state-observation/examples/offline-model-base-flex-estimation.hxx>
+} // namespace examples
 
-    }
-
-}
+} // namespace stateObservation
 
 #endif // FLEXIBILITYESTIMATION_OFFLINEEKFFLEXIBILITYESTIMATION_H

--- a/include/state-observation/flexibility-estimation/ekf-flexibility-estimator-base.hpp
+++ b/include/state-observation/flexibility-estimation/ekf-flexibility-estimator-base.hpp
@@ -20,146 +20,140 @@
 
 #include <state-observation/flexibility-estimation/flexibility-estimator-base.hpp>
 
-
 namespace stateObservation
 {
 namespace flexibilityEstimation
 {
-   /**
-    * \class  EKFFlexibilityEstimatorBase
-    * \brief  This class is the base class of the flexibility estimators that
-    *         use an extended Kalman Filter. Several methods require to be overloaded
-    *         to derive an implementation from this base class.
-    *
-    */
+/**
+ * \class  EKFFlexibilityEstimatorBase
+ * \brief  This class is the base class of the flexibility estimators that
+ *         use an extended Kalman Filter. Several methods require to be overloaded
+ *         to derive an implementation from this base class.
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI EKFFlexibilityEstimatorBase:
-                public FlexibilityEstimatorBase
-    {
-    public:
+class STATE_OBSERVATION_DLLAPI EKFFlexibilityEstimatorBase : public FlexibilityEstimatorBase
+{
+public:
+  /// The constructor.
+  ///  \li stateSize : size of the state vector
+  ///  \li measurementSize : size of the measurements vector
+  ///  \li inputSize : size of the input vector
+  ///  \li dx gives the derivation step for a finite differences derivation method
 
+  EKFFlexibilityEstimatorBase(Index stateSize,
+                              Index measurementSize,
+                              Index inputSize,
+                              const Vector & dx = Vector::Zero(0));
 
-        /// The constructor.
-        ///  \li stateSize : size of the state vector
-        ///  \li measurementSize : size of the measurements vector
-        ///  \li inputSize : size of the input vector
-        ///  \li dx gives the derivation step for a finite differences derivation method
+  /// virtual destructor
+  virtual ~EKFFlexibilityEstimatorBase();
 
-        EKFFlexibilityEstimatorBase(Index stateSize,
-                                    Index measurementSize,
-                                    Index inputSize,
-                                    const Vector & dx=Vector::Zero(0) );
+  /// Sets a value of the flexibility x_k provided from another source
+  /// can be used for initialization of the estimator
+  /// This is a pure virtual function that requires to be overloaded in
+  /// implementation
+  virtual void setFlexibilityGuess(const Matrix &) = 0;
 
+  /// Sets the covariance matrix of the flexibility Guess
+  virtual void setFlexibilityCovariance(const Matrix & P);
 
-        ///virtual destructor
-        virtual ~EKFFlexibilityEstimatorBase();
+  /// Gets the covariance matrix of the flexibility
+  virtual Matrix getFlexibilityCovariance() const;
 
-        ///Sets a value of the flexibility x_k provided from another source
-        /// can be used for initialization of the estimator
-        /// This is a pure virtual function that requires to be overloaded in
-        /// implementation
-        virtual void setFlexibilityGuess(const Matrix &)=0;
+  /// Sets the covariance matrices for the process noises
+  /// \li Q process noise
+  virtual void setProcessNoiseCovariance(const Matrix & Q);
 
-        ///Sets the covariance matrix of the flexibility Guess
-        virtual void setFlexibilityCovariance(const Matrix & P);
+  /// Sets the covariance matrices for the sensor noises
+  /// \li R sensor noise
+  virtual void setMeasurementNoiseCovariance(const Matrix & R);
 
-        ///Gets the covariance matrix of the flexibility
-        virtual Matrix getFlexibilityCovariance() const;
+  /// gets the covariance matrices for the process noises
+  virtual Matrix getProcessNoiseCovariance() const;
 
-        ///Sets the covariance matrices for the process noises
-        /// \li Q process noise
-        virtual void setProcessNoiseCovariance(const Matrix & Q);
+  /// gets the covariance matrices for the sensor noises
+  virtual Matrix getMeasurementNoiseCovariance() const;
 
-        ///Sets the covariance matrices for the sensor noises
-        /// \li R sensor noise
-        virtual void setMeasurementNoiseCovariance(const Matrix & R);
+  /// Sets the value of the next sensor measurement y_{k+1}
+  virtual void setMeasurement(const Vector & y);
 
-        ///gets the covariance matrices for the process noises
-        virtual Matrix getProcessNoiseCovariance() const ;
+  virtual Vector getMeasurement();
 
-        ///gets the covariance matrices for the sensor noises
-        virtual Matrix getMeasurementNoiseCovariance() const ;
+  /// Sets the value of the next input for the state process dynamics
+  /// i.e. : gives u_k such that x_{k+1} = f(x_k,u_k)
+  virtual void setInput(const Vector & u);
 
-        /// Sets the value of the next sensor measurement y_{k+1}
-        virtual void setMeasurement(const Vector & y);
+  /// Sets the value of the next  measurement
+  /// i.e. : gives u_{k+1} such that y_{k+1}=h(x_{k+1},u_{k+1})
+  virtual void setMeasurementInput(const Vector & u);
 
-        virtual Vector getMeasurement();
+  virtual Vector getInput();
 
-        /// Sets the value of the next input for the state process dynamics
-        /// i.e. : gives u_k such that x_{k+1} = f(x_k,u_k)
-        virtual void setInput(const Vector & u);
+  virtual Vector getMeasurementInput();
 
-        /// Sets the value of the next  measurement
-        /// i.e. : gives u_{k+1} such that y_{k+1}=h(x_{k+1},u_{k+1})
-        virtual void setMeasurementInput(const Vector & u);
+  /// Gets an estimation of the flexibility in the form of a state vector \hat{x_{k+1}}
+  virtual const Vector & getFlexibilityVector();
 
-        virtual Vector getInput();
+  /// Gets an estimation of the flexibility in the form of a homogeneous matrix
+  virtual Matrix4 getFlexibility() = 0;
 
-        virtual Vector getMeasurementInput();
+  /// Gets a const reference on the extended Kalman filter
+  virtual const stateObservation::ExtendedKalmanFilter & getEKF() const;
 
-        /// Gets an estimation of the flexibility in the form of a state vector \hat{x_{k+1}}
-        virtual const Vector& getFlexibilityVector();
+  /// Gets a reference on the extended Kalman filter
+  virtual stateObservation::ExtendedKalmanFilter & getEKF();
 
-        /// Gets an estimation of the flexibility in the form of a homogeneous matrix
-        virtual Matrix4 getFlexibility()=0;
+  /// Gets the state size
+  /// this method is pure virtual and reauires to be overloaded in implementation
+  virtual Index getStateSize() const = 0;
 
-        /// Gets a const reference on the extended Kalman filter
-        virtual const stateObservation::ExtendedKalmanFilter & getEKF() const;
+  /// Gets the measurements size
+  /// this method is pure virtual and reauires to be overloaded in implementation
+  virtual Index getMeasurementSize() const = 0;
 
-        /// Gets a reference on the extended Kalman filter
-        virtual stateObservation::ExtendedKalmanFilter & getEKF();
+  /// Gets the input size
+  /// this method is pure virtual and reauires to be overloaded in implementation
+  virtual Index getInputSize() const = 0;
 
-        /// Gets the state size
-        /// this method is pure virtual and reauires to be overloaded in implementation
-        virtual Index getStateSize() const =0;
+  /// Gets a simulation of the
+  virtual Vector getSimulatedMeasurement();
 
-        /// Gets the measurements size
-        /// this method is pure virtual and reauires to be overloaded in implementation
-        virtual Index getMeasurementSize() const =0;
+  /// Resets the covariance matrices to their original values
+  virtual void resetCovarianceMatrices() = 0;
 
-        /// Gets the input size
-        /// this method is pure virtual and reauires to be overloaded in implementation
-        virtual Index getInputSize() const =0;
+  /// Get the last vector of inovation of the Kalman filter
+  virtual Vector getInnovation();
 
-        /// Gets a simulation of the
-        virtual Vector getSimulatedMeasurement();
+  /// Get the simulated measurement of the predicted state
+  virtual Vector getPredictedMeasurement();
 
-        ///Resets the covariance matrices to their original values
-        virtual void resetCovarianceMatrices()=0;
+  /// Get the predicted state
+  virtual Vector getPrediction();
 
-        ///Get the last vector of inovation of the Kalman filter
-        virtual Vector getInnovation();
+  /// Get the last simulated measurement
+  virtual Vector getLastPredictedMeasurement();
 
-        ///Get the simulated measurement of the predicted state
-        virtual Vector getPredictedMeasurement();
+  /// Get the last predicted state
+  virtual Vector getLastPrediction();
 
-        ///Get the predicted state
-        virtual Vector getPrediction();
+protected:
+  virtual void setJacobians(const Matrix & A, const Matrix & C);
 
-        ///Get the last simulated measurement
-        virtual Vector getLastPredictedMeasurement();
+  virtual void useFiniteDifferencesJacobians(Vector dx);
 
-        ///Get the last predicted state
-        virtual Vector getLastPrediction();
+  stateObservation::ExtendedKalmanFilter ekf_;
 
-    protected:
-        virtual void setJacobians(const Matrix & A, const Matrix & C);
+  bool finiteDifferencesJacobians_;
 
-        virtual void useFiniteDifferencesJacobians(Vector dx);
+  Vector dx_;
 
-        stateObservation::ExtendedKalmanFilter ekf_;
+  Vector lastX_;
 
-        bool finiteDifferencesJacobians_;
+  TimeIndex k_;
 
-        Vector dx_;
-
-        Vector lastX_;
-
-        TimeIndex k_;
-
-    private:
-
-    };
-}
-}
+private:
+};
+} // namespace flexibilityEstimation
+} // namespace stateObservation
 #endif // FLEXIBILITYESTIMATION_EKFFLEXIBILITYESTIMATORBASE_H

--- a/include/state-observation/flexibility-estimation/fixed-contact-ekf-flex-estimator-imu.hpp
+++ b/include/state-observation/flexibility-estimation/fixed-contact-ekf-flex-estimator-imu.hpp
@@ -10,7 +10,6 @@
  *
  */
 
-
 #ifndef FLEXBILITYESTMATOR_FIXEDCONTACTEKFFLEXIBILITYESTIMATOR_IMU_H
 #define FLEXBILITYESTMATOR_FIXEDCONTACTEKFFLEXIBILITYESTIMATOR_IMU_H
 
@@ -23,101 +22,96 @@ namespace stateObservation
 namespace flexibilityEstimation
 {
 
-    /**
-    * \class  FixedContactEKFFlexEstimatorIMU
-    * \brief  This class implements the flexibility estimation of a robot with
-    *         the hypothesis that the contact positions do not move. This constraint
-    *         is expressed using fictious measurements but the interface is transparent
-    *         to this assumption, the state is expressed using classical representation
-    *         of position, velocity, acceleration, orientation (using (theta x mu) representation)
-    *         angular velocity (omega) and acceleration (omega dot)
-    *
-    */
+/**
+ * \class  FixedContactEKFFlexEstimatorIMU
+ * \brief  This class implements the flexibility estimation of a robot with
+ *         the hypothesis that the contact positions do not move. This constraint
+ *         is expressed using fictious measurements but the interface is transparent
+ *         to this assumption, the state is expressed using classical representation
+ *         of position, velocity, acceleration, orientation (using (theta x mu) representation)
+ *         angular velocity (omega) and acceleration (omega dot)
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI FixedContactEKFFlexEstimatorIMU :
-                                            public EKFFlexibilityEstimatorBase,
-                                            private boost::noncopyable
-    {
-    public:
+class STATE_OBSERVATION_DLLAPI FixedContactEKFFlexEstimatorIMU : public EKFFlexibilityEstimatorBase,
+                                                                 private boost::noncopyable
+{
+public:
+  /// The constructor, it requires the value of the time discretization period
+  explicit FixedContactEKFFlexEstimatorIMU(double dt = 0.005);
 
-        ///The constructor, it requires the value of the time discretization period
-        explicit FixedContactEKFFlexEstimatorIMU( double dt=0.005 );
+  /// Virtual destructor
+  virtual ~FixedContactEKFFlexEstimatorIMU();
 
-        ///Virtual destructor
-        virtual ~FixedContactEKFFlexEstimatorIMU();
+  /// Sets the number of contacts can be changed online
+  void setContactsNumber(unsigned i);
 
-        ///Sets the number of contacts can be changed online
-        void setContactsNumber(unsigned i);
+  /// Sets the position of the i-th contact
+  void setContactPosition(unsigned i, Vector3 position);
 
-        ///Sets the position of the i-th contact
-        void setContactPosition(unsigned i, Vector3 position);
+  /// Sets the value of the next sensor measurement y_{k+1}
+  virtual void setMeasurement(const Vector & y);
 
-        /// Sets the value of the next sensor measurement y_{k+1}
-        virtual void setMeasurement(const Vector & y);
+  /// Sets the covariance of the fictious measurements (not mandatory)
+  virtual void setVirtualMeasurementsCovariance(double c_);
 
-        ///Sets the covariance of the fictious measurements (not mandatory)
-        virtual void setVirtualMeasurementsCovariance(double c_);
+  /// Sets the covariance of the fictious measurements (not mandatory)
+  virtual double getVirtualMeasurementsCovariance() const;
 
-        ///Sets the covariance of the fictious measurements (not mandatory)
-        virtual double getVirtualMeasurementsCovariance() const;
+  /// Sets the process covariance matrice
+  virtual void setProcessNoiseCovariance(const Matrix & Q);
 
-        ///Sets the process covariance matrice
-        virtual void setProcessNoiseCovariance(const Matrix & Q);
+  /// Sets the measurements covariance matrice
+  virtual void setMeasurementNoiseCovariance(const Matrix & R);
 
-        ///Sets the measurements covariance matrice
-        virtual void setMeasurementNoiseCovariance(const Matrix & R);
+  /// gets the covariance matrices for the process noises
+  virtual Matrix getProcessNoiseCovariance() const;
 
-        ///gets the covariance matrices for the process noises
-        virtual Matrix getProcessNoiseCovariance() const ;
+  /// gets the covariance matrices for the sensor noises
+  virtual Matrix getMeasurementNoiseCovariance() const;
 
-        ///gets the covariance matrices for the sensor noises
-        virtual Matrix getMeasurementNoiseCovariance() const ;
+  /// Sets a value of the flexibility x_k provided from another source
+  /// can be used for initialization of the estimator
+  virtual void setFlexibilityGuess(const Matrix & x);
 
-        ///Sets a value of the flexibility x_k provided from another source
-        /// can be used for initialization of the estimator
-        virtual void setFlexibilityGuess(const Matrix & x);
+  /// Gets an estimation of the flexibility in the form of a homogeneous matrix
+  virtual Matrix4 getFlexibility();
 
-        /// Gets an estimation of the flexibility in the form of a homogeneous matrix
-        virtual Matrix4 getFlexibility();
+  /// Gets an estimation of the flexibility in the form of a state vector \hat{x_{k+1}}
+  virtual const Vector & getFlexibilityVector();
 
-        /// Gets an estimation of the flexibility in the form of a state vector \hat{x_{k+1}}
-        virtual const Vector& getFlexibilityVector();
+  virtual Index getMeasurementSize() const;
 
+  virtual Index getStateSize() const;
 
-        virtual Index getMeasurementSize() const ;
+  virtual Index getInputSize() const;
 
-        virtual Index getStateSize() const ;
+  /// sets the sampling period
+  virtual void setSamplingPeriod(double);
 
-        virtual Index getInputSize() const ;
+  /// Resets the covariance matrices to their original values
+  virtual void resetCovarianceMatrices();
 
-        /// sets the sampling period
-        virtual void setSamplingPeriod(double);
+protected:
+  typedef kine::indexes<kine::rotationVector> indexes;
 
-        ///Resets the covariance matrices to their original values
-        virtual void resetCovarianceMatrices();
+  virtual void updateCovarianceMatrix_();
 
+  IMUFixedContactDynamicalSystem functor_;
 
-    protected:
+  double virtualMeasurementCovariance_;
 
-        typedef kine::indexes<kine::rotationVector> indexes;
+  Matrix R_, Q_;
 
-        virtual void updateCovarianceMatrix_();
+  static const Index stateSizeConst_ = 18;
+  static const Index measurementSizeConst_ = 6;
+  static const Index inputSizeConst_ = 15;
 
-        IMUFixedContactDynamicalSystem functor_;
+  double dt_; // sampling period
 
-        double virtualMeasurementCovariance_;
+private:
+};
 
-        Matrix R_,Q_;
-
-        static const Index stateSizeConst_=18;
-        static const Index measurementSizeConst_=6;
-        static const Index inputSizeConst_=15;
-
-        double dt_;//sampling period
-
-    private:
-    };
-
-}
-}
+} // namespace flexibilityEstimation
+} // namespace stateObservation
 #endif // FLEXBILITYESTMATOR_FIXEDCONTACTEKFFLEXIBILITYESTIMATOR_H

--- a/include/state-observation/flexibility-estimation/flexibility-estimator-base.hpp
+++ b/include/state-observation/flexibility-estimation/flexibility-estimator-base.hpp
@@ -19,39 +19,34 @@ namespace stateObservation
 {
 namespace flexibilityEstimation
 {
-    /**
-    * \class  FlexibilityEstimatorBase
-    * \brief  This class is the base class of the flexibility estimators.
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI FlexibilityEstimatorBase
-    {
-    public:
-        /// virtual destructor
-        virtual ~FlexibilityEstimatorBase(){}
+/**
+ * \class  FlexibilityEstimatorBase
+ * \brief  This class is the base class of the flexibility estimators.
+ *
+ */
+class STATE_OBSERVATION_DLLAPI FlexibilityEstimatorBase
+{
+public:
+  /// virtual destructor
+  virtual ~FlexibilityEstimatorBase() {}
 
-        ///The constructor
-        explicit FlexibilityEstimatorBase();
+  /// The constructor
+  explicit FlexibilityEstimatorBase();
 
-        ///Sets a value of the flexibility x_k provided from another source
-        /// can be used for initialization of the estimator
-        virtual void setFlexibilityGuess(const Matrix &)=0;
+  /// Sets a value of the flexibility x_k provided from another source
+  /// can be used for initialization of the estimator
+  virtual void setFlexibilityGuess(const Matrix &) = 0;
 
-        /// Sets the value of the next sensor measurement y_{k+1}
-        virtual void setMeasurement(const Vector &)=0;
+  /// Sets the value of the next sensor measurement y_{k+1}
+  virtual void setMeasurement(const Vector &) = 0;
 
-        /// Gets an estimation of the flexibility in the form of a homogeneous matrix
-        virtual Matrix4 getFlexibility()=0;
+  /// Gets an estimation of the flexibility in the form of a homogeneous matrix
+  virtual Matrix4 getFlexibility() = 0;
 
+protected:
+};
 
+} // namespace flexibilityEstimation
+} // namespace stateObservation
 
-    protected:
-
-
-
-    };
-
-} //namespace flexibilityEstimation
-}//namespace stateobservation
-
-#endif //FLEXIBILITY_ESTIMATION_FLEXIBILITY_ESTIMATOR_BASE_HPP
+#endif // FLEXIBILITY_ESTIMATION_FLEXIBILITY_ESTIMATOR_BASE_HPP

--- a/include/state-observation/flexibility-estimation/imu-elastic-local-frame-dynamical-system.hpp
+++ b/include/state-observation/flexibility-estimation/imu-elastic-local-frame-dynamical-system.hpp
@@ -8,538 +8,545 @@
 #ifndef DYNAMICAL_SYSTEM_HPP_
 #define DYNAMICAL_SYSTEM_HPP_
 
-
 #include <vector>
 
 #include <state-observation/api.h>
 #include <state-observation/dynamical-system/dynamical-system-functor-base.hpp>
 #include <state-observation/noise/noise-base.hpp>
 #include <state-observation/sensors-simulation/accelerometer-gyrometer.hpp>
-#include <state-observation/tools/rigid-body-kinematics.hpp>
 #include <state-observation/tools/hrp2.hpp>
+#include <state-observation/tools/rigid-body-kinematics.hpp>
 
 #include <Eigen/Cholesky>
-
 
 namespace stateObservation
 {
 
-  namespace flexibilityEstimation
+namespace flexibilityEstimation
+{
+
+/**
+ * \class  DynamicalSystem
+ * \brief  This class describes the dynamics of a robot's flexibility
+ *         this dynamics is the simplest possible system, the flexibility
+ *         is expressed as a rotation against the contact positions with no
+ *         other hypothesis than that the contact points are at constant position
+ *
+ */
+class STATE_OBSERVATION_DLLAPI IMUElasticLocalFrameDynamicalSystem : public stateObservation::DynamicalSystemFunctorBase
+{
+public:
+  struct input
+  {
+    /// indexes of the different components of a vector of the input state
+    static const unsigned posCom = 0;
+    static const unsigned velCom = 3;
+    static const unsigned accCom = 6;
+    static const unsigned inertia = 9;
+    static const unsigned angMoment = 15;
+    static const unsigned dotInertia = 18;
+    static const unsigned dotAngMoment = 24;
+    static const unsigned posIMU = 27;
+    static const unsigned oriIMU = 30;
+    static const unsigned linVelIMU = 33;
+    static const unsigned angVelIMU = 36;
+    static const unsigned linAccIMU = 39;
+    static const unsigned additionalForces = 42;
+    static const unsigned contacts = 48;
+
+    static const unsigned sizeBase = 48;
+  };
+
+  struct state
+  {
+    static const unsigned pos = 0;
+    static const unsigned ori = 3;
+    static const unsigned linVel = 6;
+    static const unsigned angVel = 9;
+    static const unsigned fc = 12;
+    static const unsigned unmodeledForces = 24;
+    static const unsigned comBias = 30;
+    static const unsigned drift = 32;
+
+    static const unsigned size = 35;
+  };
+
+  struct contactModel
+  {
+    /// indexes of the different components of a vector of the input state
+    static const unsigned elasticContact = 1;
+    static const unsigned pendulum = 2;
+    static const unsigned none = 0;
+  };
+
+  typedef Eigen::LLT<Matrix3> LLTMatrix3;
+
+  /// constructor
+  explicit IMUElasticLocalFrameDynamicalSystem(double dt);
+
+  /// virtual destructor
+  virtual ~IMUElasticLocalFrameDynamicalSystem();
+
+  void test();
+
+  // Get the contact wrench
+  void computeContactWrench(const Matrix3 & orientation,
+                            const Vector3 & position,
+                            const IndexedVectorArray & contactPosV,
+                            const IndexedVectorArray & contactOriV,
+                            const Vector & fc,
+                            const Vector & tc,
+                            const Vector3 & fm,
+                            const Vector3 & tm,
+                            const Vector3 & addForce,
+                            const Vector3 & addMoment);
+
+  stateObservation::Vector computeAccelerations(const Vector & x, const Vector & u);
+
+  // computation of the acceleration linear
+  virtual void computeAccelerations(const Vector3 & positionCom,
+                                    const Vector3 & velocityCom,
+                                    const Vector3 & accelerationCom,
+                                    const Vector3 & AngMomentum,
+                                    const Vector3 & dotAngMomentum,
+                                    const Matrix3 & Inertia,
+                                    const Matrix3 & dotInertia,
+                                    const IndexedVectorArray & contactPos,
+                                    const IndexedVectorArray & contactOri,
+                                    const Vector3 & position,
+                                    const Vector3 & linVelocity,
+                                    Vector3 & linearAcceleration,
+                                    const Vector3 & oriVector,
+                                    const Matrix3 & orientation,
+                                    const Vector3 & angularVel,
+                                    Vector3 & angularAcceleration,
+                                    const Vector & fc,
+                                    const Vector & tc,
+                                    const Vector3 & fm,
+                                    const Vector3 & tm,
+                                    const Vector3 & addForces,
+                                    const Vector3 & addMoments);
+
+  /// Description of the state dynamics
+  virtual stateObservation::Vector stateDynamics(const stateObservation::Vector & x,
+                                                 const stateObservation::Vector & u,
+                                                 TimeIndex k);
+
+  /// compute the jacobien of the state dynamics at the last computed value
+  stateObservation::Matrix stateDynamicsJacobian();
+
+  /// compute the jacobien of the state dynamics at a given state
+  stateObservation::Matrix stateDynamicsJacobian(const stateObservation::Vector & x,
+                                                 const stateObservation::Vector & u,
+                                                 TimeIndex k);
+
+  /// sets the finite differences derivation step vector
+  void setFDstep(const stateObservation::Vector & dx);
+
+  /// Description of the sensor's dynamics
+  virtual stateObservation::Vector measureDynamics(const stateObservation::Vector & x,
+                                                   const stateObservation::Vector & u,
+                                                   TimeIndex k);
+
+  /// compute the Jacobien of the measurements dynamics at the last computed value
+  stateObservation::Matrix measureDynamicsJacobian();
+
+  /// compute the Jacobien of the measurements dynamics at a given state value
+  stateObservation::Matrix measureDynamicsJacobian(const stateObservation::Vector & x,
+                                                   const stateObservation::Vector & u,
+                                                   TimeIndex k);
+
+  /// Sets a noise which disturbs the state dynamics
+  virtual void setProcessNoise(stateObservation::NoiseBase *);
+
+  /// Removes the process noise
+  virtual void resetProcessNoise();
+
+  /// Gets the process noise
+  virtual stateObservation::NoiseBase * getProcessNoise() const;
+
+  /// Sets a noise which disturbs the measurements
+  virtual void setMeasurementNoise(stateObservation::NoiseBase *);
+
+  /// Removes the measurement noise
+  virtual void resetMeasurementNoise();
+
+  /// Gets a pointer on the measurement noise
+  virtual stateObservation::NoiseBase * getMeasurementNoise() const;
+
+  /// Set the period of the time discretization
+  virtual void setSamplingPeriod(double dt);
+
+  /// Gets the state size
+  virtual Index getStateSize() const;
+
+  /// Gets the input size
+  virtual Index getInputSize() const;
+
+  /// Sets the input size
+  virtual void setInputSize(Index i);
+
+  /// Gets the contact number
+  /// virtual
+
+  /// Gets the contacts position
+
+  /// Gets the measurement size
+  virtual Index getMeasurementSize() const;
+
+  /// Sets the number of contacts
+  virtual void setContactsNumber(unsigned);
+
+  virtual void setPe(stateObservation::Vector3 Pe)
+  {
+    pe = Pe;
+  }
+
+  /// Gets the nimber of contacts
+  inline unsigned getContactsNumber(void) const
+  {
+    return nbContacts_;
+  }
+
+  virtual void setContactModel(unsigned nb);
+
+  virtual void setPrinted(bool b)
+  {
+    printed_ = b;
+  }
+
+  virtual void computeElastContactForcesAndMoments(const IndexedVectorArray & contactPosArray,
+                                                   const IndexedVectorArray & contactOriArray,
+                                                   const IndexedVectorArray & contactVelArray,
+                                                   const IndexedVectorArray & contactAngVelArray,
+                                                   const Vector3 & position,
+                                                   const Vector3 & linVelocity,
+                                                   const Vector3 & oriVector,
+                                                   const Matrix3 & orientation,
+                                                   const Vector3 & angVel,
+                                                   Vector & fc,
+                                                   Vector & tc);
+
+  virtual void computeElastPendulumForcesAndMoments(const IndexedVectorArray & PrArray,
+                                                    const Vector3 & position,
+                                                    const Vector3 & linVelocity,
+                                                    const Vector3 & oriVector,
+                                                    const Matrix3 & orientation,
+                                                    const Vector3 & angVel,
+                                                    Vector & forces,
+                                                    Vector & moments);
+
+  void computeForcesAndMoments(const IndexedVectorArray & position1,
+                               const IndexedVectorArray & position2,
+                               const IndexedVectorArray & velocity1,
+                               const IndexedVectorArray & velocity2,
+                               const Vector3 & position,
+                               const Vector3 & linVelocity,
+                               const Vector3 & oriVector,
+                               const Matrix3 & orientation,
+                               const Vector3 & angVel,
+                               Vector & fc,
+                               Vector & tc);
+
+  virtual void computeForcesAndMoments(const Vector & x, const Vector & u);
+
+  virtual Vector getForcesAndMoments();
+
+  virtual Vector getForcesAndMoments(const Vector & x, const Vector & u);
+
+  virtual Vector getMomentaDotFromForces(const Vector & x, const Vector & u);
+  virtual Vector getMomentaDotFromKinematics(const Vector & x, const Vector & u);
+
+  virtual void iterateDynamicsEuler(const Vector3 & positionCom,
+                                    const Vector3 & velocityCom,
+                                    const Vector3 & accelerationCom,
+                                    const Vector3 & AngMomentum,
+                                    const Vector3 & dotAngMomentum,
+                                    const Matrix3 & Inertia,
+                                    const Matrix3 & dotInertia,
+                                    const IndexedVectorArray & contactPos,
+                                    const IndexedVectorArray & contactOri,
+                                    Vector3 & position,
+                                    Vector3 & linVelocity,
+                                    Vector & fc1,
+                                    Vector3 & oriVector,
+                                    Vector3 & angularVel,
+                                    Vector & fc2,
+                                    const Vector3 & fm,
+                                    const Vector3 & tm,
+                                    const Vector3 & addForces,
+                                    const Vector3 & addMoments,
+                                    double dt);
+
+  virtual void iterateDynamicsRK4(const Vector3 & positionCom,
+                                  const Vector3 & velocityCom,
+                                  const Vector3 & accelerationCom,
+                                  const Vector3 & AngMomentum,
+                                  const Vector3 & dotAngMomentum,
+                                  const Matrix3 & Inertia,
+                                  const Matrix3 & dotInertia,
+                                  const IndexedVectorArray & contactPos,
+                                  const IndexedVectorArray & contactOri,
+                                  Vector3 & position,
+                                  Vector3 & linVelocity,
+                                  Vector & fc1,
+                                  Vector3 & oriVector,
+                                  Vector3 & angularVel,
+                                  Vector & fc2,
+                                  const Vector3 & fm,
+                                  const Vector3 & tm,
+                                  const Vector3 & addForces,
+                                  const Vector3 & addMoments,
+                                  double dt);
+
+  virtual void setWithForceMeasurements(bool b);
+  virtual bool getWithForceMeasurements() const;
+  virtual void setWithComBias(bool b);
+  virtual bool getWithComBias() const;
+  virtual void setWithAbsolutePosition(bool b);
+  virtual bool getWithAbsolutePosition() const;
+  void setWithUnmodeledForces(bool b);
+
+  virtual void setKfe(const Matrix3 & m);
+  virtual void setKfv(const Matrix3 & m);
+  virtual void setKte(const Matrix3 & m);
+  virtual void setKtv(const Matrix3 & m);
+
+  virtual void setKfeRopes(const Matrix3 & m);
+  virtual void setKfvRopes(const Matrix3 & m);
+  virtual void setKteRopes(const Matrix3 & m);
+  virtual void setKtvRopes(const Matrix3 & m);
+
+  virtual Matrix getKfe() const;
+  virtual Matrix getKfv() const;
+  virtual Matrix getKte() const;
+  virtual Matrix getKtv() const;
+
+  virtual void setRobotMass(double d);
+
+  virtual double getRobotMass() const;
+
+protected:
+  bool printed_;
+
+  stateObservation::AccelerometerGyrometer sensor_;
+
+  stateObservation::NoiseBase * processNoise_;
+
+  void updateMeasurementSize_();
+
+  double dt_;
+
+  double robotMass_;
+  double robotMassInv_;
+
+  Matrix3 & computeRotation_(const Vector3 & x, int i);
+
+  static const Index stateSize_ = state::size;
+  Index inputSize_;
+  static const Index measurementSizeBase_ = 6;
+  unsigned nbContacts_;
+  unsigned contactModel_;
+
+  Vector fc_;
+  Vector tc_;
+
+  Vector dx_;
+
+  Vector xk1_;
+  Vector xk_;
+  Vector uk_;
+
+  Vector xk_fory_;
+  Vector yk_;
+  Vector uk_fory_;
+
+  Index measurementSize_;
+
+  std::vector<Vector3, Eigen::aligned_allocator<Vector3>> contactPositions_;
+
+  Matrix3 Kfe_, Kte_, Kfv_, Ktv_;
+  Matrix3 KfeRopes_, KteRopes_, KfvRopes_, KtvRopes_;
+
+  TimeIndex kcurrent_;
+
+  bool withForceMeasurements_;
+  bool withComBias_;
+  bool withAbsolutePos_;
+  bool withUnmodeledForces_;
+
+  stateObservation::Vector3 pe;
+
+  double marginalStabilityFactor_;
+  // a scaling factor a=1-epsilon to avoid the natural marginal stability of
+  // the dynamics x_{k+1}=x_k we replace it with x_{k+1}=a*x_k
+
+  unsigned index_;
+
+  struct Optimization
   {
 
-    /**
-    * \class  DynamicalSystem
-    * \brief  This class describes the dynamics of a robot's flexibility
-    *         this dynamics is the simplest possible system, the flexibility
-    *         is expressed as a rotation against the contact positions with no
-    *         other hypothesis than that the contact points are at constant position
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI	IMUElasticLocalFrameDynamicalSystem :
-      public stateObservation::DynamicalSystemFunctorBase
+    Vector6 momentaDot;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    Vector3 positionFlex;
+    Vector3 velocityFlex;
+    Vector3 accelerationFlex;
+    Vector3 orientationFlexV;
+    Vector3 angularVelocityFlex;
+    Vector3 angularAccelerationFlex;
+    Vector3 positionComBias;
+
+    Matrix3 rFlex;
+    Matrix3 rFlexT;
+
+    Vector3 drift;
+    Vector3 pdrift;
+    Matrix3 rdrift;
+
+    double cy, sy;
+
+    AngleAxis orientationAA;
+
+    Vector xk1;
+    Vector xk;
+    Vector xk1dx;
+
+    Vector xdx;
+
+    Vector xk_fory;
+    Vector yk;
+    Vector ykdy;
+
+    TimeIndex k_fory;
+
+    Matrix3 orinertia;
+
+    LLTMatrix3 invinertia;
+
+    Matrix3 rtotal;
+    Vector3 ptotal;
+    AngleAxis aatotal;
+    Vector3 oritotal;
+
+    Matrix Jx;
+    Matrix Jy;
+
+    Matrix3 rimu;
+    Vector3 imuAcc;
+    Vector3 imuOmega;
+    Vector sensorState;
+
+    Vector3 positionCom;
+    Vector3 velocityCom;
+    Vector3 accelerationCom;
+    Vector3 AngMomentum;
+    Vector3 dotAngMomentum;
+
+    Vector3 positionControl;
+    Vector3 velocityControl;
+    Vector3 accelerationControl;
+    Vector3 orientationControlV;
+    Vector3 angularVelocityControl;
+
+    Matrix3 rControl;
+
+    IndexedVectorArray contactPosV;
+    IndexedVectorArray contactOriV;
+    IndexedVectorArray contactVelArray;
+    IndexedVectorArray contactAngVelArray;
+
+    Matrix3 inertia;
+    Matrix3 dotInertia;
+
+    IndexedVectorArray efforts;
+
+    Vector3 f, fi;
+    Vector3 t;
+
+    // unmodelled and unmeasured forces
+    Vector3 fm;
+    Vector3 tm;
+
+    Vector3 linearAcceleration;
+    Vector3 angularAcceleration;
+
+    Vector3 vf;
+    Vector3 vt;
+
+    Vector3 crosstempV;
+    Matrix3 crosstempM;
+
+    // elastic contact forces and moments
+    Matrix3 Rci; // rotation of contact i
+    Matrix3 Rcit; // transpose of previous
+    Vector3 contactPos; //
+    Vector3 contactVel;
+    Vector3 RciContactPos;
+    Vector3 globalContactPos;
+    Matrix3 Rt;
+
+    Vector3 forcei;
+    Vector3 momenti;
+
+    // additional forces and moments
+    Vector3 addForce;
+    Vector3 addMoment;
+
+    Matrix3 skewV;
+    Matrix3 skewV2;
+    Matrix3 skewVR;
+    Matrix3 skewV2R;
+    Matrix3 RIRT;
+    Vector3 wx2Rc;
+    Vector3 _2wxRv;
+    Vector3 Ra;
+    Vector3 Rc;
+    Vector3 Rcp;
+
+    // optimization of orientation transformation between vector3 to rotation matrix
+
+    Matrix3 curRotation0;
+    Vector3 orientationVector0;
+    Matrix3 curRotation1;
+    Vector3 orientationVector1;
+    Matrix3 curRotation2;
+    Vector3 orientationVector2;
+    Matrix3 curRotation3;
+    Vector3 orientationVector3;
+
+    Optimization()
+    : curRotation0(Matrix3::Identity()), orientationVector0(Vector3::Zero()), curRotation1(Matrix3::Identity()),
+      orientationVector1(Vector3::Zero()), curRotation2(Matrix3::Identity()), orientationVector2(Vector3::Zero()),
+      curRotation3(Matrix3::Identity()), orientationVector3(Vector3::Zero())
     {
-    public:
-      struct input
-      {
-        ///indexes of the different components of a vector of the input state
-        static const unsigned posCom = 0;
-        static const unsigned velCom = 3;
-        static const unsigned accCom = 6;
-        static const unsigned inertia = 9;
-        static const unsigned angMoment = 15;
-        static const unsigned dotInertia = 18;
-        static const unsigned dotAngMoment = 24;
-        static const unsigned posIMU = 27;
-        static const unsigned oriIMU = 30;
-        static const unsigned linVelIMU = 33;
-        static const unsigned angVelIMU = 36;
-        static const unsigned linAccIMU = 39;
-        static const unsigned additionalForces = 42;
-        static const unsigned contacts = 48;
-
-        static const unsigned sizeBase = 48;
-      };
-
-      struct state
-      {
-        static const unsigned pos = 0;
-        static const unsigned ori = 3;
-        static const unsigned linVel = 6;
-        static const unsigned angVel = 9;
-        static const unsigned fc = 12;
-        static const unsigned unmodeledForces = 24;
-        static const unsigned comBias = 30;
-        static const unsigned drift = 32;
-
-        static const unsigned size =35;
-      };
-
-
-      struct contactModel
-      {
-        ///indexes of the different components of a vector of the input state
-        static const unsigned elasticContact= 1;
-        static const unsigned pendulum= 2;
-        static const unsigned none= 0;
-
-      };
-
-
-      typedef Eigen::LLT<Matrix3> LLTMatrix3;
-
-      ///constructor
-      explicit IMUElasticLocalFrameDynamicalSystem(double dt);
-
-      ///virtual destructor
-      virtual ~IMUElasticLocalFrameDynamicalSystem();
-
-      void test();
-
-      // Get the contact wrench
-      void computeContactWrench
-              (const Matrix3& orientation, const Vector3& position,
-               const IndexedVectorArray& contactPosV, const IndexedVectorArray& contactOriV,
-               const Vector& fc, const Vector& tc, const Vector3 & fm, const Vector3& tm,
-               const Vector3& addForce, const Vector3 & addMoment);
-
-      stateObservation::Vector computeAccelerations(const Vector& x,const Vector& u);
-
-      // computation of the acceleration linear
-      virtual void computeAccelerations
-      (const Vector3& positionCom, const Vector3& velocityCom,
-       const Vector3& accelerationCom, const Vector3& AngMomentum,
-       const Vector3& dotAngMomentum,
-       const Matrix3& Inertia, const Matrix3& dotInertia,
-       const IndexedVectorArray& contactPos,
-       const IndexedVectorArray& contactOri,
-       const Vector3& position, const Vector3& linVelocity,
-       Vector3& linearAcceleration,  const Vector3& oriVector ,
-       const Matrix3& orientation, const Vector3& angularVel,
-       Vector3& angularAcceleration,
-       const Vector& fc, const Vector& tc,
-       const Vector3 & fm, const Vector3& tm,
-       const Vector3 & addForces, const Vector3& addMoments);
-
-      ///Description of the state dynamics
-      virtual stateObservation::Vector stateDynamics
-      (const stateObservation::Vector& x, const stateObservation::Vector& u,
-       TimeIndex k);
-
-      ///compute the jacobien of the state dynamics at the last computed value
-      stateObservation::Matrix stateDynamicsJacobian();
-
-      ///compute the jacobien of the state dynamics at a given state
-      stateObservation::Matrix stateDynamicsJacobian(const stateObservation::Vector& x, const stateObservation::Vector& u,
-       TimeIndex k);
-
-      ///sets the finite differences derivation step vector
-      void setFDstep(const stateObservation::Vector & dx);
-
-
-      ///Description of the sensor's dynamics
-      virtual stateObservation::Vector measureDynamics
-      (const stateObservation::Vector& x, const stateObservation::Vector& u,
-       TimeIndex k);
-
-      ///compute the Jacobien of the measurements dynamics at the last computed value
-      stateObservation::Matrix measureDynamicsJacobian();
-
-      ///compute the Jacobien of the measurements dynamics at a given state value
-      stateObservation::Matrix measureDynamicsJacobian(const stateObservation::Vector& x, const stateObservation::Vector& u,
-       TimeIndex k);
-
-      ///Sets a noise which disturbs the state dynamics
-      virtual void setProcessNoise( stateObservation::NoiseBase * );
-
-      ///Removes the process noise
-      virtual void resetProcessNoise();
-
-      ///Gets the process noise
-      virtual stateObservation::NoiseBase * getProcessNoise() const;
-
-      ///Sets a noise which disturbs the measurements
-      virtual void setMeasurementNoise( stateObservation::NoiseBase * );
-
-      ///Removes the measurement noise
-      virtual void resetMeasurementNoise();
-
-      ///Gets a pointer on the measurement noise
-      virtual stateObservation::NoiseBase * getMeasurementNoise() const;
-
-      ///Set the period of the time discretization
-      virtual void setSamplingPeriod(double dt);
-
-      ///Gets the state size
-      virtual Index getStateSize() const;
-
-      ///Gets the input size
-      virtual Index getInputSize() const;
-
-      ///Sets the input size
-      virtual void setInputSize(Index i);
-
-      ///Gets the contact number
-      ///virtual
-
-      ///Gets the contacts position
-
-      ///Gets the measurement size
-      virtual Index getMeasurementSize() const;
-
-      ///Sets the number of contacts
-      virtual void setContactsNumber(unsigned);
-
-      virtual void setPe(stateObservation::Vector3 Pe)
-      {
-          pe=Pe;
-      }
-
-      ///Gets the nimber of contacts
-      inline unsigned getContactsNumber(void) const
-      {
-         return  nbContacts_;
-      }
-
-      virtual void setContactModel(unsigned nb);
-
-      virtual void setPrinted(bool b)
-      {
-          printed_ = b;
-      }
-
-      virtual void computeElastContactForcesAndMoments
-      (const IndexedVectorArray& contactPosArray,
-       const IndexedVectorArray& contactOriArray,
-       const IndexedVectorArray& contactVelArray,
-       const IndexedVectorArray& contactAngVelArray,
-       const Vector3& position, const Vector3& linVelocity,
-       const Vector3& oriVector, const Matrix3& orientation,
-       const Vector3& angVel,
-       Vector& fc, Vector& tc);
-
-      virtual void computeElastPendulumForcesAndMoments
-      (const IndexedVectorArray& PrArray,
-       const Vector3& position, const Vector3& linVelocity,
-       const Vector3& oriVector, const Matrix3& orientation,
-       const Vector3& angVel,
-       Vector& forces, Vector& moments);
-
-      void computeForcesAndMoments
-      (const IndexedVectorArray& position1,
-       const IndexedVectorArray& position2,
-       const IndexedVectorArray& velocity1,
-       const IndexedVectorArray& velocity2,
-       const Vector3& position, const Vector3& linVelocity,
-       const Vector3& oriVector, const Matrix3& orientation,
-       const Vector3& angVel,
-       Vector& fc, Vector& tc);
-
-      virtual void computeForcesAndMoments
-      (const Vector& x,
-       const Vector& u);
-
-
-      virtual Vector getForcesAndMoments();
-
-      virtual Vector getForcesAndMoments (const Vector& x,
-       const Vector& u);
-
-      virtual Vector getMomentaDotFromForces(const Vector& x, const Vector& u);
-      virtual Vector getMomentaDotFromKinematics(const Vector& x, const Vector& u);
-
-      virtual void iterateDynamicsEuler
-      (const Vector3& positionCom, const Vector3& velocityCom,
-       const Vector3& accelerationCom, const Vector3& AngMomentum,
-       const Vector3& dotAngMomentum,
-       const Matrix3& Inertia, const Matrix3& dotInertia,
-       const IndexedVectorArray& contactPos,
-       const IndexedVectorArray& contactOri,
-       Vector3& position, Vector3& linVelocity, Vector& fc1,
-       Vector3 &oriVector, Vector3& angularVel, Vector& fc2,
-       const Vector3 & fm, const Vector3& tm,
-       const Vector3 & addForces, const Vector3& addMoments,
-       double dt
-      );
-
-      virtual void iterateDynamicsRK4
-      (const Vector3& positionCom, const Vector3& velocityCom,
-       const Vector3& accelerationCom, const Vector3& AngMomentum,
-       const Vector3& dotAngMomentum,
-       const Matrix3& Inertia, const Matrix3& dotInertia,
-       const IndexedVectorArray& contactPos,
-       const IndexedVectorArray& contactOri,
-       Vector3& position, Vector3& linVelocity, Vector& fc1,
-       Vector3 &oriVector, Vector3& angularVel, Vector& fc2,
-       const Vector3 & fm, const Vector3& tm,
-       const Vector3 & addForces, const Vector3& addMoments,
-       double dt
-      );
-
-      virtual void setWithForceMeasurements(bool b);
-      virtual bool getWithForceMeasurements() const;
-      virtual void setWithComBias(bool b);
-      virtual bool getWithComBias() const;
-      virtual void setWithAbsolutePosition(bool b);
-      virtual bool getWithAbsolutePosition() const;
-      void setWithUnmodeledForces(bool b);
-
-
-      virtual void setKfe(const Matrix3 & m);
-      virtual void setKfv(const Matrix3 & m);
-      virtual void setKte(const Matrix3 & m);
-      virtual void setKtv(const Matrix3 & m);
-
-      virtual void setKfeRopes(const Matrix3 & m);
-      virtual void setKfvRopes(const Matrix3 & m);
-      virtual void setKteRopes(const Matrix3 & m);
-      virtual void setKtvRopes(const Matrix3 & m);
-
-      virtual Matrix getKfe() const;
-      virtual Matrix getKfv() const;
-      virtual Matrix getKte() const;
-      virtual Matrix getKtv() const;
-
-      virtual void setRobotMass(double d);
-
-      virtual double getRobotMass() const;
-
-    protected:
-
-      bool printed_;
-
-      stateObservation::AccelerometerGyrometer sensor_;
-
-      stateObservation::NoiseBase * processNoise_;
-
-      void updateMeasurementSize_();
-
-      double dt_;
-
-      double robotMass_;
-      double robotMassInv_;
-
-      Matrix3& computeRotation_(const Vector3 & x, int i);
-
-      static const Index stateSize_=state::size;
-      Index inputSize_;
-      static const Index measurementSizeBase_=6;
-      unsigned nbContacts_;
-      unsigned contactModel_;
-
-      Vector fc_;
-      Vector tc_;
-
-      Vector dx_;
-
-      Vector xk1_;
-      Vector xk_;
-      Vector uk_;
-
-      Vector xk_fory_;
-      Vector yk_;
-      Vector uk_fory_;
-
-
-      Index measurementSize_;
-
-      std::vector <Vector3,Eigen::aligned_allocator<Vector3> > contactPositions_;
-
-      Matrix3 Kfe_, Kte_, Kfv_, Ktv_;
-      Matrix3 KfeRopes_, KteRopes_, KfvRopes_, KtvRopes_;
-
-      TimeIndex kcurrent_;
-
-      bool withForceMeasurements_;
-      bool withComBias_;
-      bool withAbsolutePos_;
-      bool withUnmodeledForces_;
-
-      stateObservation::Vector3 pe;
-
-      double marginalStabilityFactor_;
-      //a scaling factor a=1-epsilon to avoid the natural marginal stability of
-      //the dynamics x_{k+1}=x_k we replace it with x_{k+1}=a*x_k
-
-      unsigned index_;
-
-      struct Optimization
-      {
-
-        Vector6 momentaDot;
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-        Vector3 positionFlex;
-        Vector3 velocityFlex;
-        Vector3 accelerationFlex;
-        Vector3 orientationFlexV;
-        Vector3 angularVelocityFlex;
-        Vector3 angularAccelerationFlex;
-        Vector3 positionComBias;
-
-        Matrix3 rFlex;
-        Matrix3 rFlexT;
-
-        Vector3 drift;
-        Vector3 pdrift;
-        Matrix3 rdrift;
-
-        double cy,sy;
-
-        AngleAxis orientationAA;
-
-        Vector xk1;
-        Vector xk;
-        Vector xk1dx;
-
-        Vector xdx;
-
-        Vector xk_fory;
-        Vector yk;
-        Vector ykdy;
-
-        TimeIndex k_fory;
-
-        Matrix3 orinertia;
-
-        LLTMatrix3 invinertia;
-
-        Matrix3 rtotal;
-        Vector3 ptotal;
-        AngleAxis aatotal;
-        Vector3 oritotal;
-
-        Matrix Jx;
-        Matrix Jy;
-
-        Matrix3 rimu;
-        Vector3 imuAcc;
-        Vector3 imuOmega;
-        Vector sensorState;
-
-        Vector3 positionCom;
-        Vector3 velocityCom;
-        Vector3 accelerationCom;
-        Vector3 AngMomentum;
-        Vector3 dotAngMomentum;
-
-        Vector3 positionControl;
-        Vector3 velocityControl;
-        Vector3 accelerationControl;
-        Vector3 orientationControlV;
-        Vector3 angularVelocityControl;
-
-        Matrix3 rControl;
-
-        IndexedVectorArray contactPosV;
-        IndexedVectorArray contactOriV;
-        IndexedVectorArray contactVelArray;
-        IndexedVectorArray contactAngVelArray;
-
-        Matrix3 inertia;
-        Matrix3 dotInertia;
-
-        IndexedVectorArray efforts;
-
-        Vector3 f, fi;
-        Vector3 t;
-
-        //unmodelled and unmeasured forces
-        Vector3 fm;
-        Vector3 tm;
-
-        Vector3 linearAcceleration;
-        Vector3 angularAcceleration;
-
-        Vector3 vf;
-        Vector3 vt;
-
-        Vector3 crosstempV;
-        Matrix3 crosstempM;
-
-        //elastic contact forces and moments
-        Matrix3 Rci; //rotation of contact i
-        Matrix3 Rcit;//transpose of previous
-        Vector3 contactPos; //
-        Vector3 contactVel;
-        Vector3 RciContactPos;
-        Vector3 globalContactPos;
-        Matrix3 Rt;
-
-        Vector3 forcei;
-        Vector3 momenti;
-
-        //additional forces and moments
-        Vector3 addForce;
-        Vector3 addMoment;
-
-        Matrix3 skewV;
-        Matrix3 skewV2;
-        Matrix3 skewVR;
-        Matrix3 skewV2R;
-        Matrix3 RIRT;
-        Vector3 wx2Rc;
-        Vector3 _2wxRv;
-        Vector3 Ra;
-        Vector3 Rc;
-        Vector3 Rcp;
-
-        //optimization of orientation transformation between vector3 to rotation matrix
-
-        Matrix3 curRotation0;
-        Vector3 orientationVector0;
-        Matrix3 curRotation1;
-        Vector3 orientationVector1;
-        Matrix3 curRotation2;
-        Vector3 orientationVector2;
-        Matrix3 curRotation3;
-        Vector3 orientationVector3;
-
-        Optimization()
-          :
-          curRotation0(Matrix3::Identity()),
-          orientationVector0(Vector3::Zero()),
-          curRotation1(Matrix3::Identity()),
-          orientationVector1(Vector3::Zero()),
-          curRotation2(Matrix3::Identity()),
-          orientationVector2(Vector3::Zero()),
-          curRotation3(Matrix3::Identity()),
-          orientationVector3(Vector3::Zero())
-        {}
-
-        inline Vector3& orientationVector(int i)
-        {
-          if (i==0)
-            return orientationVector0;
-          if (i==1)
-            return orientationVector1;
-          if (i==2)
-            return orientationVector2;
-
-          return orientationVector3;
-        }
-
-        inline Matrix3& curRotation(int i)
-        {
-          if (i==0)
-            return curRotation0;
-          if (i==1)
-            return curRotation1;
-          if (i==2)
-            return curRotation2;
-
-          return curRotation3;
-        }
-
-      } op_;
-
-    public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-    };
-  }
-}
-
-
+    }
+
+    inline Vector3 & orientationVector(int i)
+    {
+      if(i == 0) return orientationVector0;
+      if(i == 1) return orientationVector1;
+      if(i == 2) return orientationVector2;
+
+      return orientationVector3;
+    }
+
+    inline Matrix3 & curRotation(int i)
+    {
+      if(i == 0) return curRotation0;
+      if(i == 1) return curRotation1;
+      if(i == 2) return curRotation2;
+
+      return curRotation3;
+    }
+
+  } op_;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+} // namespace flexibilityEstimation
+} // namespace stateObservation
 
 #endif /* DYNAMICAL_SYSTEM_HPP_ */

--- a/include/state-observation/flexibility-estimation/imu-fixed-contact-dynamical-system.hpp
+++ b/include/state-observation/flexibility-estimation/imu-fixed-contact-dynamical-system.hpp
@@ -24,97 +24,93 @@ namespace stateObservation
 {
 namespace flexibilityEstimation
 {
-    /**
-    * \class  IMUFixedContactDynamicalSystem
-    * \brief  This class describes the dynamics of a robot's flexibility
-    *         this dynamics is the simplest possible system, the flexibility
-    *         is expressed as a rotation against the contact positions with no
-    *         other hypothesis than that the contact points are at constant position
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI IMUFixedContactDynamicalSystem :
-        public stateObservation::DynamicalSystemFunctorBase
-    {
-    public:
-        ///constructor
-        explicit IMUFixedContactDynamicalSystem(double dt);
+/**
+ * \class  IMUFixedContactDynamicalSystem
+ * \brief  This class describes the dynamics of a robot's flexibility
+ *         this dynamics is the simplest possible system, the flexibility
+ *         is expressed as a rotation against the contact positions with no
+ *         other hypothesis than that the contact points are at constant position
+ *
+ */
+class STATE_OBSERVATION_DLLAPI IMUFixedContactDynamicalSystem : public stateObservation::DynamicalSystemFunctorBase
+{
+public:
+  /// constructor
+  explicit IMUFixedContactDynamicalSystem(double dt);
 
-        ///virtual destructor
-        virtual ~IMUFixedContactDynamicalSystem();
+  /// virtual destructor
+  virtual ~IMUFixedContactDynamicalSystem();
 
-        ///Description of the state dynamics
-        virtual stateObservation::Vector stateDynamics
-        (const stateObservation::Vector& x, const stateObservation::Vector& u,
-            TimeIndex k);
+  /// Description of the state dynamics
+  virtual stateObservation::Vector stateDynamics(const stateObservation::Vector & x,
+                                                 const stateObservation::Vector & u,
+                                                 TimeIndex k);
 
-        ///Description of the sensor's dynamics
-        virtual stateObservation::Vector measureDynamics
-        (const stateObservation::Vector& x, const stateObservation::Vector& u,
-            TimeIndex k);
+  /// Description of the sensor's dynamics
+  virtual stateObservation::Vector measureDynamics(const stateObservation::Vector & x,
+                                                   const stateObservation::Vector & u,
+                                                   TimeIndex k);
 
-        ///Sets a noise which disturbs the state dynamics
-        virtual void setProcessNoise( stateObservation::NoiseBase * );
+  /// Sets a noise which disturbs the state dynamics
+  virtual void setProcessNoise(stateObservation::NoiseBase *);
 
-        ///Removes the process noise
-        virtual void resetProcessNoise();
+  /// Removes the process noise
+  virtual void resetProcessNoise();
 
-        ///Gets the process noise
-        virtual stateObservation::NoiseBase * getProcessNoise() const;
+  /// Gets the process noise
+  virtual stateObservation::NoiseBase * getProcessNoise() const;
 
-        ///Sets a noise which disturbs the measurements
-        virtual void setMeasurementNoise( stateObservation::NoiseBase * );
+  /// Sets a noise which disturbs the measurements
+  virtual void setMeasurementNoise(stateObservation::NoiseBase *);
 
-        ///Removes the measurement noise
-        virtual void resetMeasurementNoise();
+  /// Removes the measurement noise
+  virtual void resetMeasurementNoise();
 
-        ///Gets a pointer on the measurement noise
-        virtual stateObservation::NoiseBase * getMeasurementNoise() const;
+  /// Gets a pointer on the measurement noise
+  virtual stateObservation::NoiseBase * getMeasurementNoise() const;
 
-        ///Set the period of the time discretization
-        virtual void setSamplingPeriod(double dt);
+  /// Set the period of the time discretization
+  virtual void setSamplingPeriod(double dt);
 
-        ///Gets the state size
-        virtual Index getStateSize() const;
-        ///Gets the input size
-        virtual Index getInputSize() const;
-        ///Gets the measurement size
-        virtual Index getMeasurementSize() const;
+  /// Gets the state size
+  virtual Index getStateSize() const;
+  /// Gets the input size
+  virtual Index getInputSize() const;
+  /// Gets the measurement size
+  virtual Index getMeasurementSize() const;
 
-        ///Sets the number of contacts
-        virtual void setContactsNumber(unsigned);
+  /// Sets the number of contacts
+  virtual void setContactsNumber(unsigned);
 
-        ///Sets the position of the contact number i
-        virtual void setContactPosition(unsigned i, const Vector3 & position);
+  /// Sets the position of the contact number i
+  virtual void setContactPosition(unsigned i, const Vector3 & position);
 
-    protected:
+protected:
+  typedef kine::indexes<kine::rotationVector> indexes;
 
-        typedef kine::indexes<kine::rotationVector> indexes;
+  stateObservation::AccelerometerGyrometer sensor_;
 
-        stateObservation::AccelerometerGyrometer sensor_;
+  stateObservation::NoiseBase * processNoise_;
 
-        stateObservation::NoiseBase * processNoise_;
+  double dt_;
 
-        double dt_;
+  Vector3Unaligned orientationVector_;
+  QuaternionUnaligned quaternion_;
 
-        Vector3Unaligned orientationVector_;
-        QuaternionUnaligned quaternion_;
+  Quaternion computeQuaternion_(const Vector3 & x);
 
-        Quaternion computeQuaternion_(const Vector3 & x);
+  static const Index stateSize_ = 18;
+  static const Index inputSize_ = 15;
+  static const Index measurementSizeBase_ = 6;
 
-        static const Index stateSize_=18;
-        static const Index inputSize_=15;
-        static const Index measurementSizeBase_=6;
+  Index measurementSize_;
 
-        Index measurementSize_;
+  std::vector<Vector3, Eigen::aligned_allocator<Vector3>> contactPositions_;
 
-        std::vector <Vector3,Eigen::aligned_allocator<Vector3> >
-            contactPositions_;
-
-    private:
-
-    public:
-    };
-}
-}
+private:
+public:
+};
+} // namespace flexibilityEstimation
+} // namespace stateObservation
 
 #endif // FIXED-CONTACTS-IMU-DYNAMICS-FUNCTOR_HPP

--- a/include/state-observation/flexibility-estimation/stable-imu-fixed-contact-dynamical-system.hpp
+++ b/include/state-observation/flexibility-estimation/stable-imu-fixed-contact-dynamical-system.hpp
@@ -24,105 +24,100 @@ namespace stateObservation
 {
 namespace flexibilityEstimation
 {
-    /**
-    * \class  IMUFixedContactDynamicalSystem
-    * \brief  This class describes the dynamics of a robot's flexibility
-    *         this dynamics is the simplest possible system, the flexibility
-    *         is expressed as a rotation against the contact positions with no
-    *         other hypothesis than that the contact points are at constant position
-    *
-    */
-    class STATE_OBSERVATION_DLLAPI StableIMUFixedContactDynamicalSystem :
-        public stateObservation::DynamicalSystemFunctorBase
-    {
-    public:
-        ///constructor
-        explicit StableIMUFixedContactDynamicalSystem(double dt);
+/**
+ * \class  IMUFixedContactDynamicalSystem
+ * \brief  This class describes the dynamics of a robot's flexibility
+ *         this dynamics is the simplest possible system, the flexibility
+ *         is expressed as a rotation against the contact positions with no
+ *         other hypothesis than that the contact points are at constant position
+ *
+ */
+class STATE_OBSERVATION_DLLAPI StableIMUFixedContactDynamicalSystem
+: public stateObservation::DynamicalSystemFunctorBase
+{
+public:
+  /// constructor
+  explicit StableIMUFixedContactDynamicalSystem(double dt);
 
-        ///virtual destructor
-        virtual ~StableIMUFixedContactDynamicalSystem();
+  /// virtual destructor
+  virtual ~StableIMUFixedContactDynamicalSystem();
 
-        // stabilization of the acceleration linear
-        virtual Vector3 stabilizeAccelerationLinear
-    	(Vector3 , Vector3);
+  // stabilization of the acceleration linear
+  virtual Vector3 stabilizeAccelerationLinear(Vector3, Vector3);
 
-        // stabilization of the acceleration angular
-        virtual Vector3 stabilizeAccelerationAngular
-        (Vector3 , Vector3);
+  // stabilization of the acceleration angular
+  virtual Vector3 stabilizeAccelerationAngular(Vector3, Vector3);
 
-        ///Description of the state dynamics
-        virtual stateObservation::Vector stateDynamics
-        (const stateObservation::Vector& x, const stateObservation::Vector& u,
-            TimeIndex k);
+  /// Description of the state dynamics
+  virtual stateObservation::Vector stateDynamics(const stateObservation::Vector & x,
+                                                 const stateObservation::Vector & u,
+                                                 TimeIndex k);
 
-        ///Description of the sensor's dynamics
-        virtual stateObservation::Vector measureDynamics
-        (const stateObservation::Vector& x, const stateObservation::Vector& u,
-            TimeIndex k);
+  /// Description of the sensor's dynamics
+  virtual stateObservation::Vector measureDynamics(const stateObservation::Vector & x,
+                                                   const stateObservation::Vector & u,
+                                                   TimeIndex k);
 
-        ///Sets a noise which disturbs the state dynamics
-        virtual void setProcessNoise( stateObservation::NoiseBase * );
+  /// Sets a noise which disturbs the state dynamics
+  virtual void setProcessNoise(stateObservation::NoiseBase *);
 
-        ///Removes the process noise
-        virtual void resetProcessNoise();
+  /// Removes the process noise
+  virtual void resetProcessNoise();
 
-        ///Gets the process noise
-        virtual stateObservation::NoiseBase * getProcessNoise() const;
+  /// Gets the process noise
+  virtual stateObservation::NoiseBase * getProcessNoise() const;
 
-        ///Sets a noise which disturbs the measurements
-        virtual void setMeasurementNoise( stateObservation::NoiseBase * );
+  /// Sets a noise which disturbs the measurements
+  virtual void setMeasurementNoise(stateObservation::NoiseBase *);
 
-        ///Removes the measurement noise
-        virtual void resetMeasurementNoise();
+  /// Removes the measurement noise
+  virtual void resetMeasurementNoise();
 
-        ///Gets a pointer on the measurement noise
-        virtual stateObservation::NoiseBase * getMeasurementNoise() const;
+  /// Gets a pointer on the measurement noise
+  virtual stateObservation::NoiseBase * getMeasurementNoise() const;
 
-        ///Set the period of the time discretization
-        virtual void setSamplingPeriod(double dt);
+  /// Set the period of the time discretization
+  virtual void setSamplingPeriod(double dt);
 
-        ///Gets the state size
-        virtual Index getStateSize() const;
-        ///Gets the input size
-        virtual Index getInputSize() const;
-        ///Gets the measurement size
-        virtual Index getMeasurementSize() const;
+  /// Gets the state size
+  virtual Index getStateSize() const;
+  /// Gets the input size
+  virtual Index getInputSize() const;
+  /// Gets the measurement size
+  virtual Index getMeasurementSize() const;
 
-        ///Sets the number of contacts
-        virtual void setContactsNumber(unsigned);
+  /// Sets the number of contacts
+  virtual void setContactsNumber(unsigned);
 
-        ///Sets the position of the contact number i
-        virtual void setContactPosition(unsigned i, const Vector3 & position);
+  /// Sets the position of the contact number i
+  virtual void setContactPosition(unsigned i, const Vector3 & position);
 
-    protected:
+protected:
+  typedef kine::indexes<kine::rotationVector> indexes;
 
-        typedef kine::indexes<kine::rotationVector> indexes;
+  stateObservation::AccelerometerGyrometer sensor_;
 
-        stateObservation::AccelerometerGyrometer sensor_;
+  stateObservation::NoiseBase * processNoise_;
 
-        stateObservation::NoiseBase * processNoise_;
+  double dt_;
 
-        double dt_;
+  Vector3Unaligned orientationVector_;
+  QuaternionUnaligned quaternion_;
 
-        Vector3Unaligned orientationVector_;
-        QuaternionUnaligned quaternion_;
+  Quaternion computeQuaternion_(const Vector3 & x);
 
-        Quaternion computeQuaternion_(const Vector3 & x);
+  static const Index stateSize_ = 18;
+  static const Index inputSize_ = 15;
+  static const Index measurementSizeBase_ = 6;
 
-        static const Index stateSize_=18;
-        static const Index inputSize_=15;
-        static const Index measurementSizeBase_=6;
+  Index measurementSize_;
 
-        Index measurementSize_;
+  std::vector<Vector3, Eigen::aligned_allocator<Vector3>> contactPositions_;
 
-        std::vector <Vector3,Eigen::aligned_allocator<Vector3> >
-            contactPositions_;
-
-    private:
-
-    public:
-    };
-}
-}
+private:
+public:
+};
+} // namespace flexibilityEstimation
+} // namespace stateObservation
 
 #endif // FIXED-CONTACTS-IMU-DYNAMICS-FUNCTOR_HPP

--- a/include/state-observation/noise/gaussian-white-noise.hpp
+++ b/include/state-observation/noise/gaussian-white-noise.hpp
@@ -17,75 +17,69 @@
 namespace stateObservation
 {
 
-    /**
-     * \class  GaussienWhiteNoise
-     * \brief The class derivates the NoiseBase class to implement a gaussian
-     *          white noise with a given covariance matrix, and bias
-     *
-     * \details
-     *
-     */
+/**
+ * \class  GaussienWhiteNoise
+ * \brief The class derivates the NoiseBase class to implement a gaussian
+ *          white noise with a given covariance matrix, and bias
+ *
+ * \details
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI GaussianWhiteNoise : public NoiseBase
-    {
-    public:
+class STATE_OBSERVATION_DLLAPI GaussianWhiteNoise : public NoiseBase
+{
+public:
+  /// Virtual destructor
+  virtual ~GaussianWhiteNoise() {}
 
-        ///Virtual destructor
-        virtual ~GaussianWhiteNoise(){}
+  /// The constructor that provides the dimension of the noise vector
+  GaussianWhiteNoise(Index dimension);
 
-        ///The constructor that provides the dimension of the noise vector
-        GaussianWhiteNoise(Index dimension);
+  /// The default constructor
+  GaussianWhiteNoise();
 
-        ///The default constructor
-        GaussianWhiteNoise();
+  /// get the noisy version of a given vector it is only an addition of a given vector
+  /// and a gaussian white noise
+  virtual Vector getNoisy(const Vector &);
 
+  /// Sets the standard deviation of the Gaussian white noise.
+  /// The covariance matrix is then std*std.transpose()
+  virtual void setStandardDeviation(const Matrix & std);
 
-        ///get the noisy version of a given vector it is only an addition of a given vector
-        ///and a gaussian white noise
-        virtual Vector getNoisy(const Vector &);
+  /// Sets the covariance matrix, the covariance matrix must be positive semi
+  /// definite. This method makes a cholesky decomposition to recompute the
+  /// standard deviation
+  virtual void setCovarianceMatrix(const Matrix & cov);
 
-        ///Sets the standard deviation of the Gaussian white noise.
-        /// The covariance matrix is then std*std.transpose()
-        virtual void setStandardDeviation(const Matrix & std);
+  /// sets the bias of the white noise
+  virtual void setBias(const Vector & bias);
 
-        ///Sets the covariance matrix, the covariance matrix must be positive semi
-        ///definite. This method makes a cholesky decomposition to recompute the
-        ///standard deviation
-        virtual void setCovarianceMatrix(const Matrix & cov);
+  /// sets the dimension of the noise vector
+  virtual void setDimension(Index dim_);
 
-        ///sets the bias of the white noise
-        virtual void setBias(const Vector & bias);
+  /// Gets the dimension of the noise vector
+  virtual Index getDimension() const;
 
-        ///sets the dimension of the noise vector
-        virtual void setDimension(Index dim_);
+  /// set update functions for sum for a vector
+  /// (used in case of lie group vectors)
+  void setSumFunction(void (*sum)(const Vector & stateVector, const Vector & tangentVector, Vector & result));
 
-        ///Gets the dimension of the noise vector
-        virtual Index getDimension() const;
+protected:
+  virtual void checkMatrix_(const Matrix & m) const;
 
-        ///set update functions for sum for a vector
-        /// (used in case of lie group vectors)
-        void setSumFunction(void (* sum)(const  Vector& stateVector, const Vector& tangentVector, Vector& result));
+  virtual void checkVector_(const Vector & v) const;
 
-    protected:
-        virtual void checkMatrix_(const Matrix & m) const ;
+  Index dim_;
 
-        virtual void checkVector_(const Vector & v) const;
+  Matrix std_;
 
-        Index dim_;
+  Vector bias_;
 
+  Vector noisy_;
 
+  void (*sum_)(const Vector & stateVector, const Vector & tangentVector, Vector & result);
+};
 
-        Matrix std_;
+} // namespace stateObservation
 
-        Vector bias_;
-
-        Vector noisy_;
-
-        void (* sum_)(const  Vector& stateVector, const Vector& tangentVector, Vector& result);
-
-
-    };
-
-}
-
-#endif //SENSORSIMULATIONGAUSSIANWHITENOISEHPP
+#endif // SENSORSIMULATIONGAUSSIANWHITENOISEHPP

--- a/include/state-observation/noise/noise-base.hpp
+++ b/include/state-observation/noise/noise-base.hpp
@@ -8,8 +8,6 @@
  *
  */
 
-
-
 #ifndef SENSORSIMULATIONNOISEBASEHPP
 #define SENSORSIMULATIONNOISEBASEHPP
 
@@ -19,27 +17,26 @@
 namespace stateObservation
 {
 
-    /**
-     * \class  NoiseBase
-     * \brief
-     *
-     * \details
-     *
-     */
+/**
+ * \class  NoiseBase
+ * \brief
+ *
+ * \details
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI NoiseBase
-    {
-    public:
-        /// Virtual destructor
-        virtual ~NoiseBase(){}
+class STATE_OBSERVATION_DLLAPI NoiseBase
+{
+public:
+  /// Virtual destructor
+  virtual ~NoiseBase() {}
 
-        /// The method to overload to produce the noisy version of a given vector
-        virtual Vector getNoisy( const Vector &)=0;
+  /// The method to overload to produce the noisy version of a given vector
+  virtual Vector getNoisy(const Vector &) = 0;
 
-    protected:
+protected:
+};
 
-    };
+} // namespace stateObservation
 
-}
-
-#endif //SENSORSIMULATIONNOISEBASEHPP
+#endif // SENSORSIMULATIONNOISEBASEHPP

--- a/include/state-observation/observer/extended-kalman-filter.hpp
+++ b/include/state-observation/observer/extended-kalman-filter.hpp
@@ -12,146 +12,147 @@
  *
  */
 
-
 #ifndef STATEOBSERVER_EXTENDEDKALMANFILTERHPP
 #define STATEOBSERVER_EXTENDEDKALMANFILTERHPP
 
 #include <state-observation/api.h>
-#include <state-observation/observer/kalman-filter-base.hpp>
 #include <state-observation/dynamical-system/dynamical-system-functor-base.hpp>
+#include <state-observation/observer/kalman-filter-base.hpp>
 
 namespace stateObservation
 {
 /**
-     * \class  ExtendedKalmanFilter
-     * \brief
-     *
-     *        The class to intanciate to use an extended Kalman filter.
-     *        To use this class, one needs to provide a pointer on a functor
-     *        that describes the state dynamics and the measurement dynamics.
-     *        The functor type needs to be a derived class from the class
-     *        DynamicsFunctorBase.
-     *
-     *        x_{k+1}=f(x_k,u_k)+v_k
-     *
-     *        y_k=h(x_k,u_k)+w_k
-     *
-     *
-     *
-     */
+ * \class  ExtendedKalmanFilter
+ * \brief
+ *
+ *        The class to intanciate to use an extended Kalman filter.
+ *        To use this class, one needs to provide a pointer on a functor
+ *        that describes the state dynamics and the measurement dynamics.
+ *        The functor type needs to be a derived class from the class
+ *        DynamicsFunctorBase.
+ *
+ *        x_{k+1}=f(x_k,u_k)+v_k
+ *
+ *        y_k=h(x_k,u_k)+w_k
+ *
+ *
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI ExtendedKalmanFilter: public KalmanFilterBase
-    {
+class STATE_OBSERVATION_DLLAPI ExtendedKalmanFilter : public KalmanFilterBase
+{
 
-    public:
+public:
+  /// The constructor.
+  ///  \li n : size of the state vector
+  ///  \li m : size of the measurements vector
 
-        /// The constructor.
-        ///  \li n : size of the state vector
-        ///  \li m : size of the measurements vector
+  ExtendedKalmanFilter(Index n, Index m);
 
-        ExtendedKalmanFilter(Index n,Index m);
+  /// The constructor.
+  ///  \li n : size of the state vector
+  ///  \li m : size of the measurements vector
+  ///  \li p : size of the input vector
+  ///  \li The parameter directInputOutputFeedthrough defines whether (true) or not (false) the measurement y_k requires
+  ///  the input u_k \li The parameter directInputStateProcessFeedthrough defines whether (true) or not (false) the
+  ///  state x_{k+1} requires the input u_k
 
-        /// The constructor.
-        ///  \li n : size of the state vector
-        ///  \li m : size of the measurements vector
-        ///  \li p : size of the input vector
-        ///  \li The parameter directInputOutputFeedthrough defines whether (true) or not (false) the measurement y_k requires the input u_k
-        ///  \li The parameter directInputStateProcessFeedthrough defines whether (true) or not (false) the state x_{k+1} requires the input u_k
+  ExtendedKalmanFilter(Index n,
+                       Index m,
+                       Index p,
+                       bool directInputOutputFeedthrough = true,
+                       bool directInputStateProcessFeedthrough = true);
 
-        ExtendedKalmanFilter(Index n,Index m,Index p,
-                bool directInputOutputFeedthrough=true,
-                bool directInputStateProcessFeedthrough=true);
+  /// The constructor.
+  ///  \li n : size of the state vector
+  ///  \li nt: size of the state tengent vector representation (usually nt<=n)
+  ///  \li m : size of the measurements vector
+  ///  \li p : size of the input vector
+  ///  \li The parameter directInputOutputFeedthrough defines whether (true) or not (false) the measurement y_k requires
+  ///  the input u_k \li The parameter directInputStateProcessFeedthrough defines whether (true) or not (false) the
+  ///  state x_{k+1} requires the input u_k
 
-        /// The constructor.
-        ///  \li n : size of the state vector
-        ///  \li nt: size of the state tengent vector representation (usually nt<=n)
-        ///  \li m : size of the measurements vector
-        ///  \li p : size of the input vector
-        ///  \li The parameter directInputOutputFeedthrough defines whether (true) or not (false) the measurement y_k requires the input u_k
-        ///  \li The parameter directInputStateProcessFeedthrough defines whether (true) or not (false) the state x_{k+1} requires the input u_k
+  ExtendedKalmanFilter(Index n,
+                       Index nt,
+                       Index m,
+                       Index mt,
+                       Index p,
+                       bool directInputOutputFeedthrough,
+                       bool directInputStateProcessFeedthrough);
 
-        ExtendedKalmanFilter(Index n, Index nt, Index  m, Index mt, Index p,
-                bool directInputOutputFeedthrough,
-                bool directInputStateProcessFeedthrough);
+  /// Set a pointer to the functor that defines the dynamics of the states
+  /// and the measurement the user is responsible for the validity of the
+  /// pointer during the execution of the kalman filter
+  void setFunctor(DynamicalSystemFunctorBase * f);
+  DynamicalSystemFunctorBase * getFunctor(void) const;
 
+  /// Gets a pointer to the functor
+  DynamicalSystemFunctorBase * functor() const;
 
-        /// Set a pointer to the functor that defines the dynamics of the states
-        ///and the measurement the user is responsible for the validity of the
-        ///pointer during the execution of the kalman filter
-        void setFunctor(DynamicalSystemFunctorBase* f);
-        DynamicalSystemFunctorBase* getFunctor(void) const;
+  /// Clear the value of the functor
+  /// Does not destroy the pointed object
+  void clearFunctor();
 
-        ///Gets a pointer to the functor
-        DynamicalSystemFunctorBase* functor() const;
+  /// Precise whether (true) or not (false) the measurement y_k requires
+  /// the input u_k
+  void setDirectInputOutputFeedthrough(bool b = true);
 
-        /// Clear the value of the functor
-        ///Does not destroy the pointed object
-        void clearFunctor();
+  /// Precise whether (true) or not (false) the estimation of the state x_{k+1} requires
+  /// the input u_k
+  void setDirectInputStateFeedthrough(bool b = true);
 
-        /// Precise whether (true) or not (false) the measurement y_k requires
-        ///the input u_k
-        void setDirectInputOutputFeedthrough(bool b=true);
+  /// Give an estimation of A matrix using
+  /// finite difference method (the forward difference method)
+  /// the parameter dx is the step vector for derivation
+  /// it must have the size nt (tangent vector)
+  virtual Amatrix getAMatrixFD(const Vector & dx);
 
-        /// Precise whether (true) or not (false) the estimation of the state x_{k+1} requires
-        ///the input u_k
-        void setDirectInputStateFeedthrough(bool b=true);
+  /// Give an estimation of C matrix using
+  /// finite difference method (the forward difference method)
+  /// the parameter dx is the step vector for derivation
+  /// it must have the size nt (tangent vector)
+  virtual Cmatrix getCMatrixFD(const Vector & dx);
 
+  /// Reset the extended kalman filter (call also the reset function of the dynamics functor)
+  virtual void reset();
 
+protected:
+  /// simulate the dynamics of the state using the functor
+  virtual StateVector prediction_(TimeIndex k);
 
-        ///Give an estimation of A matrix using
-        ///finite difference method (the forward difference method)
-        ///the parameter dx is the step vector for derivation
-        /// it must have the size nt (tangent vector)
-        virtual Amatrix getAMatrixFD(const Vector &dx);
+  /// simulate the dynamic of the measurement using the functor
+  virtual MeasureVector simulateSensor_(const StateVector & x, TimeIndex k);
 
-        ///Give an estimation of C matrix using
-        ///finite difference method (the forward difference method)
-        ///the parameter dx is the step vector for derivation
-        /// it must have the size nt (tangent vector)
-        virtual Cmatrix getCMatrixFD(const Vector &dx);
+  /// predicts the measurement using the functor, assumed that the predicted state is up-to-date
+  virtual MeasureVector predictSensor_(TimeIndex k);
 
-        /// Reset the extended kalman filter (call also the reset function of the dynamics functor)
-        virtual void reset();
+  /// boolean that provides if theris a need of not for input for the masurement
+  bool directInputOutputFeedthrough_;
 
-    protected:
-        /// simulate the dynamics of the state using the functor
-        virtual StateVector prediction_(TimeIndex k);
+  /// boolean that provides if theris a need of not for input for the state dynamics
+  bool directInputStateProcessFeedthrough_;
 
-        /// simulate the dynamic of the measurement using the functor
-        virtual MeasureVector simulateSensor_(const StateVector& x, TimeIndex k);
+  /// pointer on the dynamics functor
+  DynamicalSystemFunctorBase * f_;
 
-        /// predicts the measurement using the functor, assumed that the predicted state is up-to-date
-        virtual MeasureVector predictSensor_(TimeIndex k);
+  // optimization
+  struct Optimization
+  {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    ObserverBase::InputVector u_;
+    KalmanFilterBase::Amatrix a_;
+    KalmanFilterBase::Cmatrix c_;
+    ObserverBase::StateVector x_;
+    ObserverBase::StateVector dx_;
+    ObserverBase::StateVector xp_;
+    ObserverBase::MeasureVector yp_;
 
+  } opt;
 
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
 
-        /// boolean that provides if theris a need of not for input for the masurement
-        bool directInputOutputFeedthrough_;
+} // namespace stateObservation
 
-        /// boolean that provides if theris a need of not for input for the state dynamics
-        bool directInputStateProcessFeedthrough_;
-
-        /// pointer on the dynamics functor
-        DynamicalSystemFunctorBase* f_;
-
-        //optimization
-        struct Optimization
-        {
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-          ObserverBase::InputVector u_;
-          KalmanFilterBase::Amatrix a_;
-          KalmanFilterBase::Cmatrix c_;
-          ObserverBase::StateVector x_;
-          ObserverBase::StateVector dx_;
-          ObserverBase::StateVector xp_;
-          ObserverBase::MeasureVector yp_;
-
-        } opt;
-
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    };
-
-}
-
-#endif //EXTENDEDKALMANFILTERHPP
+#endif // EXTENDEDKALMANFILTERHPP

--- a/include/state-observation/observer/linear-kalman-filter.hpp
+++ b/include/state-observation/observer/linear-kalman-filter.hpp
@@ -17,7 +17,6 @@
  *
  */
 
-
 #ifndef STATEOBSERVER_LINEARKALMANFILTERHPP
 #define STATEOBSERVER_LINEARKALMANFILTERHPP
 
@@ -28,121 +27,112 @@ namespace stateObservation
 {
 
 /**
-     * \class  LinearKalmanFilter
-     * \brief
-     *        The class of a Linear Kalman filter
-     *
-     *        It implements the Kalman filter for linear systems (LTI-LTV).
-     *        This is the class to instanciate when you want to use Kalman filtering
-     *        for linear systems. To use this class, one needs to provide the
-     *        matrices that describe the dynamics of the state and the measurement.
-     *
-     *             x_{k+1}=A_k x_k+ B_k u_k + v_k
-     *
-     *             y_k=C_k x_k + D_k u_k + w_k
-     *
-     *
-     *
-     */
+ * \class  LinearKalmanFilter
+ * \brief
+ *        The class of a Linear Kalman filter
+ *
+ *        It implements the Kalman filter for linear systems (LTI-LTV).
+ *        This is the class to instanciate when you want to use Kalman filtering
+ *        for linear systems. To use this class, one needs to provide the
+ *        matrices that describe the dynamics of the state and the measurement.
+ *
+ *             x_{k+1}=A_k x_k+ B_k u_k + v_k
+ *
+ *             y_k=C_k x_k + D_k u_k + w_k
+ *
+ *
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI LinearKalmanFilter: public KalmanFilterBase
-    {
-    public:
+class STATE_OBSERVATION_DLLAPI LinearKalmanFilter : public KalmanFilterBase
+{
+public:
+  /// The constructor
+  ///  \li n : size of the state vector
+  ///  \li m : size of the measurements vector
+  ///  \li p : size of the input vector
+  LinearKalmanFilter(Index n, Index m, Index p = 0) : KalmanFilterBase(n, m, p) {}
 
+  /// Default constructor
+  LinearKalmanFilter() {}
 
+  /// The type of the matrix linking the input to the state
+  typedef Matrix Bmatrix;
 
-        /// The constructor
-        ///  \li n : size of the state vector
-        ///  \li m : size of the measurements vector
-        ///  \li p : size of the input vector
-        LinearKalmanFilter(Index n,Index m,Index p=0)
-            :KalmanFilterBase(n,m,p){}
+  /// The type of the matrix linking the input to the measurement
+  typedef Matrix Dmatrix;
 
-        /// Default constructor
-        LinearKalmanFilter(){}
+  /// Set the value of the input-state matrix
+  virtual void setB(const Bmatrix & B);
 
-        /// The type of the matrix linking the input to the state
-        typedef Matrix Bmatrix;
+  /// Clear the value of the input-state Matrix
+  virtual void clearB();
 
-        /// The type of the matrix linking the input to the measurement
-        typedef Matrix Dmatrix;
+  /// Set the value of the input-measurement matrix
+  virtual void setD(const Dmatrix & D);
 
-        /// Set the value of the input-state matrix
-        virtual void setB(const Bmatrix& B);
+  /// Clear the value of the input-measurement matrix
+  virtual void clearD();
 
-        ///Clear the value of the input-state Matrix
-        virtual void clearB();
+  /// Reset all the observer
+  virtual void reset();
 
-        ///Set the value of the input-measurement matrix
-        virtual void setD(const Dmatrix& D);
+  /// Get a matrix having the size of the B matrix having "c" values
+  Bmatrix getBmatrixConstant(double c) const;
 
-        ///Clear the value of the input-measurement matrix
-        virtual void clearD();
+  /// Get a matrix having the size of the B matrix having random values
+  Bmatrix getBmatrixRandom() const;
 
-        ///Reset all the observer
-        virtual void reset();
+  /// Get a matrix having the size of the B matrix having zero values
+  Bmatrix getBmatrixZero() const;
 
+  /// checks whether or not a matrix has the dimensions of the B matrix
+  bool checkBmatrix(const Bmatrix &) const;
 
-        /// Get a matrix having the size of the B matrix having "c" values
-        Bmatrix getBmatrixConstant(double c) const;
+  /// Get a matrix having the size of the D matrix having "c" values
+  Dmatrix getDmatrixConstant(double c) const;
 
-        /// Get a matrix having the size of the B matrix having random values
-        Bmatrix getBmatrixRandom() const;
+  /// Get a matrix having the size of the D matrix having random values
+  Dmatrix getDmatrixRandom() const;
 
-        /// Get a matrix having the size of the B matrix having zero values
-        Bmatrix getBmatrixZero() const;
+  /// Get a matrix having the size of the D matrix having zero values
+  Dmatrix getDmatrixZero() const;
 
-        ///checks whether or not a matrix has the dimensions of the B matrix
-        bool checkBmatrix(const Bmatrix & ) const;
+  /// checks whether or not a matrix has the dimensions of the D matrix
+  bool checkDmatrix(const Dmatrix &) const;
 
+  /// changes the dimension of the state vector:
+  /// resets the internal container for the state vector and
+  /// the containers for the matrices A, B, C, Q, P
+  virtual void setStateSize(Index n);
 
-        /// Get a matrix having the size of the D matrix having "c" values
-        Dmatrix getDmatrixConstant(double c) const;
+  /// changes the dimension of the measurement vector:
+  /// resets the internal container for the measurement vectors and
+  /// the containers for the matrices C, D, R
+  virtual void setMeasureSize(Index m);
 
-        /// Get a matrix having the size of the D matrix having random values
-        Dmatrix getDmatrixRandom() const;
+  /// changes the dimension of the input vector:
+  /// resets the internal container for the input vectors and
+  /// the containers for the matrices B, D
+  virtual void setInputSize(Index p);
 
-        /// Get a matrix having the size of the D matrix having zero values
-        Dmatrix getDmatrixZero() const;
+protected:
+  /// The implementation of the (linear) prediction (state dynamics)
+  virtual StateVector prediction_(TimeIndex k);
 
-        ///checks whether or not a matrix has the dimensions of the D matrix
-        bool checkDmatrix(const Dmatrix &) const;
+  /// The implementation of the (linear) measurement (state dynamics)
+  virtual MeasureVector simulateSensor_(const StateVector & x, TimeIndex k);
 
+  /// The container of the Input-State matrix
+  Matrix d_;
 
-        ///changes the dimension of the state vector:
-        ///resets the internal container for the state vector and
-        ///the containers for the matrices A, B, C, Q, P
-        virtual void setStateSize(Index n);
+  /// The container of the Input-Measurement matrix
+  Matrix b_;
 
-        ///changes the dimension of the measurement vector:
-        ///resets the internal container for the measurement vectors and
-        ///the containers for the matrices C, D, R
-        virtual void setMeasureSize(Index m);
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
 
-        ///changes the dimension of the input vector:
-        ///resets the internal container for the input vectors and
-        ///the containers for the matrices B, D
-        virtual void setInputSize(Index p);
+} // namespace stateObservation
 
-    protected:
-        /// The implementation of the (linear) prediction (state dynamics)
-        virtual StateVector prediction_(TimeIndex k);
-
-        /// The implementation of the (linear) measurement (state dynamics)
-        virtual MeasureVector simulateSensor_(const StateVector& x, TimeIndex k);
-
-        /// The container of the Input-State matrix
-        Matrix d_;
-
-        /// The container of the Input-Measurement matrix
-        Matrix b_;
-
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-    };
-
-
-}
-
-#endif //STATEOBSERVER_LINEARKALMANFILTERHPP
+#endif // STATEOBSERVER_LINEARKALMANFILTERHPP

--- a/include/state-observation/observer/observer-base.hpp
+++ b/include/state-observation/observer/observer-base.hpp
@@ -14,153 +14,144 @@
  *
  */
 
-
-
 #ifndef OBSERVERBASEHPP
 #define OBSERVERBASEHPP
 
-
-
-#include <boost/static_assert.hpp>
 #include <boost/assert.hpp>
+#include <boost/static_assert.hpp>
 
 #include <state-observation/api.h>
 #include <state-observation/tools/definitions.hpp>
 
 namespace stateObservation
 {
-     /**
-     * \class  ObserverBase
-     * \brief  The base class for observers.
-     *         The observer is destinated to any dynamical system with a vector
-     *         state representation. This class mostly defined an abstract
-     *         interface, static constants and types. It is templated by:
-     *
-     *
-     */
+/**
+ * \class  ObserverBase
+ * \brief  The base class for observers.
+ *         The observer is destinated to any dynamical system with a vector
+ *         state representation. This class mostly defined an abstract
+ *         interface, static constants and types. It is templated by:
+ *
+ *
+ */
 
+class STATE_OBSERVATION_DLLAPI ObserverBase
+{
+public:
+  /// StateVector is the type of state vector
+  typedef Vector StateVector;
 
-    class STATE_OBSERVATION_DLLAPI ObserverBase
-    {
-    public:
+  /// MeasureVector is the type of measurements vector
+  typedef Vector MeasureVector;
 
-        ///StateVector is the type of state vector
-        typedef Vector StateVector;
+  /// InputVector is the type of the input vector
+  typedef Vector InputVector;
 
-        ///MeasureVector is the type of measurements vector
-        typedef Vector MeasureVector;
+  /// constructor
+  ///      \li n : size of the state vector
+  ///      \li m : size of the measurements vector
+  ///      \li p : size of the input vector
+  ObserverBase(Index n, Index m, Index p = 0);
 
-        ///InputVector is the type of the input vector
-        typedef Vector InputVector;
+  /// default constructor (default values for n,m,p are zero)
+  ObserverBase();
 
+  /// Destructor
+  virtual ~ObserverBase(){};
 
-        ///constructor
-        ///      \li n : size of the state vector
-        ///      \li m : size of the measurements vector
-        ///      \li p : size of the input vector
-        ObserverBase(Index n, Index m, Index p=0);
+  /// Changes the size of the state vector
+  virtual void setStateSize(Index n);
 
-        ///default constructor (default values for n,m,p are zero)
-        ObserverBase();
+  /// gets the size of the state vector
+  virtual Index getStateSize() const;
 
-        ///Destructor
-        virtual ~ObserverBase(){};
+  /// Changes the size of the measurement vector
+  virtual void setMeasureSize(Index m);
 
-        /// Changes the size of the state vector
-        virtual void setStateSize(Index n);
+  /// gets the size of the measurement vector
+  virtual Index getMeasureSize() const;
 
-        /// gets the size of the state vector
-        virtual Index getStateSize() const;
+  /// Changes the size of the input vector
+  virtual void setInputSize(Index p);
 
-        /// Changes the size of the measurement vector
-        virtual void setMeasureSize(Index m);
+  /// gets the size of the input vector
+  virtual Index getInputSize() const;
 
-        /// gets the size of the measurement vector
-        virtual Index getMeasureSize() const;
+  /// Set the value of the state vector at time index k
+  virtual void setState(const StateVector & x_k, TimeIndex k) = 0;
 
-        /// Changes the size of the input vector
-        virtual void setInputSize(Index p);
+  /// Remove all the given past values of the state
+  virtual void clearStates() = 0;
 
-        /// gets the size of the input vector
-        virtual Index getInputSize() const;
+  /// Set the value of the measurements vector at time index k
+  virtual void setMeasurement(const MeasureVector & y_k, TimeIndex k) = 0;
 
-        ///Set the value of the state vector at time index k
-        virtual void setState(const StateVector& x_k,TimeIndex k)=0;
+  /// Remove all the given past values of the measurements
+  virtual void clearMeasurements() = 0;
 
-        ///Remove all the given past values of the state
-        virtual void clearStates()=0;
+  /// Set the value of the input vector at time index k
+  virtual void setInput(const InputVector & x_k, TimeIndex k) = 0;
 
-        ///Set the value of the measurements vector at time index k
-        virtual void setMeasurement(const MeasureVector& y_k,TimeIndex k)=0;
+  /// Remove all the given past values of the inputs
+  virtual void clearInputs() = 0;
 
-        ///Remove all the given past values of the measurements
-        virtual void clearMeasurements()=0;
+  /// Run the observer loop and gets the state estimation of the state at
+  /// instant k
+  virtual StateVector getEstimatedState(TimeIndex k) = 0;
 
-        ///Set the value of the input vector at time index k
-        virtual void setInput(const InputVector& x_k,TimeIndex k)=0;
+  /// Reinitializes the whole observer
+  /// default behavior is to call the three "ObserverBase::clear*" methods
+  virtual void reset();
 
-        ///Remove all the given past values of the inputs
-        virtual void clearInputs()=0;
+  /// These are initializer  for vectors
+  /// We do not use the get prefix to be consistent with eigen initializers
+  /// Gives a vector of state vector size having duplicated "c" value
+  virtual StateVector stateVectorConstant(double c) const;
 
-        ///Run the observer loop and gets the state estimation of the state at
-        ///instant k
-        virtual StateVector getEstimatedState(TimeIndex k)=0;
+  /// Gives a vector of state vector size having random values
+  virtual StateVector stateVectorRandom() const;
 
-        ///Reinitializes the whole observer
-        ///default behavior is to call the three "ObserverBase::clear*" methods
-        virtual void reset();
+  /// Gives a vector of state vector size having zero values
+  virtual StateVector stateVectorZero() const;
 
-        ///These are initializer  for vectors
-        /// We do not use the get prefix to be consistent with eigen initializers
-        ///Gives a vector of state vector size having duplicated "c" value
-        virtual StateVector stateVectorConstant( double c ) const;
+  /// Tells whether or not the vector has the dimensions of a state vector
+  virtual bool checkStateVector(const StateVector & v) const;
 
-        ///Gives a vector of state vector size having random values
-        virtual StateVector stateVectorRandom() const;
+  /// Gives a vector of measurement vector size having duplicated "c" value
+  virtual MeasureVector measureVectorConstant(double c) const;
 
-        ///Gives a vector of state vector size having zero values
-        virtual StateVector stateVectorZero() const;
+  /// Gives a vector of measurement vector size having random values
+  virtual MeasureVector measureVectorRandom() const;
 
-        ///Tells whether or not the vector has the dimensions of a state vector
-        virtual bool checkStateVector(const StateVector & v ) const;
+  /// Gives a vector of measurement vector size having zero values
+  virtual MeasureVector measureVectorZero() const;
 
-        ///Gives a vector of measurement vector size having duplicated "c" value
-        virtual MeasureVector measureVectorConstant( double c ) const;
+  /// Tells whether or not the vector has the dimensions of a measurement vector
+  virtual bool checkMeasureVector(const MeasureVector &) const;
 
-        ///Gives a vector of measurement vector size having random values
-        virtual MeasureVector measureVectorRandom() const;
+  /// Gives a vector of input vector size having duplicated "c" value
+  virtual InputVector inputVectorConstant(double c) const;
 
-        ///Gives a vector of measurement vector size having zero values
-        virtual MeasureVector measureVectorZero() const;
+  /// Gives a vector of input vector size having random values
+  virtual InputVector inputVectorRandom() const;
 
-        ///Tells whether or not the vector has the dimensions of a measurement vector
-        virtual bool checkMeasureVector(const MeasureVector &) const;
+  /// Gives a vector of input vector size having zero values
+  virtual InputVector inputVectorZero() const;
 
-        ///Gives a vector of input vector size having duplicated "c" value
-        virtual InputVector inputVectorConstant( double c ) const;
+  /// Tells whether or not the vector has the dimensions of a input vector
+  virtual bool checkInputVector(const InputVector &) const;
 
-        ///Gives a vector of input vector size having random values
-        virtual InputVector inputVectorRandom() const;
+protected:
+  /// stateSize is the size of the state vector
+  Index n_;
 
-        ///Gives a vector of input vector size having zero values
-        virtual InputVector inputVectorZero() const;
+  /// measureSize is the size of measurements vector
+  Index m_;
 
-        ///Tells whether or not the vector has the dimensions of a input vector
-        virtual bool checkInputVector(const InputVector &) const;
+  /// inputSize is the size of the input vector
+  Index p_;
+};
 
-    protected:
+} // namespace stateObservation
 
-        ///stateSize is the size of the state vector
-        Index n_;
-
-        ///measureSize is the size of measurements vector
-        Index m_;
-
-        ///inputSize is the size of the input vector
-        Index p_;
-
-    };
-
-}
-
-#endif//OBSERVERBASEHPP
+#endif // OBSERVERBASEHPP

--- a/include/state-observation/observer/tilt-estimator.hpp
+++ b/include/state-observation/observer/tilt-estimator.hpp
@@ -9,135 +9,183 @@
  *
  */
 
-
-
 #ifndef TILTESTIMATORHPP
 #define TILTESTIMATORHPP
 
 #include <state-observation/api.h>
 #include <state-observation/observer/zero-delay-observer.hpp>
 
-
 namespace stateObservation
 {
 
 /**
-  * \class  TiltEstimator
-  * \brief
-  *         Description is pending
-  *
-  *         use getEstimatedState to obtain the state vector
-  *         the tilt R.transpose()*e_z is constituted
-  *         with the last three components of the state vector.
-  *
-  */
-  class STATE_OBSERVATION_DLLAPI TiltEstimator: public ZeroDelayObserver
+ * \class  TiltEstimator
+ * \brief
+ *         Description is pending
+ *
+ *         use getEstimatedState to obtain the state vector
+ *         the tilt R.transpose()*e_z is constituted
+ *         with the last three components of the state vector.
+ *
+ */
+class STATE_OBSERVATION_DLLAPI TiltEstimator : public ZeroDelayObserver
+{
+public:
+  /// The constructor
+  ///  \li alpha : parameter related to the convergence of the linear velocity
+  ///              of the IMU expressed in the control frame
+  ///  \li beta  : parameter related to the fast convergence of the tilt
+  ///  \li gamma : parameter related to the orthogonality
+  TiltEstimator(double alpha, double beta, double gamma);
+
+  /// set the gain of x1_hat variable
+  void setAlpha(const double alpha)
   {
-  public:
+    alpha_ = alpha;
+  }
+  double getAlpha() const
+  {
+    return alpha_;
+  }
 
-    /// The constructor
-    ///  \li alpha : parameter related to the convergence of the linear velocity
-    ///              of the IMU expressed in the control frame
-    ///  \li beta  : parameter related to the fast convergence of the tilt
-    ///  \li gamma : parameter related to the orthogonality
-    TiltEstimator(double alpha, double beta, double gamma);
+  /// set the gain of x2prime_hat variable
+  void setBeta(const double beta)
+  {
+    beta_ = beta;
+  }
+  double getBeta() const
+  {
+    return beta_;
+  }
 
-    ///set the gain of x1_hat variable
-    void setAlpha(const double alpha) { alpha_ = alpha; }
-    double getAlpha() const { return alpha_; }
+  /// set the gain of x2_hat variable
+  void setGamma(const double gamma)
+  {
+    gamma_ = gamma;
+  }
+  double getGamma() const
+  {
+    return gamma_;
+  }
 
-    ///set the gain of x2prime_hat variable
-    void setBeta(const double beta) { beta_ = beta; }
-    double getBeta() const { return beta_; }
+  /// set the sampling time of the measurements
+  void setSamplingTime(const double dt)
+  {
+    dt_ = dt;
+  }
+  double getSamplingTime() const
+  {
+    return dt_;
+  }
 
-    ///set the gain of x2_hat variable
-    void setGamma(const double gamma) { gamma_ = gamma; }
-    double getGamma() const { return gamma_; }
+  /// sets the position of the IMU sensor in the control frame
+  void setSensorPositionInC(const Vector3 & p)
+  {
+    p_S_C_ = p;
+  }
+  Vector3 getSensorPositionInC()
+  {
+    return p_S_C_;
+  }
 
-    ///set the sampling time of the measurements
-    void setSamplingTime(const double dt) { dt_ = dt; }
-    double getSamplingTime() const { return dt_; }
+  /// sets the oriantation of the IMU sensor in the control frame
+  void setSensorOrientationInC(const Matrix3 & R)
+  {
+    R_S_C_ = R;
+  }
+  Matrix3 getSensorOrientationInC()
+  {
+    return R_S_C_;
+  }
 
-    /// sets the position of the IMU sensor in the control frame
-    void setSensorPositionInC(const Vector3& p) { p_S_C_ = p; }
-    Vector3 getSensorPositionInC() { return p_S_C_; }
+  /// sets teh linear velocity of the IMU sensor in the control frame
+  void setSensorLinearVelocityInC(const Vector3 & v)
+  {
+    v_S_C_ = v;
+  }
+  Vector3 getSensorLinearVelocityInC()
+  {
+    return v_S_C_;
+  }
 
-    /// sets the oriantation of the IMU sensor in the control frame
-    void setSensorOrientationInC(const Matrix3& R) { R_S_C_ = R; }
-    Matrix3 getSensorOrientationInC() { return R_S_C_; }
+  /// sets the angular velocity of the IMU sensor in the control frame
+  void setSensorAngularVelocityInC(const Vector3 & w)
+  {
+    w_S_C_ = w;
+  }
+  Vector3 getSensorAngularVelocityInC()
+  {
+    return w_S_C_;
+  }
 
-    /// sets teh linear velocity of the IMU sensor in the control frame
-    void setSensorLinearVelocityInC(const Vector3& v) { v_S_C_ = v; }
-    Vector3 getSensorLinearVelocityInC() { return v_S_C_; }
-
-    /// sets the angular velocity of the IMU sensor in the control frame
-    void setSensorAngularVelocityInC(const Vector3& w) { w_S_C_ = w; }
-    Vector3 getSensorAngularVelocityInC() { return w_S_C_; }
-
-    /// sets the velocity of the control origin in the world frame
-    /// this velocity has to be expressed in the control frame.
-    void setControlOriginVelocityInW(const Vector3& v) { v_C_ = v; }
-    Vector3 getControlOriginVelocityInW() { return v_C_; }
+  /// sets the velocity of the control origin in the world frame
+  /// this velocity has to be expressed in the control frame.
+  void setControlOriginVelocityInW(const Vector3 & v)
+  {
+    v_C_ = v;
+  }
+  Vector3 getControlOriginVelocityInW()
+  {
+    return v_C_;
+  }
 
 /// prevent c++ overloaded virtual function warning
 #if defined(__clang__)
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Woverloaded-virtual"
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Woverloaded-virtual"
 #else
-# if defined(__GNUC__)
-#   pragma GCC diagnostic push
-#   pragma GCC diagnostic ignored "-Woverloaded-virtual"
-# endif
+#  if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#  endif
 #endif
 
-    /// sets ths measurement (accelero and gyro stacked in one vector)
-    void setMeasurement(const Vector3 ya_k, const Vector3 yg_k, TimeIndex k);
+  /// sets ths measurement (accelero and gyro stacked in one vector)
+  void setMeasurement(const Vector3 ya_k, const Vector3 yg_k, TimeIndex k);
 
 #if defined(__clang__)
-#pragma clang diagnostic pop
-    #else
-# if defined(__GNUC__)
-#   pragma GCC diagnostic pop
-# endif
+#  pragma clang diagnostic pop
+#else
+#  if defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#  endif
 #endif
 
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  protected:
+protected:
+  /// The parameters of the estimator
+  double alpha_, beta_, gamma_;
 
-    /// The parameters of the estimator
-    double alpha_, beta_, gamma_;
+  /// Sampling time
+  double dt_;
 
-    /// Sampling time
-    double dt_;
+  /// Position of the IMU in the control frame
+  Vector3 p_S_C_;
 
-    /// Position of the IMU in the control frame
-    Vector3 p_S_C_;
+  /// Orientation of the IMU in the control frame
+  Matrix3 R_S_C_;
 
-    /// Orientation of the IMU in the control frame
-    Matrix3 R_S_C_;
+  /// Linear velocity of the IMU in the control frame
+  Vector3 v_S_C_;
 
-    /// Linear velocity of the IMU in the control frame
-    Vector3 v_S_C_;
+  /// Angular velocity of the IMU in the control frame
+  Vector3 w_S_C_;
 
-    /// Angular velocity of the IMU in the control frame
-    Vector3 w_S_C_;
+  /// Linear velocity of the control frame
+  Vector3 v_C_;
 
-    /// Linear velocity of the control frame
-    Vector3 v_C_;
+  /// variables used for the computation
+  Vector3 x1_;
+  Vector3 x1_hat_;
+  Vector3 x2_hat_prime_;
+  Vector3 x2_hat_;
+  Vector3 dx1_hat;
 
+  /// The tilt estimator loop
+  StateVector oneStepEstimation_();
+};
 
-    ///variables used for the computation
-    Vector3 x1_;
-    Vector3 x1_hat_;
-    Vector3 x2_hat_prime_;
-    Vector3 x2_hat_;
-    Vector3 dx1_hat;
+} // namespace stateObservation
 
-    /// The tilt estimator loop
-    StateVector oneStepEstimation_();
-  };
-
-}
-
-#endif //TILTESTIMATORHPP
+#endif // TILTESTIMATORHPP

--- a/include/state-observation/observer/zero-delay-observer.hpp
+++ b/include/state-observation/observer/zero-delay-observer.hpp
@@ -13,7 +13,6 @@
  *
  */
 
-
 #ifndef ZERODELAYOBSERVER_H
 #define ZERODELAYOBSERVER_H
 
@@ -22,140 +21,132 @@
 #include <state-observation/api.h>
 #include <state-observation/observer/observer-base.hpp>
 
-
 namespace stateObservation
 {
-    /**
-     * \class  ZeroDelayObserver
-     * \brief  Defines the base class of online zero delay observers.
-     *         Zero delay observers are the classical state observers where
-     *         input and state values at instant k and the measurement value
-     *         at instant k+1 are enough to provide the estimation of the state
-     *         at instant k+1.
-     *         This class mostly defines the data structures for storing the
-     *         vectors, it describes the set routines and the observation
-     *         loop mechanism. It requires to be derviated to implement the
-     *         new oneStepEstimation_() method
-     *
+/**
+ * \class  ZeroDelayObserver
+ * \brief  Defines the base class of online zero delay observers.
+ *         Zero delay observers are the classical state observers where
+ *         input and state values at instant k and the measurement value
+ *         at instant k+1 are enough to provide the estimation of the state
+ *         at instant k+1.
+ *         This class mostly defines the data structures for storing the
+ *         vectors, it describes the set routines and the observation
+ *         loop mechanism. It requires to be derviated to implement the
+ *         new oneStepEstimation_() method
+ *
 
-     *
-     * \details
-     *
-     */
-    class STATE_OBSERVATION_DLLAPI ZeroDelayObserver: public ObserverBase
-    {
-    public:
+ *
+ * \details
+ *
+ */
+class STATE_OBSERVATION_DLLAPI ZeroDelayObserver : public ObserverBase
+{
+public:
+  /// The constructor
+  ///  \li n : size of the state vector
+  ///  \li m : size of the measurements vector
+  ///  \li p : size of the input vector
+  ZeroDelayObserver(Index n, Index m, Index p = 0) : ObserverBase(n, m, p) {}
 
-        /// The constructor
-        ///  \li n : size of the state vector
-        ///  \li m : size of the measurements vector
-        ///  \li p : size of the input vector
-        ZeroDelayObserver(Index n, Index m, Index p=0):
-            ObserverBase(n,m,p){}
+  /// Default constructor (default values for n,m,p are zero)
+  ZeroDelayObserver() {}
 
-        ///Default constructor (default values for n,m,p are zero)
-        ZeroDelayObserver(){}
+  /// Destructor
+  virtual ~ZeroDelayObserver(){};
 
-        ///Destructor
-        virtual ~ZeroDelayObserver(){};
+  /// Set the value of the state vector at time index k. Only the value
+  /// with the highest time-index is kept and others are deleted, the
+  /// highest index is called the current time k_0
+  virtual void setState(const ObserverBase::StateVector & x_k, TimeIndex k);
 
-        ///Set the value of the state vector at time index k. Only the value
-        ///with the highest time-index is kept and others are deleted, the
-        ///highest index is called the current time k_0
-        virtual void setState(
-            const ObserverBase::StateVector& x_k,TimeIndex k);
+  /// Remove all the given past values of the state
+  virtual void clearStates();
 
-        ///Remove all the given past values of the state
-        virtual void clearStates();
+  /// Set the value of the measurements vector at time index k. The
+  /// measurements have to be inserted in chronological order without gaps.
+  virtual void setMeasurement(const ObserverBase::MeasureVector & y_k, TimeIndex k);
 
-        ///Set the value of the measurements vector at time index k. The
-        ///measurements have to be inserted in chronological order without gaps.
-        virtual void setMeasurement(
-            const ObserverBase::MeasureVector& y_k,TimeIndex k);
+  /// Remove all the given past values of the measurements
+  virtual void clearMeasurements();
 
-        ///Remove all the given past values of the measurements
-        virtual void clearMeasurements();
+  /// Set the value of the input vector at time index k. The
+  /// inputs have to be inserted in chronological order without gaps.
+  /// If there is no input in the system (p==0), this instruction has no effect
+  virtual void setInput(const ObserverBase::InputVector & u_k, TimeIndex k);
 
-        ///Set the value of the input vector at time index k. The
-        ///inputs have to be inserted in chronological order without gaps.
-        ///If there is no input in the system (p==0), this instruction has no effect
-        virtual void setInput(const ObserverBase::InputVector& u_k,TimeIndex k);
+  /// Remove all the given past values of the inputs
+  /// If there is no input, this instruction has no effect
+  virtual void clearInputs();
 
-        ///Remove all the given past values of the inputs
-        ///If there is no input, this instruction has no effect
-        virtual void clearInputs();
+  /// Run the observer loop and gets the state estimation of the state at
+  /// instant k.
+  /// In order to estimate the state k, two conditions have to be met:
+  /// \li the time index k must be superior to the current time k_0, the
+  ///     does *not* record past values of the state and cannot observe
+  ///     past states.
+  /// \li the observer has to be able to reconstruct all the state
+  ///     values from k_0 to k. That means all the measurements or input
+  ///     values reauired have to be provided before.
+  ///
+  /// That means generally (for most zero delay observers) that when
+  /// current time is k_0 (we know an estimation of x_{k_0}) and we want
+  /// to reconstruct the state at time k>k_0 we need to have the values of
+  /// y_{k_0+1} to y_{k} and u_{k_0} to u_{k-1}
+  ///
+  /// This method sets the current time to k
+  virtual ObserverBase::StateVector getEstimatedState(TimeIndex k);
 
-        ///Run the observer loop and gets the state estimation of the state at
-        ///instant k.
-        ///In order to estimate the state k, two conditions have to be met:
-        /// \li the time index k must be superior to the current time k_0, the
-        ///     does *not* record past values of the state and cannot observe
-        ///     past states.
-        /// \li the observer has to be able to reconstruct all the state
-        ///     values from k_0 to k. That means all the measurements or input
-        ///     values reauired have to be provided before.
-        ///
-        ///That means generally (for most zero delay observers) that when
-        ///current time is k_0 (we know an estimation of x_{k_0}) and we want
-        ///to reconstruct the state at time k>k_0 we need to have the values of
-        ///y_{k_0+1} to y_{k} and u_{k_0} to u_{k-1}
-        ///
-        /// This method sets the current time to k
-        virtual ObserverBase::StateVector getEstimatedState(TimeIndex k);
+  /// Get the value of the current time index
+  virtual TimeIndex getCurrentTime() const;
 
-        ///Get the value of the current time index
-        virtual TimeIndex getCurrentTime()const;
+  /// Get the value of the input of the time index k
+  Vector getInput(TimeIndex k) const;
 
-        ///Get the value of the input of the time index k
-        Vector getInput(TimeIndex k) const;
+  /// Get the number of available inputs
+  virtual TimeSize getInputsNumber() const;
 
-        ///Get the number of available inputs
-        virtual TimeSize getInputsNumber()const;
+  /// Get the time index of the last given input
+  virtual TimeIndex getInputTime() const;
 
-        ///Get the time index of the last given input
-        virtual TimeIndex getInputTime()const;
+  /// Get the measurement of the time index k
+  Vector getMeasurement(TimeIndex k) const;
 
-        ///Get the measurement of the time index k
-        Vector getMeasurement(TimeIndex k) const;
+  /// Get the time index of the last given measurement
+  virtual TimeIndex getMeasurementTime() const;
 
-        ///Get the time index of the last given measurement
-        virtual TimeIndex getMeasurementTime()const;
+  /// Gets the number of regitered measurements
+  virtual TimeSize getMeasurementsNumber() const;
 
-        ///Gets the number of regitered measurements
-        virtual TimeSize getMeasurementsNumber()const;
+  /// changes the size of the state vector: resets the stored state vector
+  virtual void setStateSize(Index n);
 
-        ///changes the size of the state vector: resets the stored state vector
-        virtual void setStateSize(Index n);
+  /// changes the size of the measurement vector: reset the stored measurement vectors
+  virtual void setMeasureSize(Index m);
 
-        ///changes the size of the measurement vector: reset the stored measurement vectors
-        virtual void setMeasureSize(Index m);
+  /// changes the size of the input vector: reset the stored input vectors
+  virtual void setInputSize(Index p);
 
-        ///changes the size of the input vector: reset the stored input vectors
-        virtual void setInputSize(Index p);
+protected:
+  /// This method describes one loop of the observer (from k_0 to k_0+1)
+  /// it has to be implemented in derived classes.
+  virtual StateVector oneStepEstimation_() = 0;
 
-    protected:
+  /// while the measurements and iputs are put in lists
 
-        ///This method describes one loop of the observer (from k_0 to k_0+1)
-        /// it has to be implemented in derived classes.
-        virtual StateVector oneStepEstimation_()=0;
+  /// The state estimation of the observer (only one state is recorded)
+  IndexedVector x_;
 
-        ///while the measurements and iputs are put in lists
+  /// Container for the measurements.
+  IndexedVectorArray y_;
 
-        ///The state estimation of the observer (only one state is recorded)
-        IndexedVector x_;
+  /// Container for the inputs.
+  IndexedVectorArray u_;
 
-        ///Container for the measurements.
-        IndexedVectorArray y_;
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
 
-        ///Container for the inputs.
-        IndexedVectorArray u_;
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} // namespace stateObservation
 
-    };
-
-}
-
-
-
-#endif //ZERODELAYOBSERVER
+#endif // ZERODELAYOBSERVER

--- a/include/state-observation/sensors-simulation/accelerometer-gyrometer-magnetometer.hpp
+++ b/include/state-observation/sensors-simulation/accelerometer-gyrometer-magnetometer.hpp
@@ -8,75 +8,68 @@
  *
  */
 
-
-
 #ifndef SIMULATIONACCELEROMETERGYROMETERMAGNETOMETERSENSORHPP
 #define SIMULATIONACCELEROMETERGYROMETERMAGNETOMETERSENSORHPP
 
-#include <Eigen/Core>
 #include <boost/assert.hpp>
+#include <Eigen/Core>
 
 #include <state-observation/api.h>
 #include <state-observation/sensors-simulation/algebraic-sensor.hpp>
 #include <state-observation/sensors-simulation/algorithm/linear-acceleration.hpp>
-#include <state-observation/sensors-simulation/algorithm/rotation-velocity.hpp>
 #include <state-observation/sensors-simulation/algorithm/magnetic-field.hpp>
+#include <state-observation/sensors-simulation/algorithm/rotation-velocity.hpp>
 
 namespace stateObservation
 {
-    /**
-     * \class  AccelerometerGyrometerMagnetometer
-     * \brief  Implements the accelerometer-gyrometer-magnetometer measurements
-     *
-     *
-     *
-     * \details
-     *
-     */
+/**
+ * \class  AccelerometerGyrometerMagnetometer
+ * \brief  Implements the accelerometer-gyrometer-magnetometer measurements
+ *
+ *
+ *
+ * \details
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI AccelerometerGyrometerMagnetometer : public AlgebraicSensor,
-        protected algorithm::LinearAcceleration,
-        protected algorithm::RotationVelocity,
-        protected algorithm::MagneticField
-    {
-    public:
-        AccelerometerGyrometerMagnetometer();
+class STATE_OBSERVATION_DLLAPI AccelerometerGyrometerMagnetometer : public AlgebraicSensor,
+                                                                    protected algorithm::LinearAcceleration,
+                                                                    protected algorithm::RotationVelocity,
+                                                                    protected algorithm::MagneticField
+{
+public:
+  AccelerometerGyrometerMagnetometer();
 
-        ///Virtual destructor
-        virtual ~AccelerometerGyrometerMagnetometer(){}
+  /// Virtual destructor
+  virtual ~AccelerometerGyrometerMagnetometer() {}
 
+  void setMatrixMode(bool matrixMode);
 
+protected:
+  /// Gets the state vector Size
+  virtual Index getStateSize_() const;
 
-        void setMatrixMode(bool matrixMode);
+  /// Gets the measurements vector size
+  virtual Index getMeasurementSize_() const;
 
+  virtual Vector computeNoiselessMeasurement_();
 
-    protected:
-        ///Gets the state vector Size
-        virtual Index getStateSize_() const;
+  Matrix3 r_;
+  Vector3 acc_;
+  Vector3 omega_;
+  Vector3 magne_;
+  Vector output_;
 
-        ///Gets the measurements vector size
-        virtual Index getMeasurementSize_() const;
+  bool matrixMode_;
 
+  static const Index stateSize_ = 10;
+  static const Index stateSizeMatrix_ = 15;
 
-        virtual Vector computeNoiselessMeasurement_();
+  static const Index measurementSize_ = 9;
 
-        Matrix3 r_;
-        Vector3 acc_;
-        Vector3 omega_;
-        Vector3 magne_;
-        Vector output_;
+  Index currentStateSize_;
+};
 
-        bool matrixMode_;
-
-        static const Index stateSize_= 10;
-        static const Index stateSizeMatrix_= 15;
-
-        static const Index measurementSize_=9;
-
-        Index currentStateSize_;
-
-    };
-
-}
+} // namespace stateObservation
 
 #endif // SIMULATIONACCELEROMETERGYROMETERMAGNETOMETERSENSORHPP

--- a/include/state-observation/sensors-simulation/accelerometer-gyrometer.hpp
+++ b/include/state-observation/sensors-simulation/accelerometer-gyrometer.hpp
@@ -7,13 +7,11 @@
  *
  */
 
-
-
 #ifndef SIMULATIONACCELEROMETERGYROMETERSENSORHPP
 #define SIMULATIONACCELEROMETERGYROMETERSENSORHPP
 
-#include <Eigen/Core>
 #include <boost/assert.hpp>
+#include <Eigen/Core>
 
 #include <state-observation/api.h>
 #include <state-observation/sensors-simulation/algebraic-sensor.hpp>
@@ -22,57 +20,52 @@
 
 namespace stateObservation
 {
-    /**
-     * \class  AccelerometerGyrometer
-     * \brief  Implements the accelerometer-gyrometer measurements
-     *
-     *
-     *
-     * \details
-     *
-     */
+/**
+ * \class  AccelerometerGyrometer
+ * \brief  Implements the accelerometer-gyrometer measurements
+ *
+ *
+ *
+ * \details
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI AccelerometerGyrometer : public AlgebraicSensor,
-        protected algorithm::LinearAcceleration,
-        protected algorithm::RotationVelocity
-    {
-    public:
-        AccelerometerGyrometer();
+class STATE_OBSERVATION_DLLAPI AccelerometerGyrometer : public AlgebraicSensor,
+                                                        protected algorithm::LinearAcceleration,
+                                                        protected algorithm::RotationVelocity
+{
+public:
+  AccelerometerGyrometer();
 
-        ///Virtual destructor
-        virtual ~AccelerometerGyrometer(){}
+  /// Virtual destructor
+  virtual ~AccelerometerGyrometer() {}
 
+  void setMatrixMode(bool matrixMode);
 
+protected:
+  /// Gets the state vector Size
+  virtual Index getStateSize_() const;
 
-        void setMatrixMode(bool matrixMode);
+  /// Gets the measurements vector size
+  virtual Index getMeasurementSize_() const;
 
+  virtual Vector computeNoiselessMeasurement_();
 
-    protected:
-        ///Gets the state vector Size
-        virtual Index getStateSize_() const;
+  Matrix3 r_;
+  Vector3 acc_;
+  Vector3 omega_;
+  Vector output_;
 
-        ///Gets the measurements vector size
-        virtual Index getMeasurementSize_() const;
+  bool matrixMode_;
 
+  static const Index stateSize_ = 10;
+  static const Index stateSizeMatrix_ = 15;
 
-        virtual Vector computeNoiselessMeasurement_();
+  static const Index measurementSize_ = 6;
 
-        Matrix3 r_;
-        Vector3 acc_;
-        Vector3 omega_;
-        Vector output_;
+  Index currentStateSize_;
+};
 
-        bool matrixMode_;
+} // namespace stateObservation
 
-        static const Index stateSize_= 10;
-        static const Index stateSizeMatrix_= 15;
-
-        static const Index measurementSize_=6;
-
-        Index currentStateSize_;
-
-    };
-
-}
-
-#endif //SIMULATIONACCELEROMETERGYROMETERSENSORHPP
+#endif // SIMULATIONACCELEROMETERGYROMETERSENSORHPP

--- a/include/state-observation/sensors-simulation/algebraic-sensor.hpp
+++ b/include/state-observation/sensors-simulation/algebraic-sensor.hpp
@@ -7,94 +7,90 @@
  *
  */
 
-
-
 #ifndef SIMULATIONALGEBRAICSENSORHPP
 #define SIMULATIONALGEBRAICSENSORHPP
 
-#include <Eigen/Core>
 #include <boost/assert.hpp>
+#include <Eigen/Core>
 
 #include <state-observation/api.h>
 #include <state-observation/sensors-simulation/sensor-base.hpp>
 
 namespace stateObservation
 {
-    /**
-     * \class  AlgebraicSensor
-     * \brief  The base class for algebraic sensors. Algebraic sensors are sensors
-     *         which depend only on the state value and the current time
-     *          and do not have internal dynamics
-     *         (or a dynamics which converges fast enough to be ignored). This class
-     *         implements mostly the containers and the interface to algebraic sensors.
-     *         Algebraic sensors must be derived from this class.
-     *
-     * \details
-     *
-     */
+/**
+ * \class  AlgebraicSensor
+ * \brief  The base class for algebraic sensors. Algebraic sensors are sensors
+ *         which depend only on the state value and the current time
+ *          and do not have internal dynamics
+ *         (or a dynamics which converges fast enough to be ignored). This class
+ *         implements mostly the containers and the interface to algebraic sensors.
+ *         Algebraic sensors must be derived from this class.
+ *
+ * \details
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI AlgebraicSensor: public SensorBase
-    {
-    public:
-        /// Default constructor
-        AlgebraicSensor();
+class STATE_OBSERVATION_DLLAPI AlgebraicSensor : public SensorBase
+{
+public:
+  /// Default constructor
+  AlgebraicSensor();
 
-        ///virtual destructor
-        virtual ~AlgebraicSensor(){}
+  /// virtual destructor
+  virtual ~AlgebraicSensor() {}
 
-        ///gets the measurement of the current time. We can choose to consider
-        ///noise or not (default is noisy)
-        virtual Vector getMeasurements(bool noisy=true);
+  /// gets the measurement of the current time. We can choose to consider
+  /// noise or not (default is noisy)
+  virtual Vector getMeasurements(bool noisy = true);
 
-        ///Sets the value of the state at instant k
-        virtual void setState(const Vector & state, TimeIndex k);
+  /// Sets the value of the state at instant k
+  virtual void setState(const Vector & state, TimeIndex k);
 
-        ///gets the current time
-        virtual TimeIndex getTime() const;
+  /// gets the current time
+  virtual TimeIndex getTime() const;
 
-        ///gets the state vector size. Pure virtual method.
-        virtual Index getStateSize() const;
+  /// gets the state vector size. Pure virtual method.
+  virtual Index getStateSize() const;
 
-        ///get the size of the measurements. Pure virtual method.
-        virtual Index getMeasurementSize() const;
+  /// get the size of the measurements. Pure virtual method.
+  virtual Index getMeasurementSize() const;
 
-        ///concatenates the n last components of the state in the measurement
-        ///(useful when the measurements are already computed or
-        ///when they come from external source)
-        virtual Index concatenateWithInput( Index n);
+  /// concatenates the n last components of the state in the measurement
+  ///(useful when the measurements are already computed or
+  /// when they come from external source)
+  virtual Index concatenateWithInput(Index n);
 
-    protected:
-        ///the actual algorithm for the computation of the measurements, must
-        ///be overloaded to implement any sensor
-        virtual Vector computeNoiselessMeasurement_()=0;
+protected:
+  /// the actual algorithm for the computation of the measurements, must
+  /// be overloaded to implement any sensor
+  virtual Vector computeNoiselessMeasurement_() = 0;
 
-        virtual Index getStateSize_() const=0;
+  virtual Index getStateSize_() const = 0;
 
-        virtual Index getMeasurementSize_() const=0;
+  virtual Index getMeasurementSize_() const = 0;
 
+  Vector computeNoisyMeasurement_();
 
-        Vector computeNoisyMeasurement_();
+  virtual void checkState_(const Vector &);
 
-        virtual void checkState_(const Vector &);
+  TimeIndex time_;
 
-        TimeIndex time_;
+  Index concat_;
 
-        Index concat_;
+  Vector state_;
 
-        Vector state_;
+  Vector directInputToOutput_;
 
-        Vector directInputToOutput_;
+  bool storedNoisyMeasurement_;
 
-        bool storedNoisyMeasurement_;
+  Vector noisyMeasurement_;
 
-        Vector noisyMeasurement_;
+  bool storedNoiselessMeasurement_;
 
-        bool storedNoiselessMeasurement_;
+  Vector noiselessMeasurement_;
+};
 
-        Vector noiselessMeasurement_;
+} // namespace stateObservation
 
-    };
-
-}
-
-#endif //SIMULATIONALGEBRAICSENSORHPP
+#endif // SIMULATIONALGEBRAICSENSORHPP

--- a/include/state-observation/sensors-simulation/algorithm/linear-acceleration.hpp
+++ b/include/state-observation/sensors-simulation/algorithm/linear-acceleration.hpp
@@ -9,8 +9,6 @@
  *
  */
 
-
-
 #ifndef SENSORALGORITHMSLINEARACCELERATIONHPP
 #define SENSORALGORITHMSLINEARACCELERATIONHPP
 
@@ -19,28 +17,27 @@
 
 namespace stateObservation
 {
-    namespace algorithm
-    {
-        /**
-         * \class LinearAcceleration
-         * \brief Implements the measurements given by an accelerometer.
-         *
-         */
+namespace algorithm
+{
+/**
+ * \class LinearAcceleration
+ * \brief Implements the measurements given by an accelerometer.
+ *
+ */
 
-        class STATE_OBSERVATION_DLLAPI LinearAcceleration
-        {
-        public:
-            ///virtual destructor
-            virtual ~LinearAcceleration(){}
+class STATE_OBSERVATION_DLLAPI LinearAcceleration
+{
+public:
+  /// virtual destructor
+  virtual ~LinearAcceleration() {}
 
-            ///The acceleration measurement in the local frame represented by the orientation Matrix
-            Vector3 accelerationMeasure(const Vector3 & acceleration, const Matrix3 & orientation) const;
+  /// The acceleration measurement in the local frame represented by the orientation Matrix
+  Vector3 accelerationMeasure(const Vector3 & acceleration, const Matrix3 & orientation) const;
 
-        protected:
+protected:
+};
+} // namespace algorithm
 
-        };
-    }
+} // namespace stateObservation
 
-}
-
-#endif //SENSORALGORITHMSLINEARACCELERATIONHPP
+#endif // SENSORALGORITHMSLINEARACCELERATIONHPP

--- a/include/state-observation/sensors-simulation/algorithm/magnetic-field.hpp
+++ b/include/state-observation/sensors-simulation/algorithm/magnetic-field.hpp
@@ -9,8 +9,6 @@
  *
  */
 
-
-
 #ifndef SENSORALGORITHMSMAGNETICFIELDHPP
 #define SENSORALGORITHMSMAGNETICFIELDHPP
 
@@ -19,31 +17,30 @@
 
 namespace stateObservation
 {
-    namespace algorithm
-    {
-        /**
-         * \class MagneticField
-         * \brief Implements the measurements given by an magnetometer.
-         *
-         */
+namespace algorithm
+{
+/**
+ * \class MagneticField
+ * \brief Implements the measurements given by an magnetometer.
+ *
+ */
 
-        class STATE_OBSERVATION_DLLAPI MagneticField
-        {
-        public:
+class STATE_OBSERVATION_DLLAPI MagneticField
+{
+public:
+  MagneticField();
 
-            MagneticField();
+  /// virtual destructor
+  virtual ~MagneticField() {}
 
-            ///virtual destructor
-            virtual ~MagneticField(){}
+  /// The magnetic field measurement in the local frame represented by the orientation Matrix
+  Vector3 magneticFieldMeasure(const Matrix3 & orientation) const;
 
-            ///The magnetic field measurement in the local frame represented by the orientation Matrix
-            Vector3 magneticFieldMeasure(const Matrix3 & orientation) const;
+private:
+  Vector3 earthLocalMagneticField_;
+};
+} // namespace algorithm
 
-        private:
-            Vector3 earthLocalMagneticField_;
-        };
-    }
+} // namespace stateObservation
 
-}
-
-#endif //SENSORALGORITHMSLINEARACCELERATIONHPP
+#endif // SENSORALGORITHMSLINEARACCELERATIONHPP

--- a/include/state-observation/sensors-simulation/algorithm/rotation-velocity.hpp
+++ b/include/state-observation/sensors-simulation/algorithm/rotation-velocity.hpp
@@ -9,8 +9,6 @@
  *
  */
 
-
-
 #ifndef SENSORALGORITHMSROTATIONVELOCITYHPP
 #define SENSORALGORITHMSROTATIONVELOCITYHPP
 
@@ -19,28 +17,27 @@
 
 namespace stateObservation
 {
-     namespace algorithm
-    {
-        /**
-         * \class  RotationVelocity
-         * \brief Implements the gyrometer measurement algorithm
-         *
-         */
+namespace algorithm
+{
+/**
+ * \class  RotationVelocity
+ * \brief Implements the gyrometer measurement algorithm
+ *
+ */
 
-        class STATE_OBSERVATION_DLLAPI RotationVelocity
-        {
-        public:
-            ///virtual destructor
-            virtual ~RotationVelocity(){}
+class STATE_OBSERVATION_DLLAPI RotationVelocity
+{
+public:
+  /// virtual destructor
+  virtual ~RotationVelocity() {}
 
-            ///The angular velocity measurement in the local frame represented by the orientation Matrix
-            Vector3 rotationVelocityMeasure(const Vector3 & angVelocityVector, const Matrix3 & orientation) const;
+  /// The angular velocity measurement in the local frame represented by the orientation Matrix
+  Vector3 rotationVelocityMeasure(const Vector3 & angVelocityVector, const Matrix3 & orientation) const;
 
-        protected:
+protected:
+};
+} // namespace algorithm
 
-        };
-    }
+} // namespace stateObservation
 
-}
-
-#endif //SENSORALGORITHMSROTATIONVELOCITYHPP
+#endif // SENSORALGORITHMSROTATIONVELOCITYHPP

--- a/include/state-observation/sensors-simulation/sensor-base.hpp
+++ b/include/state-observation/sensors-simulation/sensor-base.hpp
@@ -7,78 +7,71 @@
  *
  */
 
-
-
 #ifndef SIMULATIONSENSORBASEHPP
 #define SIMULATIONSENSORBASEHPP
 
-#include <Eigen/Core>
 #include <boost/assert.hpp>
+#include <Eigen/Core>
 
 #include <state-observation/api.h>
 #include <state-observation/noise/noise-base.hpp>
 
 namespace stateObservation
 {
-    /**
-     * \class  SensorBase
-     * \brief  The base class for sensors. This must be derived to implement a
-     *         sensor
-     *
-     * \details
-     *
-     */
+/**
+ * \class  SensorBase
+ * \brief  The base class for sensors. This must be derived to implement a
+ *         sensor
+ *
+ * \details
+ *
+ */
 
-    class STATE_OBSERVATION_DLLAPI SensorBase
-    {
-    public:
-        ///default constructor
-        SensorBase();
+class STATE_OBSERVATION_DLLAPI SensorBase
+{
+public:
+  /// default constructor
+  SensorBase();
 
-        ///virtual destructor
-        virtual ~SensorBase(){}
+  /// virtual destructor
+  virtual ~SensorBase() {}
 
-        ///gets the measurement of the current time. We can choose to consider
-        ///noise or not (default is noisy)
-        virtual Vector getMeasurements(bool noisy=true)=0;
+  /// gets the measurement of the current time. We can choose to consider
+  /// noise or not (default is noisy)
+  virtual Vector getMeasurements(bool noisy = true) = 0;
 
-        ///Sets the value of the state at instant k
-        virtual void setState(const Vector & state, TimeIndex k)=0;
+  /// Sets the value of the state at instant k
+  virtual void setState(const Vector & state, TimeIndex k) = 0;
 
-        ///Sets a pointer on the noise on the measurements. The class does NOT destroy the noise
-        ///when the destructor is called.
-        virtual void setNoise(NoiseBase *);
+  /// Sets a pointer on the noise on the measurements. The class does NOT destroy the noise
+  /// when the destructor is called.
+  virtual void setNoise(NoiseBase *);
 
-        ///gets the pointer on the measurements noise
-        virtual NoiseBase* getNoise() const;
+  /// gets the pointer on the measurements noise
+  virtual NoiseBase * getNoise() const;
 
-        ///removes the noise
-        virtual void resetNoise();
+  /// removes the noise
+  virtual void resetNoise();
 
-        ///gets the current time, pure virtual method
-        virtual TimeIndex getTime() const=0;
+  /// gets the current time, pure virtual method
+  virtual TimeIndex getTime() const = 0;
 
-        ///gets the state vector size. Pure virtual method.
-        virtual Index getStateSize() const=0;
+  /// gets the state vector size. Pure virtual method.
+  virtual Index getStateSize() const = 0;
 
-        ///get the size of the measurements. Pure virtual method.
-        virtual Index getMeasurementSize() const=0;
+  /// get the size of the measurements. Pure virtual method.
+  virtual Index getMeasurementSize() const = 0;
 
-        ///gets a zero vector of the size of a state vector
-        virtual Vector stateVectorZero() const;
+  /// gets a zero vector of the size of a state vector
+  virtual Vector stateVectorZero() const;
 
-        ///checks whether a vector is correctly sized or not
-        virtual bool checkStateVector(const Vector &) const;
+  /// checks whether a vector is correctly sized or not
+  virtual bool checkStateVector(const Vector &) const;
 
+protected:
+  NoiseBase * noise_;
+};
 
-    protected:
+} // namespace stateObservation
 
-        NoiseBase *  noise_;
-
-    };
-
-
-
-}
-
-#endif //SIMULATIONSENSORBASEHPP
+#endif // SIMULATIONSENSORBASEHPP

--- a/include/state-observation/tools/definitions.hpp
+++ b/include/state-observation/tools/definitions.hpp
@@ -14,13 +14,13 @@
 
 //#define STATEOBSERVATION_VERBOUS_CONSTRUCTORS
 
-#include <vector>
+#include <chrono>
 #include <deque>
 #include <stdexcept>
-#include <chrono>
+#include <vector>
 
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-#   include <iostream>
+#  include <iostream>
 #endif
 
 #include <boost/assert.hpp>
@@ -36,542 +36,526 @@
 
 #include <state-observation/api.h>
 
-
 // basic file operations
 #include <fstream>
 
 namespace stateObservation
 {
-  ///Dynamic sized scalar vector
-  typedef Eigen::VectorXd Vector;
+/// Dynamic sized scalar vector
+typedef Eigen::VectorXd Vector;
 
-  ///1D Vector
-  typedef Eigen::Matrix<double,1,1> Vector1;
+/// 1D Vector
+typedef Eigen::Matrix<double, 1, 1> Vector1;
 
-  ///2d Vector
-  typedef Eigen::Matrix<double,2,1> Vector2;
+/// 2d Vector
+typedef Eigen::Matrix<double, 2, 1> Vector2;
 
-  ///3D vector
-  typedef Eigen::Vector3d Vector3;
+/// 3D vector
+typedef Eigen::Vector3d Vector3;
 
-  ///3D vector unaligned
-  typedef Eigen::Matrix<double, 3, 1, Eigen::DontAlign> Vector3Unaligned;
+/// 3D vector unaligned
+typedef Eigen::Matrix<double, 3, 1, Eigen::DontAlign> Vector3Unaligned;
 
-  ///4D vector
-  typedef Eigen::Vector4d Vector4;
+/// 4D vector
+typedef Eigen::Vector4d Vector4;
 
-  /// 6D vector
-  typedef Eigen::Matrix<double,6,1> Vector6;
+/// 6D vector
+typedef Eigen::Matrix<double, 6, 1> Vector6;
 
-  ///Dynamic sized Matrix
-  typedef Eigen::MatrixXd Matrix;
+/// Dynamic sized Matrix
+typedef Eigen::MatrixXd Matrix;
 
-  ///1D scalar Matrix
-  typedef Eigen::Matrix<double,1,1> Matrix1;
+/// 1D scalar Matrix
+typedef Eigen::Matrix<double, 1, 1> Matrix1;
 
-  ///2D scalar Matrix
-  typedef Eigen::Matrix2d Matrix2;
+/// 2D scalar Matrix
+typedef Eigen::Matrix2d Matrix2;
 
-  ///3x3 Scalar Matrix
-  typedef Eigen::Matrix3d Matrix3;
+/// 3x3 Scalar Matrix
+typedef Eigen::Matrix3d Matrix3;
 
-  ///3x3 Scalar Matrix Unaligned
-  typedef Eigen::Matrix<double, 3, 3, Eigen::DontAlign> Matrix3Unaligned;
+/// 3x3 Scalar Matrix Unaligned
+typedef Eigen::Matrix<double, 3, 3, Eigen::DontAlign> Matrix3Unaligned;
 
-  ///4x4 Scalar Matrix
-  typedef Eigen::Matrix4d Matrix4;
+/// 4x4 Scalar Matrix
+typedef Eigen::Matrix4d Matrix4;
 
-  ///6x6 Scalar Matrix
-  typedef Eigen::Matrix<double, 6, 6> Matrix6;
+/// 6x6 Scalar Matrix
+typedef Eigen::Matrix<double, 6, 6> Matrix6;
 
-  ///12x12 scalar Matrix
-  typedef Eigen::Matrix<double, 12, 12> Matrix12;
+/// 12x12 scalar Matrix
+typedef Eigen::Matrix<double, 12, 12> Matrix12;
 
-  ///Quaternion
-  typedef Eigen::Quaterniond Quaternion;
+/// Quaternion
+typedef Eigen::Quaterniond Quaternion;
 
-  ///Quaternion Unaligned
-  typedef Eigen::Quaternion<double, Eigen::DontAlign> QuaternionUnaligned;
+/// Quaternion Unaligned
+typedef Eigen::Quaternion<double, Eigen::DontAlign> QuaternionUnaligned;
 
-  ///Euler Axis/Angle representation of orientation
-  typedef Eigen::AngleAxis<double> AngleAxis;
+/// Euler Axis/Angle representation of orientation
+typedef Eigen::AngleAxis<double> AngleAxis;
 
-
-  typedef Eigen::Index Index;
-  typedef long int TimeIndex;
-  typedef Index TimeSize;
-
+typedef Eigen::Index Index;
+typedef long int TimeIndex;
+typedef Index TimeSize;
 
 #ifndef NDEBUG
-  static const bool isDebug=true;
+static const bool isDebug = true;
 #else
-  static const bool isDebug=false;
+static const bool isDebug = false;
 #endif // NDEBUG
 
-
 /// Debug item default value is just a way to give a default value to debug item
-///this was required by a compilation issue on Visual Studio
-template <typename T, const T defaultValue=T()>
+/// this was required by a compilation issue on Visual Studio
+template<typename T, const T defaultValue = T()>
 class DebugItemDefaultValue
 {
-  public:
-    static const T v;
+public:
+  static const T v;
 };
 
-template <typename T, const T defaultValue>
-    const T DebugItemDefaultValue<T,defaultValue>::v=defaultValue;
+template<typename T, const T defaultValue>
+const T DebugItemDefaultValue<T, defaultValue>::v = defaultValue;
 
 namespace detail
 {
-  typedef DebugItemDefaultValue<bool,true> defaultTrue;
+typedef DebugItemDefaultValue<bool, true> defaultTrue;
 
-  enum errorType
-  {
-    message,
-    exception,
-    exceptionAddr
-  };
+enum errorType
+{
+  message,
+  exception,
+  exceptionAddr
+};
 
-  template <errorType i = message, int dummy=0>
-  class DebugItemDefaultError
-  {
-  };
+template<errorType i = message, int dummy = 0>
+class DebugItemDefaultError
+{
+};
 
-  template <int dummy>
-  class DebugItemDefaultError<message, dummy>
-  {
-  public:
-    static const char* v;
-  };
+template<int dummy>
+class DebugItemDefaultError<message, dummy>
+{
+public:
+  static const char * v;
+};
 
-  template <int dummy>
-  class DebugItemDefaultError<exception, dummy>
-  {
-  public:
-    static const std::runtime_error v;
-  };
+template<int dummy>
+class DebugItemDefaultError<exception, dummy>
+{
+public:
+  static const std::runtime_error v;
+};
 
+template<int dummy>
+class DebugItemDefaultError<exceptionAddr, dummy>
+{
+public:
+  static const std::runtime_error * v;
+};
 
-  template <int dummy>
-  class DebugItemDefaultError<exceptionAddr, dummy>
-  {
-  public:
-    static const std::runtime_error * v;
-  };
-
-  template <int dummy>
-  const char * DebugItemDefaultError<message, dummy>::v = "The Object is not initialized. \
+template<int dummy>
+const char * DebugItemDefaultError<message, dummy>::v = "The Object is not initialized. \
        If this happened during initialization then run command chckitm_set() \
        to switch it to set. And if the initialization is incomplete, run \
        chckitm_reset() afterwards.";
 
-  template <int dummy>
-  const std::runtime_error DebugItemDefaultError< exception, dummy>::v = std::runtime_error(DebugItemDefaultError<message>::v);
+template<int dummy>
+const std::runtime_error DebugItemDefaultError<exception, dummy>::v =
+    std::runtime_error(DebugItemDefaultError<message>::v);
 
-  template <int dummy>
-  const std::runtime_error * DebugItemDefaultError<exceptionAddr, dummy>::v = &DebugItemDefaultError<exception>::v;
+template<int dummy>
+const std::runtime_error * DebugItemDefaultError<exceptionAddr, dummy>::v = &DebugItemDefaultError<exception>::v;
 
+typedef DebugItemDefaultError<message> defaultErrorMSG;
+typedef DebugItemDefaultError<exception> defaultException;
+typedef DebugItemDefaultError<exceptionAddr> defaultExceptionAddr;
 
+void STATE_OBSERVATION_DLLAPI defaultSum(const Vector & stateVector, const Vector & tangentVector, Vector & sum);
+void STATE_OBSERVATION_DLLAPI defaultDifference(const Vector & stateVector1,
+                                                const Vector & stateVector2,
+                                                Vector & difference);
 
-
-  typedef DebugItemDefaultError<message> defaultErrorMSG;
-  typedef DebugItemDefaultError<exception> defaultException;
-  typedef DebugItemDefaultError<exceptionAddr> defaultExceptionAddr;
-
-  void STATE_OBSERVATION_DLLAPI defaultSum(const  Vector& stateVector, const Vector& tangentVector, Vector& sum);
-  void STATE_OBSERVATION_DLLAPI defaultDifference(const  Vector& stateVector1, const Vector& stateVector2, Vector& difference);
-
-}
-
+} // namespace detail
 
 /// Debug item is an item that exists when the debug variable is true,
-///otherwise it is empty and returns only the default value
-  template <typename T, typename defaultValue = DebugItemDefaultValue<T>, bool debug=true>
-  class DebugItem
+/// otherwise it is empty and returns only the default value
+template<typename T, typename defaultValue = DebugItemDefaultValue<T>, bool debug = true>
+class DebugItem
+{
+public:
+  DebugItem() : b_(defaultValue::v) {}
+  explicit DebugItem(const T & v) : b_(v) {}
+  inline T & operator=(T v)
   {
-  public:
-    DebugItem():b_(defaultValue::v) {}
-    explicit DebugItem(const T& v):b_(v) {}
-    inline T& operator=(T v)
-    {
-      return b_=v;
-    }
-    inline operator T()const
-    {
-      return b_;
-    }
-    inline T set(const T& v)
-    {
-      return b_=v;
-    }
-    T get()const
-    {
-      return b_;
-    }
-  private:
-    T b_;
-
-  };
-
-  ///this specialization contains no object
-    template <typename T, typename defaultValue >
-  class DebugItem<T,defaultValue,false>
+    return b_ = v;
+  }
+  inline operator T() const
   {
-  public:
-    DebugItem() {}
-    explicit DebugItem(T ) {}
-    inline T& operator=(T v)
-    {
-      /// I am not sure what is the best behaviour, is it to return v ot defaultValue::v?
-      return v;
-    }
-    inline operator T() const
-    {
-      return defaultValue::v;
-    }
-    inline T set(const T& )
-    {
-      return defaultValue::v;
-    }
-    T get()const
-    {
-      return defaultValue::v;
-    }
-  private:
-     ///no object
-  };
-
-  ///this is simply a structure allowing for automatically verifying that
-  /// the item has been initialized or not. The chckitm_reset() function allows to
-  /// set it back to "not initialized" state.
-  /// -lazy means that the "set" value is true all the time if NDEBUG is defined
-  /// -alwaysCheck means that the check is always performed and throws exception
-  /// if it fails. Otherwise, the check is performed only for debug.
-  /// warning, this has no effect if lazy is set to true
-  /// - assertion means that an assertion will be introduced for the check.
-  /// - eigenAlignedNew should be set to true if any alignment is required for the
-  /// new operator (see eigen documentation)
-  template <typename T, bool lazy=false, bool alwaysCheck = false,
-                  bool assertion=true, bool eigenAlignedNew=false>
-  class CheckedItem
+    return b_;
+  }
+  inline T set(const T & v)
   {
-  public:
-
-    /// The parameter initialize sets whether the isSet() parameter is initialized to false
-    CheckedItem( bool initialize = true);
-    explicit CheckedItem(const T&);
-    CheckedItem( const CheckedItem &);
-    virtual ~CheckedItem() {}
-
-    inline CheckedItem& operator=(const CheckedItem & );
-    inline T& operator=(const T&);
-    inline operator T() const ;
-    inline operator const T&() const ;
-
-    inline T chckitm_getValue() const;
-
-    inline T& operator()();
-    inline const T& operator()() const;
-
-    inline bool isSet() const;
-    inline void reset();
-
-    /// set the value of the initialization check boolean
-    inline void set(bool value);
-
-    void setAssertMessage(std::string s);
-    void setExceptionPtr(std::exception* e);
-
-    /// allows to set the initialization boolean to true and give a reference
-    /// to the object with the same instruction
-    /// should be used to initialize the object without using the
-    /// assignment operator
-    inline T& set();
-
-  protected:
-
-    static const bool do_check_ = !lazy || isDebug;
-    static const bool do_assert_ = do_check_ && assertion;
-    static const bool do_exception_ = do_check_ && !assertion;
-
-    typedef DebugItem<bool,detail::defaultTrue,do_check_> IsSet;
-    typedef DebugItem<const char*,detail::defaultErrorMSG, do_assert_> AssertMsg;
-    typedef DebugItem<const std::exception*,detail::defaultExceptionAddr,
-                                                    do_exception_> ExceptionPtr;
-
-
-
-    IsSet isSet_;
-    AssertMsg assertMsg_;
-    ExceptionPtr exceptionPtr_;
-
-    bool chckitm_check_() const; /// this can throw(std::exception)
-    T v_;
-  public:
-
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF(eigenAlignedNew)
-  };
-
-  typedef CheckedItem<Matrix3,false,false,true,true> CheckedMatrix3;
-  typedef CheckedItem<Matrix6,false,false,true,true> CheckedMatrix6;
-  typedef CheckedItem<Matrix12,false,false,true,true> CheckedMatrix12;
-  typedef CheckedItem<Vector3,false,false,true,true> CheckedVector3;
-  typedef CheckedItem<Vector6,false,false,true,true> CheckedVector6;
-  typedef CheckedItem<Quaternion,false,false,true,true> CheckedQuaternion;
-
-
-  /**
-   * \class    IndexedMatrixT
-   * \brief    This class describes a structure composed by a matrix
-   *           of a given size and a time-index parameter. It can tell also if
-   *           it is initialized or not.
-   *
-   *
-   */
-  template <typename MatrixType=Matrix, bool lazy = false>
-  class IndexedMatrixT:
-    protected DebugItem<bool,detail::defaultTrue,!lazy || isDebug>
+    return b_ = v;
+  }
+  T get() const
   {
-    typedef DebugItem<bool,detail::defaultTrue,!lazy || isDebug> IsSet;
-  public:
-    ///Default constructor
-    IndexedMatrixT();
-
-    ///A constructor with a given matrix value and a time index
-    IndexedMatrixT(const MatrixType& v, TimeIndex k);
-
-    ///Set the value of the matrix and the time sample
-    inline MatrixType set(const MatrixType& v,TimeIndex k);
-
-    ///Switch the vector to "initialized" state
-    inline void set(bool value=true);
-
-    ///set the index of the matrix
-    inline void setIndex(TimeIndex index);
-
-    ///Get the matrix value
-    inline const MatrixType & operator()() const;
-
-    ///Get the matrix value
-    inline MatrixType & operator()();
-
-    ///Get the time index
-    inline TimeIndex getTime() const;
-
-    ///Says whether the matrix is initialized or not
-    inline bool isSet() const;
-
-    ///Switch off the initalization flag, the value is no longer accessible
-    inline void reset();
-
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-  protected:
-    ///Checks whether the matrix is set or not (assert)
-    ///does nothing in release mode
-    inline bool check_() const;
-    TimeIndex k_;
-    MatrixType v_;
-  };
-
-  typedef IndexedMatrixT<Matrix> IndexedMatrix;
-  typedef IndexedMatrixT<Vector> IndexedVector;
-  typedef IndexedMatrixT<Vector3> IndexedVector3;
-  typedef IndexedMatrixT<Matrix3> IndexedMatrix3;
-
-  /**
-   * \class    IndexedMatrixArray
-   * \brief    This class describes a structure that enables to store array of matrices
-   *           with time indexation.
-   *
-   */
-
-  template <typename MatrixType=Matrix, typename Allocator = std::allocator<MatrixType>>
-  class IndexedMatrixArrayT
-  {
-  public:
-    ///Default constructor
-    IndexedMatrixArrayT();
-
-
-
-    typedef std::vector< MatrixType, Allocator > Array;
-
-    ///Sets the vector v at the time index k
-    ///It checks the time index, the array must have contiguous indexes
-    ///It can be used to push a value into the back of the array
-    inline void setValue(const MatrixType& v, TimeIndex  k);
-
-    ///Pushes back the matrix to the array, the new value will take the next time
-    inline void pushBack(const MatrixType& v);
-
-    ///removes the first (oldest) element of the array
-    inline void popFront();
-
-    ///gets the value with the given time index
-    inline MatrixType operator[](TimeIndex index) const;
-
-    ///gets the value with the given time index, non const version
-    inline MatrixType  & operator[](TimeIndex index);
-
-    ///gets the first value
-    inline const MatrixType & front() const;
-
-    ///gets the first value
-    inline MatrixType& front();
-
-    ///gets the last value
-    inline const MatrixType & back() const;
-
-    ///gets the last value
-    inline MatrixType & back();
-
-    ///removes all the elements with larger indexes than timeIndex
-    void truncateAfter(TimeIndex timeIndex);
-
-    ///removes all the elements with smaller indexes than timeIndex
-    void truncateBefore(TimeIndex timeIndex);
-
-    ///resizes the array
-    inline void resize(TimeSize i, const MatrixType & m= MatrixType());
-
-    ///Get the time index
-    inline TimeIndex getLastIndex() const;
-
-    ///Get the time index of the next value that will be pushed back
-    /// Can be used in for loops
-    inline TimeIndex getNextIndex() const;
-
-    ///Set the time index of the last element
-    inline TimeIndex setLastIndex(int index);
-
-    ///Get the time index
-    inline TimeIndex getFirstIndex() const;
-
-    ///set the time index of the first element
-    inline TimeIndex setFirstIndex(int index);
-
-    inline TimeSize size() const;
-
-    ///Resets the array to initial state
-    ///the value is no longer accessible
-    inline void reset();
-
-    ///Clears the vector but keeps the last index
-    inline void clear();
-
-    ///converts the array into a standard vector
-    Array getArray() const;
-
-    ///checks whether the index is present in the array
-    inline bool checkIndex(TimeIndex k) const;
-
-    ///gets the array from a file
-    ///the line starts with the time index and then the matrix is read
-    ///row by row
-    ///WARNING: this resets the array
-    void readFromFile(const char * filename, Index rows, Index cols=1, bool withTimeStamp = true);
-    void readFromFile(const std::string &  filename, Index rows, Index cols=1, bool withTimeStamp = true);
-
-    ///gets the array from a file
-    ///the line starts with the time index and then every line of the file
-    /// is converted into a vector
-    ///WARNING: this resets the array
-    void readVectorsFromFile(const std::string &  filename, bool withTimeStamp = true );
-    void readVectorsFromFile(const char * filename, bool withTimeStamp = true );
-
-    ///write the array in a a file
-    ///the line starts with the time index and then the matrix is described
-    ///row by row
-    /// When clear is set, the array is cleared but the time index is conserved
-    /// When append is set to true, the output is appended to file
-    void writeInFile(const char * filename, bool clear=false, bool append =false);
-
-    ///write the array in a a file
-    ///the line starts with the time index and then the matrix is described
-    ///row by row
-    /// When clear is set, the array is cleared but the time index is conserved
-    /// When append is set to true, the output is appended to file
-    void writeInFile(const std::string & filename, bool clear=false, bool append =false);
-
-  protected:
-    typedef std::deque< MatrixType, Allocator > Deque;
-
-    ///Asserts that the index is present in the array
-    ///does nothing in release mode
-    inline void check_(TimeIndex time) const;
-
-    ///Asserts that the array is not empty
-    ///does nothing in release mode
-    inline void check_() const;
-
-    ///Asserts that the given time can be pushed at the back of the vector
-    ///does nothing in release mode
-    inline void checkNext_(TimeIndex time) const;
-
-    TimeIndex k_;
-
-    Deque v_;
-
-  };
-
-  typedef IndexedMatrixArrayT<Matrix> IndexedMatrixArray;
-  typedef IndexedMatrixArrayT<Vector> IndexedVectorArray;
-
-
-  namespace cst
-  {
-    constexpr double gravityConstant = 9.8;
-
-    ///Gravity Vector along Z
-    const Vector gravity= gravityConstant * Vector3::UnitZ();
-
-    ///angles considered Zero
-    constexpr double epsilonAngle=1e-16;
-
+    return b_;
   }
 
-  typedef boost::timer::auto_cpu_timer auto_cpu_timer;
-  typedef boost::timer::cpu_timer cpu_timer;
-  typedef boost::timer::cpu_timer cpu_times;
+private:
+  T b_;
+};
 
-  namespace tools
+/// this specialization contains no object
+template<typename T, typename defaultValue>
+class DebugItem<T, defaultValue, false>
+{
+public:
+  DebugItem() {}
+  explicit DebugItem(T) {}
+  inline T & operator=(T v)
   {
-    struct STATE_OBSERVATION_DLLAPI SimplestStopwatch
-    {
-      /** Always pick a steady clock */
-      using clock = typename std::conditional<std::chrono::high_resolution_clock::is_steady,
-                                        std::chrono::high_resolution_clock,
-                                        std::chrono::steady_clock>::type;
-      using time_ns = clock::time_point;
-      time_ns startTime;
-
-      inline void start()
-      {
-        startTime = clock::now();
-      }
-
-      ///provides the time since the start
-      ///the value is in nanoseconds
-      inline double stop()
-      {
-        auto elapsed = clock::now() - startTime;
-        return static_cast<double>(elapsed.count());
-      }
-    };
-
-    std::string STATE_OBSERVATION_DLLAPI matrixToString(const Matrix& mat);
-
-    std::string STATE_OBSERVATION_DLLAPI vectorToString(const Vector& v);
-
-    Matrix STATE_OBSERVATION_DLLAPI stringToMatrix(const std::string& str, Index rows, Index cols);
-
-    Vector STATE_OBSERVATION_DLLAPI stringToVector(const std::string& str, Index length);
-
-    Vector STATE_OBSERVATION_DLLAPI stringToVector(const std::string& str);
+    /// I am not sure what is the best behaviour, is it to return v ot defaultValue::v?
+    return v;
   }
+  inline operator T() const
+  {
+    return defaultValue::v;
+  }
+  inline T set(const T &)
+  {
+    return defaultValue::v;
+  }
+  T get() const
+  {
+    return defaultValue::v;
+  }
+
+private:
+  /// no object
+};
+
+/// this is simply a structure allowing for automatically verifying that
+/// the item has been initialized or not. The chckitm_reset() function allows to
+/// set it back to "not initialized" state.
+/// -lazy means that the "set" value is true all the time if NDEBUG is defined
+/// -alwaysCheck means that the check is always performed and throws exception
+/// if it fails. Otherwise, the check is performed only for debug.
+/// warning, this has no effect if lazy is set to true
+/// - assertion means that an assertion will be introduced for the check.
+/// - eigenAlignedNew should be set to true if any alignment is required for the
+/// new operator (see eigen documentation)
+template<typename T, bool lazy = false, bool alwaysCheck = false, bool assertion = true, bool eigenAlignedNew = false>
+class CheckedItem
+{
+public:
+  /// The parameter initialize sets whether the isSet() parameter is initialized to false
+  CheckedItem(bool initialize = true);
+  explicit CheckedItem(const T &);
+  CheckedItem(const CheckedItem &);
+  virtual ~CheckedItem() {}
+
+  inline CheckedItem & operator=(const CheckedItem &);
+  inline T & operator=(const T &);
+  inline operator T() const;
+  inline operator const T &() const;
+
+  inline T chckitm_getValue() const;
+
+  inline T & operator()();
+  inline const T & operator()() const;
+
+  inline bool isSet() const;
+  inline void reset();
+
+  /// set the value of the initialization check boolean
+  inline void set(bool value);
+
+  void setAssertMessage(std::string s);
+  void setExceptionPtr(std::exception * e);
+
+  /// allows to set the initialization boolean to true and give a reference
+  /// to the object with the same instruction
+  /// should be used to initialize the object without using the
+  /// assignment operator
+  inline T & set();
+
+protected:
+  static const bool do_check_ = !lazy || isDebug;
+  static const bool do_assert_ = do_check_ && assertion;
+  static const bool do_exception_ = do_check_ && !assertion;
+
+  typedef DebugItem<bool, detail::defaultTrue, do_check_> IsSet;
+  typedef DebugItem<const char *, detail::defaultErrorMSG, do_assert_> AssertMsg;
+  typedef DebugItem<const std::exception *, detail::defaultExceptionAddr, do_exception_> ExceptionPtr;
+
+  IsSet isSet_;
+  AssertMsg assertMsg_;
+  ExceptionPtr exceptionPtr_;
+
+  bool chckitm_check_() const; /// this can throw(std::exception)
+  T v_;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF(eigenAlignedNew)
+};
+
+typedef CheckedItem<Matrix3, false, false, true, true> CheckedMatrix3;
+typedef CheckedItem<Matrix6, false, false, true, true> CheckedMatrix6;
+typedef CheckedItem<Matrix12, false, false, true, true> CheckedMatrix12;
+typedef CheckedItem<Vector3, false, false, true, true> CheckedVector3;
+typedef CheckedItem<Vector6, false, false, true, true> CheckedVector6;
+typedef CheckedItem<Quaternion, false, false, true, true> CheckedQuaternion;
+
+/**
+ * \class    IndexedMatrixT
+ * \brief    This class describes a structure composed by a matrix
+ *           of a given size and a time-index parameter. It can tell also if
+ *           it is initialized or not.
+ *
+ *
+ */
+template<typename MatrixType = Matrix, bool lazy = false>
+class IndexedMatrixT : protected DebugItem<bool, detail::defaultTrue, !lazy || isDebug>
+{
+  typedef DebugItem<bool, detail::defaultTrue, !lazy || isDebug> IsSet;
+
+public:
+  /// Default constructor
+  IndexedMatrixT();
+
+  /// A constructor with a given matrix value and a time index
+  IndexedMatrixT(const MatrixType & v, TimeIndex k);
+
+  /// Set the value of the matrix and the time sample
+  inline MatrixType set(const MatrixType & v, TimeIndex k);
+
+  /// Switch the vector to "initialized" state
+  inline void set(bool value = true);
+
+  /// set the index of the matrix
+  inline void setIndex(TimeIndex index);
+
+  /// Get the matrix value
+  inline const MatrixType & operator()() const;
+
+  /// Get the matrix value
+  inline MatrixType & operator()();
+
+  /// Get the time index
+  inline TimeIndex getTime() const;
+
+  /// Says whether the matrix is initialized or not
+  inline bool isSet() const;
+
+  /// Switch off the initalization flag, the value is no longer accessible
+  inline void reset();
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+protected:
+  /// Checks whether the matrix is set or not (assert)
+  /// does nothing in release mode
+  inline bool check_() const;
+  TimeIndex k_;
+  MatrixType v_;
+};
+
+typedef IndexedMatrixT<Matrix> IndexedMatrix;
+typedef IndexedMatrixT<Vector> IndexedVector;
+typedef IndexedMatrixT<Vector3> IndexedVector3;
+typedef IndexedMatrixT<Matrix3> IndexedMatrix3;
+
+/**
+ * \class    IndexedMatrixArray
+ * \brief    This class describes a structure that enables to store array of matrices
+ *           with time indexation.
+ *
+ */
+
+template<typename MatrixType = Matrix, typename Allocator = std::allocator<MatrixType>>
+class IndexedMatrixArrayT
+{
+public:
+  /// Default constructor
+  IndexedMatrixArrayT();
+
+  typedef std::vector<MatrixType, Allocator> Array;
+
+  /// Sets the vector v at the time index k
+  /// It checks the time index, the array must have contiguous indexes
+  /// It can be used to push a value into the back of the array
+  inline void setValue(const MatrixType & v, TimeIndex k);
+
+  /// Pushes back the matrix to the array, the new value will take the next time
+  inline void pushBack(const MatrixType & v);
+
+  /// removes the first (oldest) element of the array
+  inline void popFront();
+
+  /// gets the value with the given time index
+  inline MatrixType operator[](TimeIndex index) const;
+
+  /// gets the value with the given time index, non const version
+  inline MatrixType & operator[](TimeIndex index);
+
+  /// gets the first value
+  inline const MatrixType & front() const;
+
+  /// gets the first value
+  inline MatrixType & front();
+
+  /// gets the last value
+  inline const MatrixType & back() const;
+
+  /// gets the last value
+  inline MatrixType & back();
+
+  /// removes all the elements with larger indexes than timeIndex
+  void truncateAfter(TimeIndex timeIndex);
+
+  /// removes all the elements with smaller indexes than timeIndex
+  void truncateBefore(TimeIndex timeIndex);
+
+  /// resizes the array
+  inline void resize(TimeSize i, const MatrixType & m = MatrixType());
+
+  /// Get the time index
+  inline TimeIndex getLastIndex() const;
+
+  /// Get the time index of the next value that will be pushed back
+  /// Can be used in for loops
+  inline TimeIndex getNextIndex() const;
+
+  /// Set the time index of the last element
+  inline TimeIndex setLastIndex(int index);
+
+  /// Get the time index
+  inline TimeIndex getFirstIndex() const;
+
+  /// set the time index of the first element
+  inline TimeIndex setFirstIndex(int index);
+
+  inline TimeSize size() const;
+
+  /// Resets the array to initial state
+  /// the value is no longer accessible
+  inline void reset();
+
+  /// Clears the vector but keeps the last index
+  inline void clear();
+
+  /// converts the array into a standard vector
+  Array getArray() const;
+
+  /// checks whether the index is present in the array
+  inline bool checkIndex(TimeIndex k) const;
+
+  /// gets the array from a file
+  /// the line starts with the time index and then the matrix is read
+  /// row by row
+  /// WARNING: this resets the array
+  void readFromFile(const char * filename, Index rows, Index cols = 1, bool withTimeStamp = true);
+  void readFromFile(const std::string & filename, Index rows, Index cols = 1, bool withTimeStamp = true);
+
+  /// gets the array from a file
+  /// the line starts with the time index and then every line of the file
+  /// is converted into a vector
+  /// WARNING: this resets the array
+  void readVectorsFromFile(const std::string & filename, bool withTimeStamp = true);
+  void readVectorsFromFile(const char * filename, bool withTimeStamp = true);
+
+  /// write the array in a a file
+  /// the line starts with the time index and then the matrix is described
+  /// row by row
+  /// When clear is set, the array is cleared but the time index is conserved
+  /// When append is set to true, the output is appended to file
+  void writeInFile(const char * filename, bool clear = false, bool append = false);
+
+  /// write the array in a a file
+  /// the line starts with the time index and then the matrix is described
+  /// row by row
+  /// When clear is set, the array is cleared but the time index is conserved
+  /// When append is set to true, the output is appended to file
+  void writeInFile(const std::string & filename, bool clear = false, bool append = false);
+
+protected:
+  typedef std::deque<MatrixType, Allocator> Deque;
+
+  /// Asserts that the index is present in the array
+  /// does nothing in release mode
+  inline void check_(TimeIndex time) const;
+
+  /// Asserts that the array is not empty
+  /// does nothing in release mode
+  inline void check_() const;
+
+  /// Asserts that the given time can be pushed at the back of the vector
+  /// does nothing in release mode
+  inline void checkNext_(TimeIndex time) const;
+
+  TimeIndex k_;
+
+  Deque v_;
+};
+
+typedef IndexedMatrixArrayT<Matrix> IndexedMatrixArray;
+typedef IndexedMatrixArrayT<Vector> IndexedVectorArray;
+
+namespace cst
+{
+constexpr double gravityConstant = 9.8;
+
+/// Gravity Vector along Z
+const Vector gravity = gravityConstant * Vector3::UnitZ();
+
+/// angles considered Zero
+constexpr double epsilonAngle = 1e-16;
+
+} // namespace cst
+
+typedef boost::timer::auto_cpu_timer auto_cpu_timer;
+typedef boost::timer::cpu_timer cpu_timer;
+typedef boost::timer::cpu_timer cpu_times;
+
+namespace tools
+{
+struct STATE_OBSERVATION_DLLAPI SimplestStopwatch
+{
+  /** Always pick a steady clock */
+  using clock = typename std::conditional<std::chrono::high_resolution_clock::is_steady,
+                                          std::chrono::high_resolution_clock,
+                                          std::chrono::steady_clock>::type;
+  using time_ns = clock::time_point;
+  time_ns startTime;
+
+  inline void start()
+  {
+    startTime = clock::now();
+  }
+
+  /// provides the time since the start
+  /// the value is in nanoseconds
+  inline double stop()
+  {
+    auto elapsed = clock::now() - startTime;
+    return static_cast<double>(elapsed.count());
+  }
+};
+
+std::string STATE_OBSERVATION_DLLAPI matrixToString(const Matrix & mat);
+
+std::string STATE_OBSERVATION_DLLAPI vectorToString(const Vector & v);
+
+Matrix STATE_OBSERVATION_DLLAPI stringToMatrix(const std::string & str, Index rows, Index cols);
+
+Vector STATE_OBSERVATION_DLLAPI stringToVector(const std::string & str, Index length);
+
+Vector STATE_OBSERVATION_DLLAPI stringToVector(const std::string & str);
+} // namespace tools
 
 #include <state-observation/tools/definitions.hxx>
-} //namespace stateObservation
+} // namespace stateObservation
 
-#endif //STATEOBSERVATIONDEFINITIONSHPP
+#endif // STATEOBSERVATIONDEFINITIONSHPP

--- a/include/state-observation/tools/hrp2.hpp
+++ b/include/state-observation/tools/hrp2.hpp
@@ -9,18 +9,16 @@
  *
  */
 
-
-
 #ifndef HRP2CONSTANTS
 #define HRP2CONSTANTS
 
 //#define STATEOBSERVATION_VERBOUS_CONSTRUCTORS
 
-#include <vector>
 #include <deque>
+#include <vector>
 
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-#   include <iostream>
+#  include <iostream>
 #endif
 
 #include <boost/assert.hpp>
@@ -32,29 +30,29 @@
 namespace stateObservation
 {
 
-    namespace hrp2
-    {
-        /// mass of the robot
-        constexpr double m=56.8;
+namespace hrp2
+{
+/// mass of the robot
+constexpr double m = 56.8;
 
-        /// stifness and damping
-        constexpr double linKe=40000;
-        constexpr double angKe=400;
-        constexpr double linKv=600;
-        constexpr double angKv=10;
+/// stifness and damping
+constexpr double linKe = 40000;
+constexpr double angKe = 400;
+constexpr double linKv = 600;
+constexpr double angKv = 10;
 
-        struct contact
-        {
-          static const unsigned nbMax=4;
-          static const unsigned nbModeledMax=2;
-          // index for the contacts
-          static const unsigned lf = 0;
-          static const unsigned rf = 1;
-          static const unsigned lh = 2;
-          static const unsigned rh = 3;
-        };
-    }
+struct contact
+{
+  static const unsigned nbMax = 4;
+  static const unsigned nbModeledMax = 2;
+  // index for the contacts
+  static const unsigned lf = 0;
+  static const unsigned rf = 1;
+  static const unsigned lh = 2;
+  static const unsigned rh = 3;
+};
+} // namespace hrp2
 
-}
+} // namespace stateObservation
 
-#endif //HRP2CONSTANTS
+#endif // HRP2CONSTANTS

--- a/include/state-observation/tools/logger.hpp
+++ b/include/state-observation/tools/logger.hpp
@@ -1,100 +1,95 @@
 #ifndef STATEOBSERVATIONLOGGER_H
 #define STATEOBSERVATIONLOGGER_H
 
-#include <typeinfo>
 #include <map>
-#include <string>
 #include <stdexcept>
+#include <string>
+#include <typeinfo>
 
 #include <state-observation/api.h>
 #include <state-observation/tools/definitions.hpp>
 
 namespace stateObservation
 {
-  namespace tools
+namespace tools
+{
+class STATE_OBSERVATION_DLLAPI Logger
+{
+public:
+  Logger();
+  virtual ~Logger();
+
+  /// Use this function to start the recoding of this variable.
+  /// WARNING: Be sure that the recorded variable keeps the same memory address
+  /// otherwise use updateAddress
+  template<typename T>
+  void record(const T * address, const std::string & filename = std::string(""));
+  template<typename T>
+  void record(const T & reference, const std::string & filename = std::string(""));
+
+  /// updates the address of a recorded variable with a new address
+  template<typename T>
+  void updateAddress(const void * oldAddress, const T * newAddress);
+
+  /// set the Path for the log files, the filenames will be appended to this path
+  void setPath(const std::string & path);
+
+  /// update the log with a new value of the reference
+  template<typename T>
+  void push(const T & reference);
+
+  template<typename T>
+  void push(const T * address);
+
+  /// updates all the logs for all recorded variables
+  void push();
+
+  const IndexedMatrixArray & getRecord(const void * address) const;
+
+  IndexedMatrixArray & getRecord(const void * address);
+
+  /// saves the log in a file
+  void save(bool clear = false, bool append = false);
+
+  /// clears all the tracking lists and delete all the logs
+  void clearTracking();
+
+  /// clears the logs but keeps the tracking including time indexation
+  void clearLogs();
+
+protected:
+  struct log_s
   {
-    class STATE_OBSERVATION_DLLAPI Logger
+
+    IndexedMatrixArray array;
+    std::string filename;
+    const std::type_info * type;
+
+    log_s(const std::string & newfilename) : type(0x0)
     {
-    public:
-      Logger();
-      virtual ~Logger();
+      filename = newfilename;
+    }
 
-      ///Use this function to start the recoding of this variable.
-      /// WARNING: Be sure that the recorded variable keeps the same memory address
-      ///otherwise use updateAddress
-      template <typename T>
-        void record(const T * address, const std::string & filename=std::string(""));
-      template <typename T>
-        void record(const T & reference, const std::string & filename=std::string(""));
+    template<typename T>
+    void setType()
+    {
+      type = &typeid(T);
+    }
+  };
 
-      ///updates the address of a recorded variable with a new address
-      template <typename T>
-        void updateAddress(const void * oldAddress, const T * newAddress);
+  typedef std::map<const void *, log_s> Tmap;
+  typedef std::pair<const void *, log_s> Tpair;
 
+  void update_(const Tmap::iterator & i);
 
-      ///set the Path for the log files, the filenames will be appended to this path
-      void setPath(const std::string & path);
+  std::string path_;
+  std::map<const void *, log_s> logs_;
+  Matrix scalar_;
 
-      ///update the log with a new value of the reference
-      template <typename T>
-      void push(const T & reference);
-
-      template <typename T>
-      void push(const T * address);
-
-      ///updates all the logs for all recorded variables
-      void push();
-
-      const IndexedMatrixArray & getRecord(const void *address) const;
-
-      IndexedMatrixArray & getRecord(const void *address);
-
-      ///saves the log in a file
-      void save(bool clear = false, bool append = false);
-
-      ///clears all the tracking lists and delete all the logs
-      void clearTracking();
-
-      ///clears the logs but keeps the tracking including time indexation
-      void clearLogs();
-
-    protected:
-      struct log_s
-      {
-
-        IndexedMatrixArray array;
-        std::string filename;
-        const std::type_info * type;
-
-        log_s(const std::string & newfilename):
-          type (0x0)
-        {
-          filename = newfilename;
-
-        }
-
-        template <typename T>
-        void setType()
-        {
-          type =&typeid(T);
-        }
-      };
-
-      typedef std::map<const void *, log_s > Tmap;
-      typedef std::pair<const void *, log_s > Tpair;
-
-      void update_(const Tmap::iterator & i);
-
-      std::string path_;
-      std::map<const void *, log_s > logs_;
-      Matrix scalar_;
-
-
-    private:
-
-    };
-  }
-}
+private:
+};
+} // namespace tools
+} // namespace stateObservation
 
 #include <state-observation/tools/logger.hxx>
 

--- a/include/state-observation/tools/miscellaneous-algorithms.hpp
+++ b/include/state-observation/tools/miscellaneous-algorithms.hpp
@@ -8,83 +8,76 @@
  *
  */
 
-
 #ifndef STATEOBSERVATIONTOOLSMISCELANEOUSALGORITHMS
 #define STATEOBSERVATIONTOOLSMISCELANEOUSALGORITHMS
-
 
 #include <boost/utility.hpp>
 
 #include <state-observation/api.h>
 #include <state-observation/tools/definitions.hpp>
 
-
 namespace stateObservation
 {
-    namespace tools
-    {
+namespace tools
+{
 
-        ///computes the square of a value of any type
-        template <class T>
-        inline T square (const T & x)
-        {
-            return T(x*x);
-        }
-
-        ///derivates any type with finite differences
-        template <class T>
-        inline T derivate(const T & o1 , const T & o2 , double dt)
-        {
-            T o(o2-o1);
-            return o*(1/dt);
-        }
-
-        ///gives the sign of a variable (1, 0 or -1)
-        template <typename T> inline
-        int signum(T x)
-        {
-          return (T(0) < x) - (x < T(0));
-        }
-
-        template<typename T>
-        std::string toString(T val)
-        {
-          std::stringstream ss("");
-          ss << val;
-          return ss.str();
-        }
-
-
-
-        ///provides an acceleration giving a finite time convergence to zero
-        ///the state is the position x and the derivative xd and the output is the
-        ///acceleration. The gains kp, kv must be negative
-        inline double STATE_OBSERVATION_DLLAPI finiteTimeAccControl(double x, double xd, double kp=-1, double kv=-1)
-        {
-          double sax = sqrt(fabs(x));
-          double xdr = kp*signum(x)*sax;
-          double y = xd - xdr;
-          double ydr = -kv*signum(y)*sqrt(fabs(y));
-          return ydr - kp*xd/(2*sax);
-        }
-
-
-        ///sqme as the scalar version but for every member of the vector
-        inline Vector STATE_OBSERVATION_DLLAPI finiteTimeAccControl(const Vector &x, const Vector &xd, double kp=-1, double kv=-1)
-        {
-          Vector xdd(x.size());
-          for (Index i=1;i<x.size();++i)
-          {
-            xdd(i)= finiteTimeAccControl(x(i),xd(i),kp,kv);
-          }
-          return xdd;
-
-        }
-    }
-
-
+/// computes the square of a value of any type
+template<class T>
+inline T square(const T & x)
+{
+  return T(x * x);
 }
 
+/// derivates any type with finite differences
+template<class T>
+inline T derivate(const T & o1, const T & o2, double dt)
+{
+  T o(o2 - o1);
+  return o * (1 / dt);
+}
 
+/// gives the sign of a variable (1, 0 or -1)
+template<typename T>
+inline int signum(T x)
+{
+  return (T(0) < x) - (x < T(0));
+}
 
-#endif //STATEOBSERVATIONTOOLSMISCELANEOUSALGORITHMS
+template<typename T>
+std::string toString(T val)
+{
+  std::stringstream ss("");
+  ss << val;
+  return ss.str();
+}
+
+/// provides an acceleration giving a finite time convergence to zero
+/// the state is the position x and the derivative xd and the output is the
+/// acceleration. The gains kp, kv must be negative
+inline double STATE_OBSERVATION_DLLAPI finiteTimeAccControl(double x, double xd, double kp = -1, double kv = -1)
+{
+  double sax = sqrt(fabs(x));
+  double xdr = kp * signum(x) * sax;
+  double y = xd - xdr;
+  double ydr = -kv * signum(y) * sqrt(fabs(y));
+  return ydr - kp * xd / (2 * sax);
+}
+
+/// sqme as the scalar version but for every member of the vector
+inline Vector STATE_OBSERVATION_DLLAPI finiteTimeAccControl(const Vector & x,
+                                                            const Vector & xd,
+                                                            double kp = -1,
+                                                            double kv = -1)
+{
+  Vector xdd(x.size());
+  for(Index i = 1; i < x.size(); ++i)
+  {
+    xdd(i) = finiteTimeAccControl(x(i), xd(i), kp, kv);
+  }
+  return xdd;
+}
+} // namespace tools
+
+} // namespace stateObservation
+
+#endif // STATEOBSERVATIONTOOLSMISCELANEOUSALGORITHMS

--- a/include/state-observation/tools/probability-law-simulation.hpp
+++ b/include/state-observation/tools/probability-law-simulation.hpp
@@ -8,7 +8,6 @@
  *
  */
 
-
 #ifndef SENSORSSIMULATIONPROBABILITYLAWSIMULATIONHPP
 #define SENSORSSIMULATIONPROBABILITYLAWSIMULATIONHPP
 
@@ -17,32 +16,27 @@
 #include <state-observation/api.h>
 #include <state-observation/tools/definitions.hpp>
 
-
 namespace stateObservation
 {
-    namespace tools
-    {
-        class STATE_OBSERVATION_DLLAPI ProbabilityLawSimulation
-        {
-        public:
-            ///gets a scalar Gaussian random variable
-            ///having a given bias and standard deviation(std)
-            ///default is the cetered unit Gaussian
-            double getGaussianScalar(double std = 1, double bias = 0);
+namespace tools
+{
+class STATE_OBSERVATION_DLLAPI ProbabilityLawSimulation
+{
+public:
+  /// gets a scalar Gaussian random variable
+  /// having a given bias and standard deviation(std)
+  /// default is the cetered unit Gaussian
+  double getGaussianScalar(double std = 1, double bias = 0);
 
-            ///gets vector Gaussian random variable
-            ///having a given bias and standard deviation(std)
-            static Matrix getGaussianVector( const Matrix & std, const Matrix & bias,
-                Index rows, Index cols=1);
+  /// gets vector Gaussian random variable
+  /// having a given bias and standard deviation(std)
+  static Matrix getGaussianVector(const Matrix & std, const Matrix & bias, Index rows, Index cols = 1);
 
-        protected:
-            static boost::lagged_fibonacci1279 gen_;
+protected:
+  static boost::lagged_fibonacci1279 gen_;
+};
 
-        };
+} // namespace tools
+} // namespace stateObservation
 
-    }
-}
-
-
-
-#endif //SENSORSSIMULATIONPROBABILITYLAWSIMULATIONHPP
+#endif // SENSORSSIMULATIONPROBABILITYLAWSIMULATIONHPP

--- a/include/state-observation/tools/rigid-body-kinematics.hpp
+++ b/include/state-observation/tools/rigid-body-kinematics.hpp
@@ -10,7 +10,6 @@
  *
  */
 
-
 #ifndef StATEOBSERVATIONRIGIDBODYKINEMATICS_H
 #define StATEOBSERVATIONRIGIDBODYKINEMATICS_H
 
@@ -23,482 +22,465 @@
 
 namespace stateObservation
 {
-  namespace kine
+namespace kine
+{
+inline void integrateKinematics(Vector3 & position, const Vector3 & velocity, double dt);
+
+inline void integrateKinematics(Vector3 & position, Vector3 & velocity, const Vector3 & acceleration, double dt);
+
+inline void integrateKinematics(Matrix3 & orientation, const Vector3 & rotationVelocity, double dt);
+
+inline void integrateKinematics(Matrix3 & orientation,
+                                Vector3 & rotationVelocity,
+                                const Vector3 & rotationAcceleration,
+                                double dt);
+
+inline void integrateKinematics(Quaternion & orientation, const Vector3 & rotationVelocity, double dt);
+
+inline void integrateKinematics(Quaternion & orientation,
+                                Vector3 & rotationVelocity,
+                                const Vector3 & rotationAcceleration,
+                                double dt);
+
+/// integrates the position/orientation and their time derivatives, given the
+/// accelerations, and initial velocities and positions. The rotations are
+/// expressed by rotation matrix
+inline void integrateKinematics(Vector3 & position,
+                                Vector3 & velocity,
+                                const Vector3 & acceleration,
+                                Matrix3 & orientation,
+                                Vector3 & rotationVelocity,
+                                const Vector3 & rotationAcceleration,
+                                double dt);
+
+/// integrates the position/orientation and their time derivatives, given the
+/// accelerations, and initial velocities and positions. The orientations are
+/// expressed by quaternions
+inline void integrateKinematics(Vector3 & position,
+                                Vector3 & velocity,
+                                const Vector3 & acceleration,
+                                Quaternion & orientation,
+                                Vector3 & rotationVelocity,
+                                const Vector3 & rotationAcceleration,
+                                double dt);
+
+/// integrates the postition/orientation given the velocities
+inline void integrateKinematics(Vector3 & position,
+                                const Vector3 & velocity,
+                                Matrix3 & orientation,
+                                const Vector3 & rotationVelocity,
+                                double dt);
+
+/// integrates the postition/orientation given the velocities
+inline void integrateKinematics(Vector3 & position,
+                                const Vector3 & velocity,
+                                Quaternion & orientation,
+                                const Vector3 & rotationVelocity,
+                                double dt);
+
+/// Puts the orientation vector norm between 0 and Pi if it
+/// gets close to 2pi
+inline Vector regulateRotationVector(const Vector3 & v);
+
+/// Transform the rotation vector into angle axis
+inline AngleAxis rotationVectorToAngleAxis(const Vector3 & v);
+
+/// Tranbsform the rotation vector into rotation matrix
+inline Matrix3 rotationVectorToRotationMatrix(const Vector3 & v);
+
+/// Tranbsform the rotation vector into quaternion
+inline Quaternion rotationVectorToQuaternion(const Vector3 & v);
+
+/// Tranbsform the rotation matrix into rotation vector
+inline Vector3 rotationMatrixToRotationVector(const Matrix3 & R);
+
+/// Tranbsform a quaternion into rotation vector
+inline Vector3 quaternionToRotationVector(const Quaternion & q);
+
+/// Tranbsform a quaternion into rotation vector
+inline Vector3 quaternionToRotationVector(const Vector4 & v);
+
+/// scalar component of a quaternion
+inline double scalarComponent(const Quaternion & q);
+
+/// vector part of the quaternion
+inline Vector3 vectorComponent(const Quaternion & q);
+
+/// Transform the rotation matrix into roll pitch yaw
+///(decompose R into Ry*Rp*Rr)
+inline Vector3 rotationMatrixToRollPitchYaw(const Matrix3 & R, Vector3 & v);
+
+inline Vector3 rotationMatrixToRollPitchYaw(const Matrix3 & R);
+
+/// Transform the roll pitch yaw into rotation matrix
+///( R = Ry*Rp*Rr)
+inline Matrix3 rollPitchYawToRotationMatrix(double roll, double pitch, double yaw);
+
+inline Matrix3 rollPitchYawToRotationMatrix(const Vector3 & rpy);
+
+/// Transform the roll pitch yaw into rotation matrix
+///( R = Ry*Rp*Rr)
+inline Quaternion rollPitchYawToQuaternion(double roll, double pitch, double yaw);
+
+inline Quaternion rollPitchYawToQuaternion(const Vector3 & rpy);
+
+/// Projects the Matrix to so(3)
+inline Matrix3 orthogonalizeRotationMatrix(const Matrix3 & M);
+
+/// transform a 3d vector into a skew symmetric 3x3 matrix
+inline Matrix3 skewSymmetric(const Vector3 & v, Matrix3 & R);
+
+/// transform a 3d vector into a skew symmetric 3x3 matrix
+inline Matrix3 skewSymmetric(const Vector3 & v);
+
+/// transform a 3d vector into a squared skew symmetric 3x3 matrix
+inline Matrix3 skewSymmetric2(const Vector3 & v, Matrix3 & R);
+
+/// transform a 3d vector into a squared skew symmetric 3x3 matrix
+inline Matrix3 skewSymmetric2(const Vector3 & v);
+
+/// transforms a homogeneous matrix into 6d vector (position theta mu)
+inline Vector6 homogeneousMatrixToVector6(const Matrix4 & M);
+
+/// transforms a 6d vector (position theta mu) into a homogeneous matrix
+inline Matrix4 vector6ToHomogeneousMatrix(const Vector6 & v);
+
+/// Merge the roll and pitch from the tilt (R^T e_z) with the yaw from a rotation
+/// matrix (minimizes the deviation of the x axis)
+inline Matrix3 mergeTiltWithYaw(const Vector3 & Rtez, const Matrix3 & R2);
+
+/// Merge the roll pitch from R1 with yaw from R2
+inline Matrix3 mergeRoll1Pitch1WithYaw2(const Matrix3 & R1, const Matrix3 & R2);
+
+inline Quaternion zeroRotationQuaternion();
+
+/// transforms a rotation into translation given a constraint of a fixed point
+inline void fixedPointRotationToTranslation(const Matrix3 & R,
+                                            const Vector3 & rotationVelocity,
+                                            const Vector3 & rotationAcceleration,
+                                            const Vector3 & fixedPoint,
+                                            Vector3 & outputTranslation,
+                                            Vector3 & outputLinearVelocity,
+                                            Vector3 & outputLinearAcceleration);
+
+/// derivates a quaternion using finite difference to get a angular velocity vector
+inline Vector3 derivateRotationFD(const Quaternion & q1, const Quaternion & q2, double dt);
+
+/// derivates a rotation vector using finite difference to get a angular velocity vector
+inline Vector3 derivateRotationFD(const Vector3 & o1, const Vector3 & o2, double dt);
+
+inline Vector6 derivateHomogeneousMatrixFD(const Matrix4 & m1, const Matrix4 & m2, double dt);
+
+inline Vector6 derivatePoseThetaUFD(const Vector6 & v1, const Vector6 & v2, double dt);
+
+/// Computes the "multiplicative Jacobian" for
+/// Kalman filtering for example
+/// orientation is the current orientation
+/// dR is the rotation delta between the current orientation and the orientation
+/// at the next step.
+/// dRdR is the "multiplicative" Jacobian with regard to variations of orientation
+/// dRddeltaR is the "multiplicative" Jacobian with regard to variations of deltaR
+inline void derivateRotationMultiplicative(const Vector3 & deltaR, Matrix3 & dRdR, Matrix3 & dRddeltaR);
+
+/// Computes the "multiplicative Jacobian" for
+/// a function R^T.v giving a vector v expressed in a local frame
+/// with regard to Rotations of this local frame
+inline Matrix3 derivateRtvMultiplicative(const Matrix3 & R, const Vector3 & v);
+
+/// uses the derivation to reconstruct the velocities and accelerations given
+/// trajectories in positions and orientations only
+inline IndexedVectorArray reconstructStateTrajectory(const IndexedVectorArray & positionOrientation, double dt);
+
+inline Vector invertState(const Vector & state);
+
+inline Matrix4 invertHomoMatrix(const Matrix4 & m);
+
+enum rotationType
+{
+  matrix = 0,
+  rotationVector = 1,
+  quaternion = 2,
+  angleaxis = 3
+};
+
+template<rotationType = rotationVector>
+struct indexes
+{
+};
+
+template<>
+struct indexes<rotationVector>
+{
+  /// indexes of the different components of a vector of the kinematic state
+  /// when the orientation is represented using a 3D rotation vector
+  static const unsigned pos = 0;
+  static const unsigned ori = 3;
+  static const unsigned linVel = 6;
+  static const unsigned angVel = 9;
+  static const unsigned linAcc = 12;
+  static const unsigned angAcc = 15;
+  static const unsigned size = 18;
+};
+
+template<>
+struct indexes<quaternion>
+{
+  /// indexes of the different components of a vector of the kinematic state
+  /// when the orientation is represented using a quaternion
+  static const unsigned pos = 0;
+  static const unsigned ori = 3;
+  static const unsigned linVel = 7;
+  static const unsigned angVel = 10;
+  static const unsigned linAcc = 13;
+  static const unsigned angAcc = 16;
+  static const unsigned size = 19;
+};
+
+/// relative tolereance to the square of quaternion norm.
+constexpr double quatNormTol = 1e-6;
+
+class Orientation
+{
+public:
+  /// The parameter initialize should be set to true except when it is
+  /// certain that the initial value will not be used
+  /// And that the first operation would be to set its value
+  explicit Orientation(bool initialize = true);
+
+  /// this is the rotation vector and NOT Euler angles
+  explicit Orientation(const Vector3 & v);
+
+  explicit Orientation(const Quaternion & q);
+
+  explicit Orientation(const Matrix3 & m);
+
+  explicit Orientation(const AngleAxis & aa);
+
+  Orientation(const Quaternion & q, const Matrix3 & m);
+
+  Orientation(const double & roll, const double & pitch, const double & yaw);
+
+  Orientation(const Orientation & multiplier1, const Orientation & multiplier2);
+  Orientation(Orientation & multiplier1, const Orientation & multiplier2);
+  Orientation(const Orientation & multiplier1, Orientation & multiplier2);
+  Orientation(Orientation & multiplier1, Orientation & multiplier2);
+
+  inline Orientation & operator=(const Vector3 & v);
+
+  inline Orientation & operator=(const Quaternion & q);
+
+  inline Orientation & operator=(const Matrix3 & m);
+
+  inline Orientation & operator=(const AngleAxis & aa);
+
+  inline Orientation & setValue(const Quaternion & q, const Matrix3 & m);
+
+  inline Orientation & fromVector4(const Vector4 & v);
+
+  inline Orientation & setRandom();
+
+  template<typename t>
+  inline Orientation & setZeroRotation();
+
+  inline Orientation & setZeroRotation();
+
+  /// get a const reference on the matrix or the quaternion
+  inline const Matrix3 & matrix3();
+  inline const Quaternion & quaternion();
+
+  inline const Matrix3 & matrix3() const;
+  inline const Quaternion & quaternion() const;
+
+  inline Vector4 toVector4() const;
+  inline Vector4 toVector4();
+
+  inline operator Matrix3();
+
+  inline operator Quaternion();
+
+  inline operator Matrix3() const;
+
+  inline operator Quaternion() const;
+
+  inline Vector3 toRotationVector() const;
+  inline Vector3 toRollPitchYaw() const;
+  inline Vector3 toRollPitchYaw();
+  inline AngleAxis toAngleAxis() const;
+
+  /// Multiply the rotation (orientation) by another rotation R2
+  /// the non const versions allow to use more optimized methods
+
+  inline Orientation operator*(Orientation & R2);
+
+  inline Orientation operator*(const Orientation & R2);
+
+  inline Orientation operator*(Orientation & R2) const;
+
+  inline Orientation operator*(const Orientation & R2) const;
+
+  /// Noalias versions of the operator*
+
+  inline Orientation setToProductNoAlias(Orientation & R1, Orientation & R2);
+
+  inline Orientation setToProductNoAlias(Orientation & R1, const Orientation & R2);
+
+  inline Orientation setToProductNoAlias(const Orientation & R1, Orientation & R2);
+
+  inline Orientation setToProductNoAlias(const Orientation & R1, const Orientation & R2);
+
+  inline Orientation inverse() const;
+
+  /// use the vector dt_x_omega as the increment of rotation expressed in the
+  /// world frame. Which gives R_{k+1}=\exp(S(dtxomega))R_k
+  inline const Orientation & integrate(Vector3 dt_x_omega);
+
+  /// gives the log (rotation vector) of the difference of orientation
+  /// gives log of (*this).inverse()*R_k1
+  inline Vector3 differentiate(Orientation R_k1) const;
+
+  /// Rotate a vector
+  inline Vector3 operator*(const Vector3 & v) const;
+
+  inline Vector3 operator*(const Vector3 & v);
+
+  inline bool isSet() const;
+  inline void reset();
+
+  inline bool isMatrixSet() const;
+  inline bool isQuaternionSet() const;
+
+  /// switch the state of the Matrix or quaternion to set or not
+  /// this can be used for forward initialization
+  inline void setMatrix(bool b = true);
+  inline void setQuaternion(bool b = true);
+
+  /// no checks are performed for these functionsm use with caution
+
+  inline CheckedMatrix3 & getMatrixRefUnsafe();
+  inline CheckedQuaternion & getQuaternionRefUnsafe();
+
+  /// synchronizes the representations (quaternion and rotation matrix)
+  inline void synchronize();
+
+  /// retruns a zero rotation
+  static inline Orientation zeroRotation();
+
+  /// Returns a uniformly distributed random rotation
+  static inline Orientation randomRotation();
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+private:
+  void check_() const;
+
+  inline Matrix3 & quaternionToMatrix_();
+  inline Quaternion & matrixToQuaternion_();
+  inline Matrix3 quaternionToMatrix_() const;
+  inline Quaternion matrixToQuaternion_() const;
+
+  /// this is a helper function to avoid code duplication
+  template<typename Ori1, typename Ori2>
+  inline Orientation templateSetToProductNoAlias_(Ori1 & multiplier1, Ori2 & multiplier2);
+
+  CheckedQuaternion q_;
+  CheckedMatrix3 m_;
+};
+
+struct Kinematics
+{
+  struct Flags
   {
-    inline void integrateKinematics(Vector3 & position, const Vector3 & velocity, double dt);
+    typedef unsigned char Byte;
 
-    inline void integrateKinematics(Vector3 & position, Vector3 & velocity,
-    const Vector3 & acceleration, double dt);
+    static const Byte position = BOOST_BINARY(000001);
+    static const Byte orientation = BOOST_BINARY(000010);
+    static const Byte linVel = BOOST_BINARY(000100);
+    static const Byte angVel = BOOST_BINARY(001000);
+    static const Byte linAcc = BOOST_BINARY(010000);
+    static const Byte angAcc = BOOST_BINARY(100000);
 
-    inline void integrateKinematics( Matrix3 & orientation, const Vector3 & rotationVelocity,
-    double dt);
+    static const Byte all = position | orientation | linVel | angVel | linAcc | angAcc;
+  };
 
-    inline void integrateKinematics( Matrix3 & orientation, Vector3 & rotationVelocity,
-    const Vector3 & rotationAcceleration, double dt);
+  Kinematics() {}
 
-    inline void integrateKinematics( Quaternion & orientation, const Vector3 & rotationVelocity,
-    double dt);
+  /// Constructor from a vector
+  /// the flags show which parts of the kinematics to be loaded from the vector
+  /// the order of the vector is
+  /// position orientation (quaternion) linevel angvel linAcc angAcc
+  /// use the flags to define the structure of the vector
+  Kinematics(const Vector & v, Flags::Byte = Flags::all);
 
-    inline void integrateKinematics( Quaternion & orientation, Vector3 & rotationVelocity,
-    const Vector3 & rotationAcceleration, double dt);
+  Kinematics(const Kinematics & multiplier1, const Kinematics & multiplier2);
+  Kinematics(Kinematics & multiplier1, const Kinematics & multiplier2);
+  Kinematics(const Kinematics & multiplier1, Kinematics & multiplier2);
+  Kinematics(Kinematics & multiplier1, Kinematics & multiplier2);
 
+  /// Fills from vector
+  /// the flags show which parts of the kinematics to be loaded from the vector
+  /// the order of the vector is
+  /// position orientation (quaternion) linevel angvel linAcc angAcc
+  /// use the flags to define the structure of the vector
+  Kinematics & fromVector(const Vector & v, Flags::Byte = Flags::all);
 
-    ///integrates the position/orientation and their time derivatives, given the
-    ///accelerations, and initial velocities and positions. The rotations are
-    ///expressed by rotation matrix
-    inline void integrateKinematics
-    (Vector3 & position, Vector3 & velocity, const Vector3 & acceleration,
-    Matrix3 & orientation, Vector3 & rotationVelocity,
-    const Vector3 & rotationAcceleration, double dt);
+  /// initializes at zero all the flagged fields
+  /// the typename allows to set if the prefered type for rotation
+  /// is a Matrix3 or a Quaternion (Quaternion by default)
+  template<typename t>
+  Kinematics & setZero(Flags::Byte = Flags::all);
 
-    ///integrates the position/orientation and their time derivatives, given the
-    ///accelerations, and initial velocities and positions. The orientations are
-    ///expressed by quaternions
-    inline void integrateKinematics
-    (Vector3 & position, Vector3 & velocity, const Vector3 & acceleration,
-    Quaternion & orientation, Vector3 & rotationVelocity,
-    const Vector3 & rotationAcceleration, double dt);
+  Kinematics & setZero(Flags::Byte = Flags::all);
 
-    ///integrates the postition/orientation given the velocities
-    inline void integrateKinematics(Vector3 & position, const Vector3 & velocity,
-    Matrix3 & orientation, const Vector3 & rotationVelocity, double dt);
+  inline const Kinematics & integrate(double dt);
 
-    ///integrates the postition/orientation given the velocities
-    inline void integrateKinematics(Vector3 & position, const Vector3 & velocity,
-    Quaternion & orientation, const Vector3 & rotationVelocity, double dt);
+  inline const Kinematics & update(const Kinematics & newValue, double dt, Flags::Byte = Flags::all);
 
+  inline Kinematics getInverse() const;
 
-    /// Puts the orientation vector norm between 0 and Pi if it
-    /// gets close to 2pi
-    inline Vector regulateRotationVector(const Vector3 & v );
+  /// converts the object to a vector
+  /// the order of the vector is
+  /// position orientation (quaternion) linevel angvel linAcc angAcc
+  /// use the flags to define the structure of the vector
+  inline Vector toVector(Flags::Byte) const;
+  inline Vector toVector() const;
 
-    /// Transform the rotation vector into angle axis
-    inline AngleAxis rotationVectorToAngleAxis(const Vector3 & v);
+  /// composition of transformation
+  inline Kinematics operator*(const Kinematics &)const;
+  inline Kinematics operator*(const Kinematics &);
+  inline Kinematics operator*(Kinematics &)const;
+  inline Kinematics operator*(Kinematics &);
 
-    /// Tranbsform the rotation vector into rotation matrix
-    inline Matrix3 rotationVectorToRotationMatrix(const Vector3 & v);
+  inline Kinematics setToProductNoAlias(const Kinematics & operand1, const Kinematics & operand2);
+  inline Kinematics setToProductNoAlias(const Kinematics & operand1, Kinematics & operand2);
+  inline Kinematics setToProductNoAlias(Kinematics & operand1, const Kinematics & operand2);
+  inline Kinematics setToProductNoAlias(Kinematics & operand1, Kinematics & operand2);
 
-    /// Tranbsform the rotation vector into quaternion
-    inline Quaternion rotationVectorToQuaternion(const Vector3 & v);
+  inline void reset();
 
-    /// Tranbsform the rotation matrix into rotation vector
-    inline Vector3 rotationMatrixToRotationVector(const Matrix3 & R);
+  CheckedVector3 position;
+  Orientation orientation;
 
-    /// Tranbsform a quaternion into rotation vector
-    inline Vector3 quaternionToRotationVector(const Quaternion & q);
+  CheckedVector3 linVel;
+  CheckedVector3 angVel;
 
-    /// Tranbsform a quaternion into rotation vector
-    inline Vector3 quaternionToRotationVector(const Vector4 & v);
+  CheckedVector3 linAcc;
+  CheckedVector3 angAcc;
 
-    /// scalar component of a quaternion
-    inline double scalarComponent(const Quaternion & q);
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    /// vector part of the quaternion
-    inline Vector3 vectorComponent(const Quaternion & q);
+protected:
+  inline const Kinematics & update_deprecated(const Kinematics & newValue, double dt, Flags::Byte = Flags::all);
+  /// this is a helper function to avoid code duplication
+  template<typename operand1, typename operand2>
+  inline Kinematics templateSetToProductNoAlias_(operand1 & multilplier1, operand2 & multiplier2);
 
+  Vector3 tempVec_;
+};
 
-    /// Transform the rotation matrix into roll pitch yaw
-    ///(decompose R into Ry*Rp*Rr)
-    inline Vector3 rotationMatrixToRollPitchYaw(const Matrix3 & R, Vector3 & v );
+} // namespace kine
+} // namespace stateObservation
 
-    inline Vector3 rotationMatrixToRollPitchYaw(const Matrix3 & R);
-
-    /// Transform the roll pitch yaw into rotation matrix
-    ///( R = Ry*Rp*Rr)
-    inline Matrix3 rollPitchYawToRotationMatrix( double roll, double pitch, double yaw );
-
-    inline Matrix3 rollPitchYawToRotationMatrix( const Vector3 & rpy);
-
-
-    /// Transform the roll pitch yaw into rotation matrix
-    ///( R = Ry*Rp*Rr)
-    inline Quaternion rollPitchYawToQuaternion( double roll, double pitch, double yaw);
-
-    inline Quaternion rollPitchYawToQuaternion( const Vector3 & rpy);
-
-
-    ///Projects the Matrix to so(3)
-    inline Matrix3 orthogonalizeRotationMatrix(const Matrix3 &M);
-
-    ///transform a 3d vector into a skew symmetric 3x3 matrix
-    inline Matrix3 skewSymmetric(const Vector3 & v, Matrix3 & R);
-
-    ///transform a 3d vector into a skew symmetric 3x3 matrix
-    inline Matrix3 skewSymmetric(const Vector3 & v);
-
-    ///transform a 3d vector into a squared skew symmetric 3x3 matrix
-    inline Matrix3 skewSymmetric2(const Vector3 & v, Matrix3 & R);
-
-    ///transform a 3d vector into a squared skew symmetric 3x3 matrix
-    inline Matrix3 skewSymmetric2(const Vector3 & v);
-
-    ///transforms a homogeneous matrix into 6d vector (position theta mu)
-    inline Vector6 homogeneousMatrixToVector6(const Matrix4 & M);
-
-    ///transforms a 6d vector (position theta mu) into a homogeneous matrix
-    inline Matrix4 vector6ToHomogeneousMatrix(const Vector6 & v);
-
-    ///Merge the roll and pitch from the tilt (R^T e_z) with the yaw from a rotation
-    ///matrix (minimizes the deviation of the x axis)
-    inline Matrix3 mergeTiltWithYaw(const Vector3 & Rtez, const Matrix3 & R2);
-
-    ///Merge the roll pitch from R1 with yaw from R2
-    inline Matrix3 mergeRoll1Pitch1WithYaw2(const Matrix3 & R1, const Matrix3 & R2);
-
-    inline Quaternion zeroRotationQuaternion();
-
-    ///transforms a rotation into translation given a constraint of a fixed point
-    inline void fixedPointRotationToTranslation
-    (const Matrix3 & R, const Vector3 & rotationVelocity,
-     const Vector3 & rotationAcceleration, const Vector3 & fixedPoint,
-     Vector3 & outputTranslation, Vector3 & outputLinearVelocity,
-     Vector3 & outputLinearAcceleration);
-
-    ///derivates a quaternion using finite difference to get a angular velocity vector
-    inline Vector3 derivateRotationFD
-    (const Quaternion & q1, const Quaternion & q2, double dt);
-
-    ///derivates a rotation vector using finite difference to get a angular velocity vector
-    inline Vector3 derivateRotationFD
-    (const Vector3 & o1, const Vector3 & o2, double dt);
-
-    inline Vector6 derivateHomogeneousMatrixFD
-    (const Matrix4 & m1, const Matrix4 & m2, double dt );
-
-    inline Vector6 derivatePoseThetaUFD
-    (const Vector6 & v1, const Vector6 & v2, double dt );
-
-    ///Computes the "multiplicative Jacobian" for
-    ///Kalman filtering for example
-    ///orientation is the current orientation
-    ///dR is the rotation delta between the current orientation and the orientation
-    ///at the next step.
-    ///dRdR is the "multiplicative" Jacobian with regard to variations of orientation
-    ///dRddeltaR is the "multiplicative" Jacobian with regard to variations of deltaR
-    inline void derivateRotationMultiplicative
-                    (const Vector3 & deltaR, Matrix3 & dRdR, Matrix3& dRddeltaR);
-
-
-    ///Computes the "multiplicative Jacobian" for
-    ///a function R^T.v giving a vector v expressed in a local frame
-    ///with regard to Rotations of this local frame
-    inline Matrix3 derivateRtvMultiplicative(const Matrix3 & R, const Vector3 &v);
-
-
-    ///uses the derivation to reconstruct the velocities and accelerations given
-    ///trajectories in positions and orientations only
-    inline IndexedVectorArray reconstructStateTrajectory
-    (const IndexedVectorArray & positionOrientation,
-     double dt);
-
-    inline Vector invertState( const Vector & state);
-
-    inline Matrix4 invertHomoMatrix (const Matrix4 & m);
-
-
-    enum rotationType
-    {
-      matrix =0,
-      rotationVector =1,
-      quaternion = 2,
-      angleaxis = 3
-    };
-
-
-
-    template <rotationType = rotationVector>
-    struct indexes
-    {
-    };
-
-    template<>
-    struct indexes<rotationVector>
-    {
-      ///indexes of the different components of a vector of the kinematic state
-      /// when the orientation is represented using a 3D rotation vector
-      static const unsigned pos = 0;
-      static const unsigned ori = 3;
-      static const unsigned linVel = 6;
-      static const unsigned angVel = 9;
-      static const unsigned linAcc = 12;
-      static const unsigned angAcc = 15;
-      static const unsigned size = 18;
-    };
-
-    template<>
-    struct indexes<quaternion>
-    {
-      ///indexes of the different components of a vector of the kinematic state
-      /// when the orientation is represented using a quaternion
-      static const unsigned pos = 0;
-      static const unsigned ori = 3;
-      static const unsigned linVel = 7;
-      static const unsigned angVel = 10;
-      static const unsigned linAcc = 13;
-      static const unsigned angAcc = 16;
-      static const unsigned size = 19;
-    };
-
-
-    ///relative tolereance to the square of quaternion norm.
-    constexpr double quatNormTol = 1e-6;
-
-
-    class Orientation
-    {
-    public:
-      ///The parameter initialize should be set to true except when it is
-      /// certain that the initial value will not be used
-      /// And that the first operation would be to set its value
-      explicit Orientation(bool initialize=true);
-
-      ///this is the rotation vector and NOT Euler angles
-      explicit Orientation(const Vector3& v);
-
-      explicit Orientation(const Quaternion& q);
-
-      explicit Orientation(const Matrix3& m);
-
-      explicit Orientation(const AngleAxis& aa);
-
-      Orientation(const Quaternion& q, const Matrix3& m);
-
-      Orientation(const double& roll, const double & pitch, const double & yaw);
-
-      Orientation(const Orientation & multiplier1, const Orientation & multiplier2 );
-      Orientation(Orientation & multiplier1, const Orientation & multiplier2 );
-      Orientation(const Orientation & multiplier1, Orientation & multiplier2 );
-      Orientation(Orientation & multiplier1, Orientation & multiplier2 );
-
-      inline Orientation & operator=(const Vector3& v);
-
-      inline Orientation & operator=(const Quaternion& q);
-
-      inline Orientation & operator=(const Matrix3& m);
-
-      inline Orientation & operator=(const AngleAxis& aa);
-
-      inline Orientation & setValue(const Quaternion& q, const Matrix3& m);
-
-      inline Orientation & fromVector4(const Vector4 & v);
-
-      inline Orientation & setRandom();
-
-      template <typename t>
-      inline Orientation & setZeroRotation();
-
-      inline Orientation & setZeroRotation();
-
-
-      ///get a const reference on the matrix or the quaternion
-      inline const Matrix3& matrix3();
-      inline const Quaternion& quaternion();
-
-      inline const Matrix3& matrix3() const;
-      inline const Quaternion& quaternion() const;
-
-
-      inline Vector4 toVector4() const;
-      inline Vector4 toVector4();
-
-      inline operator Matrix3();
-
-      inline operator Quaternion();
-
-      inline operator Matrix3() const;
-
-      inline operator Quaternion() const;
-
-      inline Vector3 toRotationVector() const;
-      inline Vector3 toRollPitchYaw() const;
-      inline Vector3 toRollPitchYaw() ;
-      inline AngleAxis toAngleAxis() const;
-
-
-      ///Multiply the rotation (orientation) by another rotation R2
-      ///the non const versions allow to use more optimized methods
-
-      inline Orientation operator*( Orientation& R2);
-
-      inline Orientation operator*( const Orientation& R2);
-
-      inline Orientation operator*( Orientation& R2) const;
-
-      inline Orientation operator*( const Orientation& R2) const;
-
-
-      ///Noalias versions of the operator*
-
-      inline  Orientation setToProductNoAlias ( Orientation& R1, Orientation& R2);
-
-      inline  Orientation setToProductNoAlias ( Orientation& R1, const Orientation& R2);
-
-      inline  Orientation setToProductNoAlias ( const Orientation& R1, Orientation& R2);
-
-      inline  Orientation setToProductNoAlias ( const Orientation& R1, const Orientation& R2);
-
-
-      inline Orientation inverse() const;
-
-      ///use the vector dt_x_omega as the increment of rotation expressed in the
-      /// world frame. Which gives R_{k+1}=\exp(S(dtxomega))R_k
-      inline const Orientation & integrate(Vector3 dt_x_omega);
-
-      ///gives the log (rotation vector) of the difference of orientation
-      /// gives log of (*this).inverse()*R_k1
-      inline Vector3 differentiate(Orientation R_k1) const;
-
-      ///Rotate a vector
-      inline Vector3 operator*( const Vector3& v) const;
-
-      inline Vector3 operator*( const Vector3& v);
-
-      inline bool isSet() const;
-      inline void reset();
-
-      inline bool isMatrixSet() const;
-      inline bool isQuaternionSet() const;
-
-      /// switch the state of the Matrix or quaternion to set or not
-      /// this can be used for forward initialization
-      inline void setMatrix(bool b = true);
-      inline void setQuaternion(bool b = true);
-
-      ///no checks are performed for these functionsm use with caution
-
-      inline CheckedMatrix3 & getMatrixRefUnsafe();
-      inline CheckedQuaternion & getQuaternionRefUnsafe();
-
-      ///synchronizes the representations (quaternion and rotation matrix)
-      inline void synchronize();
-
-      /// retruns a zero rotation
-      static inline Orientation zeroRotation();
-
-      ///Returns a uniformly distributed random rotation
-      static inline Orientation randomRotation();
-
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-
-    private:
-      void check_() const;
-
-      inline Matrix3 & quaternionToMatrix_();
-      inline Quaternion & matrixToQuaternion_();
-      inline Matrix3  quaternionToMatrix_() const;
-      inline Quaternion  matrixToQuaternion_() const;
-
-      ///this is a helper function to avoid code duplication
-      template<typename Ori1, typename Ori2>
-      inline Orientation templateSetToProductNoAlias_(Ori1& multiplier1, Ori2& multiplier2);
-
-      CheckedQuaternion q_;
-      CheckedMatrix3 m_;
-    };
-
-
-    struct Kinematics
-    {
-      struct Flags
-      {
-        typedef unsigned char Byte;
-
-        static const Byte position=     BOOST_BINARY(000001);
-        static const Byte orientation=  BOOST_BINARY(000010);
-        static const Byte linVel=       BOOST_BINARY(000100);
-        static const Byte angVel=       BOOST_BINARY(001000);
-        static const Byte linAcc=       BOOST_BINARY(010000);
-        static const Byte angAcc=       BOOST_BINARY(100000);
-
-        static const Byte all= position | orientation | linVel | angVel | linAcc | angAcc;
-      };
-
-      Kinematics(){}
-
-      ///Constructor from a vector
-      /// the flags show which parts of the kinematics to be loaded from the vector
-      /// the order of the vector is
-      /// position orientation (quaternion) linevel angvel linAcc angAcc
-      /// use the flags to define the structure of the vector
-      Kinematics(const Vector & v, Flags::Byte=Flags::all);
-
-
-      Kinematics(const Kinematics & multiplier1,const Kinematics & multiplier2);
-      Kinematics(Kinematics & multiplier1,const Kinematics & multiplier2);
-      Kinematics(const Kinematics & multiplier1,Kinematics & multiplier2);
-      Kinematics(Kinematics & multiplier1, Kinematics & multiplier2);
-
-      /// Fills from vector
-      /// the flags show which parts of the kinematics to be loaded from the vector
-      /// the order of the vector is
-      /// position orientation (quaternion) linevel angvel linAcc angAcc
-      /// use the flags to define the structure of the vector
-      Kinematics & fromVector(const Vector & v, Flags::Byte=Flags::all);
-
-      /// initializes at zero all the flagged fields
-      /// the typename allows to set if the prefered type for rotation
-      /// is a Matrix3 or a Quaternion (Quaternion by default)
-      template <typename t >
-      Kinematics & setZero(Flags::Byte=Flags::all);
-
-      Kinematics & setZero(Flags::Byte=Flags::all);
-
-      inline const Kinematics & integrate(double dt);
-
-      inline const Kinematics & update(const Kinematics & newValue, double dt, Flags::Byte=Flags::all);
-
-
-      inline Kinematics getInverse() const;
-
-      ///converts the object to a vector
-      /// the order of the vector is
-      /// position orientation (quaternion) linevel angvel linAcc angAcc
-      /// use the flags to define the structure of the vector
-      inline Vector toVector(Flags::Byte) const;
-      inline Vector toVector() const;
-
-      ///composition of transformation
-      inline Kinematics operator* (const Kinematics & ) const;
-      inline Kinematics operator* (const Kinematics & ) ;
-      inline Kinematics operator* ( Kinematics & ) const;
-      inline Kinematics operator* (Kinematics & ) ;
-
-
-      inline Kinematics setToProductNoAlias(const Kinematics & operand1,const Kinematics & operand2);
-      inline Kinematics setToProductNoAlias(const Kinematics & operand1, Kinematics & operand2);
-      inline Kinematics setToProductNoAlias( Kinematics & operand1,const Kinematics & operand2);
-      inline Kinematics setToProductNoAlias( Kinematics & operand1, Kinematics & operand2);
-
-      inline void reset();
-
-      CheckedVector3 position;
-      Orientation orientation;
-
-      CheckedVector3 linVel;
-      CheckedVector3 angVel;
-
-      CheckedVector3 linAcc;
-      CheckedVector3 angAcc;
-
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-    protected:
-      inline const Kinematics & update_deprecated(const Kinematics & newValue, double dt, Flags::Byte=Flags::all);
-      ///this is a helper function to avoid code duplication
-      template<typename operand1,typename operand2>
-      inline Kinematics templateSetToProductNoAlias_(operand1& multilplier1, operand2& multiplier2);
-
-      Vector3 tempVec_;
-    };
-
-
-
-
-  }///namespace kine
-}///namespace stateObservation
-
-inline std::ostream& operator<<(std::ostream& os, const stateObservation::kine::Kinematics & k);
+inline std::ostream & operator<<(std::ostream & os, const stateObservation::kine::Kinematics & k);
 
 #include <state-observation/tools/rigid-body-kinematics.hxx>
 

--- a/include/state-observation/tools/state-vector-arithmetics.hpp
+++ b/include/state-observation/tools/state-vector-arithmetics.hpp
@@ -8,28 +8,30 @@ namespace stateObservation
 {
 namespace detail
 {
-void STATE_OBSERVATION_DLLAPI defaultSum(const Vector &stateVector, const Vector &tangentVector, Vector &result);
+void STATE_OBSERVATION_DLLAPI defaultSum(const Vector & stateVector, const Vector & tangentVector, Vector & result);
 
-void STATE_OBSERVATION_DLLAPI defaultDifference(const Vector &stateVector1, const Vector &stateVector2, Vector &difference);
+void STATE_OBSERVATION_DLLAPI defaultDifference(const Vector & stateVector1,
+                                                const Vector & stateVector2,
+                                                Vector & difference);
 
 } // namespace detail
 
 /**
-     * \class  StateArithmetics
-     * \brief
-     *        This class is used to customize the way the difference between measurements,
-     *        the state update function and the differentiation are performed.
-     *         default is the usual natual arithmetics. overload any ohter one
-     *
-     */
+ * \class  StateArithmetics
+ * \brief
+ *        This class is used to customize the way the difference between measurements,
+ *        the state update function and the differentiation are performed.
+ *         default is the usual natual arithmetics. overload any ohter one
+ *
+ */
 class STATE_OBSERVATION_DLLAPI StateVectorArithmetics
 {
 public:
-    virtual void stateSum(const Vector &stateVector, const Vector &tangentVector, Vector &sum);
+  virtual void stateSum(const Vector & stateVector, const Vector & tangentVector, Vector & sum);
 
-    virtual void stateDifference(const Vector &stateVector1, const Vector &stateVector2, Vector &difference);
+  virtual void stateDifference(const Vector & stateVector1, const Vector & stateVector2, Vector & difference);
 
-    virtual void measurementDifference(const Vector &measureVector1, const Vector &measureVector2, Vector &difference);
+  virtual void measurementDifference(const Vector & measureVector1, const Vector & measureVector2, Vector & difference);
 };
 } // namespace stateObservation
 

--- a/misc-tools/file-splitter.cpp
+++ b/misc-tools/file-splitter.cpp
@@ -1,6 +1,6 @@
-#include <iostream>
 #include <fstream>
-#include <stdexcept>      // std::invalid_argument
+#include <iostream>
+#include <stdexcept> // std::invalid_argument
 
 #include <stdlib.h>
 
@@ -17,96 +17,78 @@ using namespace stateObservation::flexibilityEstimation;
 typedef IMUElasticLocalFrameDynamicalSystem::state state;
 typedef IMUElasticLocalFrameDynamicalSystem::input input;
 
-
 using namespace stateObservation;
-
 
 /// ///////////////////////////////////////////////////////////////
 
-int main (int argc, char *argv[])
+int main(int argc, char * argv[])
 
 {
   try
   {
-    if (argc%2 ==0)
-      throw std::invalid_argument("argc");
+    if(argc % 2 == 0) throw std::invalid_argument("argc");
 
-    for (int i=1; i<argc; i=i+2) /// i is incremented twice
+    for(int i = 1; i < argc; i = i + 2) /// i is incremented twice
     {
       std::string type, filename;
       type = argv[i];
-      filename = argv[i+1];
-      if (type == "-u")
+      filename = argv[i + 1];
+      if(type == "-u")
       {
 
-///-------------- input----------------------------------
+        ///-------------- input----------------------------------
 
         IndexedVectorArray u;
-        std::cout << "Input "<< std::endl;
-        std::cout << " filename: "<<filename<< std::endl;
+        std::cout << "Input " << std::endl;
+        std::cout << " filename: " << filename << std::endl;
         u.readVectorsFromFile(filename.c_str());
-        std::cout << "Inputs loaded, size:"<< u.size() << std::endl;
+        std::cout << "Inputs loaded, size:" << u.size() << std::endl;
 
         Vector ui;
 
         std::cout << "Splitting" << std::endl;
 
-        IndexedVectorArray
-          posCom,
-          velCom,
-          accCom,
-          inertia,
-          angMoment,
-          dotInertia,
-          dotAngMoment,
-          posIMU,
-          oriIMU,
-          linVelIMU,
-          angVelIMU,
-          linAccIMU,
-          additionalForces,
-          contact1,
-          contact2 ;
-        for (TimeIndex i=u.getFirstIndex(); i<u.getNextIndex(); ++i)
+        IndexedVectorArray posCom, velCom, accCom, inertia, angMoment, dotInertia, dotAngMoment, posIMU, oriIMU,
+            linVelIMU, angVelIMU, linAccIMU, additionalForces, contact1, contact2;
+        for(TimeIndex i = u.getFirstIndex(); i < u.getNextIndex(); ++i)
         {
-          ui=u[i];
-          posCom.setValue(ui.segment<3>(input::posCom),i);
-          velCom.setValue(ui.segment<3>(input::velCom),i) ;
-          accCom.setValue(ui.segment<3>(input::accCom),i) ;
-          inertia.setValue(ui.segment<6>(input::inertia),i) ;
-          angMoment.setValue(ui.segment<3>(input::angMoment),i) ;
-          dotInertia.setValue(ui.segment<6>(input::dotInertia),i) ;
-          dotAngMoment.setValue(ui.segment<3>(input::dotAngMoment),i) ;
-          posIMU.setValue(ui.segment<3>(input::posIMU),i) ;
-          oriIMU.setValue(ui.segment<3>(input::oriIMU),i) ;
-          linVelIMU.setValue(ui.segment<3>(input::linVelIMU),i) ;
-          angVelIMU.setValue(ui.segment<3>(input::angVelIMU),i) ;
-          linAccIMU.setValue(ui.segment<3>(input::linAccIMU),i) ;
-          additionalForces.setValue(ui.segment<6>(input::additionalForces),i) ;
+          ui = u[i];
+          posCom.setValue(ui.segment<3>(input::posCom), i);
+          velCom.setValue(ui.segment<3>(input::velCom), i);
+          accCom.setValue(ui.segment<3>(input::accCom), i);
+          inertia.setValue(ui.segment<6>(input::inertia), i);
+          angMoment.setValue(ui.segment<3>(input::angMoment), i);
+          dotInertia.setValue(ui.segment<6>(input::dotInertia), i);
+          dotAngMoment.setValue(ui.segment<3>(input::dotAngMoment), i);
+          posIMU.setValue(ui.segment<3>(input::posIMU), i);
+          oriIMU.setValue(ui.segment<3>(input::oriIMU), i);
+          linVelIMU.setValue(ui.segment<3>(input::linVelIMU), i);
+          angVelIMU.setValue(ui.segment<3>(input::angVelIMU), i);
+          linAccIMU.setValue(ui.segment<3>(input::linAccIMU), i);
+          additionalForces.setValue(ui.segment<6>(input::additionalForces), i);
 
-          Vector c1,c2;
-          unsigned numberOfContacts=0;
+          Vector c1, c2;
+          unsigned numberOfContacts = 0;
 
-          if (u.size()>input::sizeBase)
+          if(u.size() > input::sizeBase)
           {
             c1.resize(13);
             numberOfContacts++;
-            c1<<numberOfContacts, ui.segment<12>(input::contacts);
+            c1 << numberOfContacts, ui.segment<12>(input::contacts);
           }
           else
           {
             c1.resize(1);
             c1 << numberOfContacts;
-            contact1.setValue(c1,i) ;
+            contact1.setValue(c1, i);
           }
 
-          if (u[i].size()>input::sizeBase+12)
+          if(u[i].size() > input::sizeBase + 12)
           {
             c2.resize(13);
             numberOfContacts++;
-            c1(0)=numberOfContacts;
-            c2<<numberOfContacts, ui.segment<12>(input::contacts+12);
-
+            c1(0) = numberOfContacts;
+            c2 << numberOfContacts, ui.segment<12>(input::contacts + 12);
           }
           else
           {
@@ -114,42 +96,40 @@ int main (int argc, char *argv[])
             c2 << numberOfContacts;
           }
 
-          contact1.setValue(c1,i) ;
-          contact2.setValue(c2,i) ;
+          contact1.setValue(c1, i);
+          contact2.setValue(c2, i);
         }
 
         std::cout << "Splitting finished" << std::endl;
 
         std::cout << "Writing files" << std::endl;
 
-        posCom          .writeInFile(filename+"-00-posCom");
-        velCom          .writeInFile(filename+"-01-velCom");
-        accCom          .writeInFile(filename+"-02-accCom");
-        inertia         .writeInFile(filename+"-03-inertia");
-        angMoment       .writeInFile(filename+"-04-angMoment");
-        dotInertia      .writeInFile(filename+"-05-dotInertia");
-        dotAngMoment    .writeInFile(filename+"-06-dotAngMoment");
-        posIMU          .writeInFile(filename+"-07-posIMU");
-        oriIMU          .writeInFile(filename+"-08-oriIMU");
-        linVelIMU       .writeInFile(filename+"-09-linVelIMU");
-        angVelIMU       .writeInFile(filename+"-10-angVelIMU");
-        linAccIMU       .writeInFile(filename+"-11-linAccIMU");
-        additionalForces.writeInFile(filename+"-12-additionalForces");
-        contact1        .writeInFile(filename+"-13-contact1");
-        contact2        .writeInFile(filename+"-14-contact2");
+        posCom.writeInFile(filename + "-00-posCom");
+        velCom.writeInFile(filename + "-01-velCom");
+        accCom.writeInFile(filename + "-02-accCom");
+        inertia.writeInFile(filename + "-03-inertia");
+        angMoment.writeInFile(filename + "-04-angMoment");
+        dotInertia.writeInFile(filename + "-05-dotInertia");
+        dotAngMoment.writeInFile(filename + "-06-dotAngMoment");
+        posIMU.writeInFile(filename + "-07-posIMU");
+        oriIMU.writeInFile(filename + "-08-oriIMU");
+        linVelIMU.writeInFile(filename + "-09-linVelIMU");
+        angVelIMU.writeInFile(filename + "-10-angVelIMU");
+        linAccIMU.writeInFile(filename + "-11-linAccIMU");
+        additionalForces.writeInFile(filename + "-12-additionalForces");
+        contact1.writeInFile(filename + "-13-contact1");
+        contact2.writeInFile(filename + "-14-contact2");
 
         std::cout << "Done " << std::endl;
-
-
       }
-      else if (type ==  "-y")
+      else if(type == "-y")
       {
 
         IndexedVectorArray y;
-        std::cout << "Measurements"<< std::endl;
-         std::cout << " filename: "<<filename<< std::endl;
+        std::cout << "Measurements" << std::endl;
+        std::cout << " filename: " << filename << std::endl;
         y.readVectorsFromFile(filename.c_str());
-        std::cout << "Measurements loaded, size:"<< y.size() << std::endl;
+        std::cout << "Measurements loaded, size:" << y.size() << std::endl;
 
         IndexedVectorArray accelerometer, gyrometer, force1, force2;
 
@@ -157,18 +137,18 @@ int main (int argc, char *argv[])
 
         std::cout << "Splitting" << std::endl;
 
-        for (TimeIndex i=y.getFirstIndex(); i<y.getNextIndex(); ++i)
+        for(TimeIndex i = y.getFirstIndex(); i < y.getNextIndex(); ++i)
         {
-          yi=y[i];
+          yi = y[i];
 
-          if (yi.size()>0)
+          if(yi.size() > 0)
           {
-            accelerometer.setValue(yi.segment<3>(0),i);
-            gyrometer.setValue(yi.segment<3>(3),i);
+            accelerometer.setValue(yi.segment<3>(0), i);
+            gyrometer.setValue(yi.segment<3>(3), i);
 
-            Vector f1,f2;
-            int numberofContact=0;
-            if (yi.size()>6)
+            Vector f1, f2;
+            int numberofContact = 0;
+            if(yi.size() > 6)
             {
               numberofContact++;
               f1.resize(7);
@@ -177,23 +157,23 @@ int main (int argc, char *argv[])
             else
             {
               f1.resize(1);
-              f1 <<numberofContact;
+              f1 << numberofContact;
             }
-            if (yi.size()>12)
+            if(yi.size() > 12)
             {
               f2.resize(7);
               numberofContact++;
-              f1(0)=numberofContact;
-              f2<< numberofContact, yi.segment<6>(12);
+              f1(0) = numberofContact;
+              f2 << numberofContact, yi.segment<6>(12);
             }
             else
             {
               f2.resize(1);
-              f2 <<numberofContact;
+              f2 << numberofContact;
             }
 
-            force1.setValue(f1,i);
-            force2.setValue(f2,i);
+            force1.setValue(f1, i);
+            force2.setValue(f2, i);
           }
         }
 
@@ -201,106 +181,80 @@ int main (int argc, char *argv[])
 
         std::cout << "Writing files" << std::endl;
 
-        accelerometer.writeInFile   (filename+"-00-accelerometer");
-        gyrometer.writeInFile       (filename+"-01-gyrometer");
-        force1.writeInFile          (filename+"-02-force1");
-        force2.writeInFile          (filename+"-03-force2");
+        accelerometer.writeInFile(filename + "-00-accelerometer");
+        gyrometer.writeInFile(filename + "-01-gyrometer");
+        force1.writeInFile(filename + "-02-force1");
+        force2.writeInFile(filename + "-03-force2");
 
         std::cout << "Done " << std::endl;
-
       }
 
-
-      else if (type ==  "-x")
+      else if(type == "-x")
       {
         IndexedVectorArray x;
-        std::cout << "State "<<std::endl;
-        std::cout << " filename: "<<filename<< std::endl;
+        std::cout << "State " << std::endl;
+        std::cout << " filename: " << filename << std::endl;
         x.readVectorsFromFile(filename.c_str());
-        std::cout << "State loaded, size:"<< x.size() << std::endl;
+        std::cout << "State loaded, size:" << x.size() << std::endl;
 
         std::cout << "Splitting" << std::endl;
 
         ///------------- state------------------------
         Vector xi;
-        IndexedVectorArray
-          pos,
-          ori,
-          linVel,
-          angVel,
-          fc1,
-          fc2,
-          unmodeledForces,
-          comBias,
-          drift          ;
+        IndexedVectorArray pos, ori, linVel, angVel, fc1, fc2, unmodeledForces, comBias, drift;
 
-        for (TimeIndex i=x.getFirstIndex(); i<x.getNextIndex(); ++i)
+        for(TimeIndex i = x.getFirstIndex(); i < x.getNextIndex(); ++i)
         {
-          xi=x[i];
-          pos             .setValue(xi.segment<3>(state::pos),i);
-          ori             .setValue(xi.segment<3>(state::ori),i);
-          linVel          .setValue(xi.segment<3>(state::linVel),i);
-          angVel          .setValue(xi.segment<3>(state::angVel),i);
-          fc1             .setValue(xi.segment<6>(state::fc),i);
-          fc2             .setValue(xi.segment<6>(state::fc+6),i);
-          unmodeledForces .setValue(xi.segment<6>(state::unmodeledForces),i);
-          comBias         .setValue(xi.segment<3>(state::comBias),i);
-          drift           .setValue(xi.segment<3>(state::drift),i);
-
-
+          xi = x[i];
+          pos.setValue(xi.segment<3>(state::pos), i);
+          ori.setValue(xi.segment<3>(state::ori), i);
+          linVel.setValue(xi.segment<3>(state::linVel), i);
+          angVel.setValue(xi.segment<3>(state::angVel), i);
+          fc1.setValue(xi.segment<6>(state::fc), i);
+          fc2.setValue(xi.segment<6>(state::fc + 6), i);
+          unmodeledForces.setValue(xi.segment<6>(state::unmodeledForces), i);
+          comBias.setValue(xi.segment<3>(state::comBias), i);
+          drift.setValue(xi.segment<3>(state::drift), i);
         }
-
 
         std::cout << "Splitting finished" << std::endl;
 
         std::cout << "Writing files" << std::endl;
 
-
-        pos             .writeInFile(filename+"-00-pos");
-        ori             .writeInFile(filename+"-01-ori");
-        linVel          .writeInFile(filename+"-02-linVel");
-        angVel          .writeInFile(filename+"-03-angVel");
-        fc1             .writeInFile(filename+"-04-fc1");
-        fc2             .writeInFile(filename+"-05-fc2");
-        unmodeledForces .writeInFile(filename+"-06-unmodeledForces");
-        comBias         .writeInFile(filename+"-07-comBias");
-        drift           .writeInFile(filename+"-08-drift");
+        pos.writeInFile(filename + "-00-pos");
+        ori.writeInFile(filename + "-01-ori");
+        linVel.writeInFile(filename + "-02-linVel");
+        angVel.writeInFile(filename + "-03-angVel");
+        fc1.writeInFile(filename + "-04-fc1");
+        fc2.writeInFile(filename + "-05-fc2");
+        unmodeledForces.writeInFile(filename + "-06-unmodeledForces");
+        comBias.writeInFile(filename + "-07-comBias");
+        drift.writeInFile(filename + "-08-drift");
 
         std::cout << "Done " << std::endl;
-
       }
       else
       {
-        std::cout << std::endl << "ERROR: \""<< type<< "\" wrong parameter!"<<std::endl<<std::endl;
+        std::cout << std::endl << "ERROR: \"" << type << "\" wrong parameter!" << std::endl << std::endl;
         throw std::invalid_argument("argc");
       }
     }
   }
 
-  catch (const std::invalid_argument& ia)
+  catch(const std::invalid_argument & ia)
   {
-    std::cout << "USAGE: argument"<<std::endl;
+    std::cout << "USAGE: argument" << std::endl;
 
-    std::cout <<"    -u <filname>"<<std::endl;
-    std::cout <<"    -y <filname>"<<std::endl;
-    std::cout <<"    -x <filname>"<<std::endl;
+    std::cout << "    -u <filname>" << std::endl;
+    std::cout << "    -y <filname>" << std::endl;
+    std::cout << "    -x <filname>" << std::endl;
     std::cout << std::endl;
-    std::cout << "Leaving"<<std::endl;
+    std::cout << "Leaving" << std::endl;
 
     return 1;
   }
 
-
-
-  std::cout << "Successfully finished"<<std::endl;
-
-
-
-
+  std::cout << "Successfully finished" << std::endl;
 
   return 0;
 }
-
-
-
-

--- a/misc-tools/model-base-flex-estimator-file-tester.cpp
+++ b/misc-tools/model-base-flex-estimator-file-tester.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include <stdlib.h>
 
@@ -12,57 +12,47 @@
 
 #include <time.h>
 
-
 using namespace stateObservation;
 
-int main (int argc, char *argv[])
+int main(int argc, char * argv[])
 {
-  if (argc!=6)
+  if(argc != 6)
   {
-    std::cout << "Parameters : measurements inputs numberOfContacts dt m"<<std::endl;
-    std::cout << "Leaving"<<std::endl;
-
+    std::cout << "Parameters : measurements inputs numberOfContacts dt m" << std::endl;
+    std::cout << "Leaving" << std::endl;
   }
   else
   {
-    IndexedVectorArray y,u,numberOfContacts;
+    IndexedVectorArray y, u, numberOfContacts;
 
-    std::cout << "Read Sensors filename: "<<argv[1]<< std::endl;
+    std::cout << "Read Sensors filename: " << argv[1] << std::endl;
     y.readVectorsFromFile(argv[1]);
-    std::cout << "Sensors loaded, size:"<< y.size() << std::endl;
-    std::cout << "Read Inputs, filename: "<<argv[2]<< std::endl;
+    std::cout << "Sensors loaded, size:" << y.size() << std::endl;
+    std::cout << "Read Inputs, filename: " << argv[2] << std::endl;
     u.readVectorsFromFile(argv[2]);
-    std::cout << "Inputs loaded, size:"<< u.size() << std::endl;
+    std::cout << "Inputs loaded, size:" << u.size() << std::endl;
 
-    std::cout << "Read contact number, filename: "<<argv[3]<< std::endl;
+    std::cout << "Read contact number, filename: " << argv[3] << std::endl;
     numberOfContacts.readVectorsFromFile(argv[3]);
-    std::cout << "Contact numbers loaded, size:"<< numberOfContacts.size() << std::endl;
+    std::cout << "Contact numbers loaded, size:" << numberOfContacts.size() << std::endl;
 
-   // std::cout <<"numberOfContacts " <<numberOfContacts.getLastIndex()<< " "
-   //           << numberOfContacts[numberOfContacts.getLastIndex()].size() << " "
-   //           << numberOfContacts[numberOfContacts.getLastIndex()] << " "
-   //           << std::endl;//<< " "<< numberOfContacts[2]<< " "<< numberOfContacts[3]<< " ";
+    // std::cout <<"numberOfContacts " <<numberOfContacts.getLastIndex()<< " "
+    //           << numberOfContacts[numberOfContacts.getLastIndex()].size() << " "
+    //           << numberOfContacts[numberOfContacts.getLastIndex()] << " "
+    //           << std::endl;//<< " "<< numberOfContacts[2]<< " "<< numberOfContacts[3]<< " ";
 
-    Matrix xh0 = Vector::Zero(flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::size,1);
+    Matrix xh0 = Vector::Zero(flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::size, 1);
 
-    double dt=atof(argv[4]);
-    double mass=atof(argv[5]);
+    double dt = atof(argv[4]);
+    double mass = atof(argv[5]);
 
     std::cout << "Rebuiding state" << std::endl;
-    IndexedVectorArray xhat=
-      examples::offlineModelBaseFlexEstimation( y, u, xh0, numberOfContacts, dt, mass, true,
-                                               IndexedMatrixArray(), IndexedMatrixArray(),
-                                                Matrix3::Zero(), Matrix3::Zero(), Matrix3::Zero(), Matrix3::Zero(),
-                                               0x0,0x0,0x0,0x0,1);
+    IndexedVectorArray xhat = examples::offlineModelBaseFlexEstimation(
+        y, u, xh0, numberOfContacts, dt, mass, true, IndexedMatrixArray(), IndexedMatrixArray(), Matrix3::Zero(),
+        Matrix3::Zero(), Matrix3::Zero(), Matrix3::Zero(), 0x0, 0x0, 0x0, 0x0, 1);
     std::cout << "State rebuilt" << std::endl;
 
     xhat.writeInFile("xhat");
   }
   return 0;
-
 }
-
-
-
-
-

--- a/misc-tools/test_model-base-ekf-flex-estimator-imu_withComBias_withForcesSensors.cpp
+++ b/misc-tools/test_model-base-ekf-flex-estimator-imu_withComBias_withForcesSensors.cpp
@@ -1,319 +1,346 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
-#include <state-observation/flexibility-estimation/model-base-ekf-flex-estimator-imu.hpp>
 #include <state-observation/flexibility-estimation/imu-elastic-local-frame-dynamical-system.hpp>
-
+#include <state-observation/flexibility-estimation/model-base-ekf-flex-estimator-imu.hpp>
 
 using namespace stateObservation;
 
-inline Matrix3 buildInertiaTensor(const Vector6 inputInertia, Matrix3& inertiaTensor)
+inline Matrix3 buildInertiaTensor(const Vector6 inputInertia, Matrix3 & inertiaTensor)
 {
 
-  const double & Ixx=inputInertia[0];
-  const double & Iyy=inputInertia[1];
-  const double & Izz=inputInertia[2];
-  const double & Ixy=inputInertia[3];
-  const double & Ixz=inputInertia[4];
-  const double & Iyz=inputInertia[5];
+  const double & Ixx = inputInertia[0];
+  const double & Iyy = inputInertia[1];
+  const double & Izz = inputInertia[2];
+  const double & Ixy = inputInertia[3];
+  const double & Ixz = inputInertia[4];
+  const double & Iyz = inputInertia[5];
 
-  inertiaTensor   <<    Ixx, Ixy, Ixz,
-                  Ixy, Iyy, Iyz,
-                  Ixz, Iyz, Izz;
+  inertiaTensor << Ixx, Ixy, Ixz, Ixy, Iyy, Iyz, Ixz, Iyz, Izz;
 
   return inertiaTensor;
 }
 
-Vector computeZmp (unsigned footNumber, IndexedMatrixArray& forces, IndexedMatrixArray& sensorPositions)
+Vector computeZmp(unsigned footNumber, IndexedMatrixArray & forces, IndexedMatrixArray & sensorPositions)
 {
-    double fnormal = 0;
-    double sumZmpx = 0;
-    double sumZmpy = 0;
-    double sumZmpz = 0;
-    Vector zmp; zmp.setZero(); zmp.resize (3);
+  double fnormal = 0;
+  double sumZmpx = 0;
+  double sumZmpy = 0;
+  double sumZmpz = 0;
+  Vector zmp;
+  zmp.setZero();
+  zmp.resize(3);
 
-    for (unsigned int i=0; i<footNumber; ++i)
+  for(unsigned int i = 0; i < footNumber; ++i)
+  {
+    const Vector & f = forces[i];
+    // Check that force is of dimension 6
+    if(f.size() != 6)
     {
-        const Vector& f = forces [i];
-        // Check that force is of dimension 6
-        if (f.size () != 6)
-        {
-            zmp.fill (0.);
-            return zmp;
-        }
-
-        const Matrix& M = sensorPositions[i];
-        double fx = M (0,0) * f (0) + M(0,1) * f (1) + M (0,2) * f (2);
-        double fy = M (1,0) * f (0) + M(1,1) * f (1) + M (1,2) * f (2);
-        double fz = M (2,0) * f (0) + M(2,1) * f (1) + M (2,2) * f (2);
-
-        if (fz > 0)
-        {
-            double Mx = M (0,0)*f(3) + M (0,1)*f(4) + M (0,2)*f(5) + M (1,3)*fz - M (2,3)*fy;
-            double My = M (1,0)*f(3) + M (1,1)*f(4) + M (1,2)*f(5) + M (2,3)*fx - M (0,3)*fz;
-
-            fnormal += fz;
-            sumZmpx -= My;
-            sumZmpy += Mx;
-            sumZmpz += fz * M (2,3);
-        }
+      zmp.fill(0.);
+      return zmp;
     }
 
-    if (fnormal != 0)
-    {
-        zmp (0) = sumZmpx / fnormal;
-        zmp (1) = sumZmpy / fnormal;
-        zmp (2) = sumZmpz / fnormal;
-    }
-    else
-    {
-        zmp.fill (0.);
-    }
+    const Matrix & M = sensorPositions[i];
+    double fx = M(0, 0) * f(0) + M(0, 1) * f(1) + M(0, 2) * f(2);
+    double fy = M(1, 0) * f(0) + M(1, 1) * f(1) + M(1, 2) * f(2);
+    double fz = M(2, 0) * f(0) + M(2, 1) * f(1) + M(2, 2) * f(2);
 
-    return zmp;
+    if(fz > 0)
+    {
+      double Mx = M(0, 0) * f(3) + M(0, 1) * f(4) + M(0, 2) * f(5) + M(1, 3) * fz - M(2, 3) * fy;
+      double My = M(1, 0) * f(3) + M(1, 1) * f(4) + M(1, 2) * f(5) + M(2, 3) * fx - M(0, 3) * fz;
+
+      fnormal += fz;
+      sumZmpx -= My;
+      sumZmpy += Mx;
+      sumZmpz += fz * M(2, 3);
+    }
+  }
+
+  if(fnormal != 0)
+  {
+    zmp(0) = sumZmpx / fnormal;
+    zmp(1) = sumZmpy / fnormal;
+    zmp(2) = sumZmpz / fnormal;
+  }
+  else
+  {
+    zmp.fill(0.);
+  }
+
+  return zmp;
 }
 
-Vector3 computeFc(unsigned nbContacts, stateObservation::Vector x, stateObservation::Vector u, stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU&)
+Vector3 computeFc(unsigned nbContacts,
+                  stateObservation::Vector x,
+                  stateObservation::Vector u,
+                  stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU &)
 {
-    stateObservation::Vector3 Fc;
-    stateObservation::Vector3 oriV, angVel, angAcc, pos, vel, acc, fm, tm, AngMomentum, dotAngMomentum;
-    stateObservation::Matrix3 rFlex, inertia, dotInertia;
-    stateObservation::Vector3 cl, dcl, ddcl;
-    IndexedMatrixArray contactPosV;
-    IndexedMatrixArray contactOriV;
-    IndexedMatrixArray efforts;
-    Vector fc_;
-    Vector tc_;
-    stateObservation::Vector3 gmuz;
+  stateObservation::Vector3 Fc;
+  stateObservation::Vector3 oriV, angVel, angAcc, pos, vel, acc, fm, tm, AngMomentum, dotAngMomentum;
+  stateObservation::Matrix3 rFlex, inertia, dotInertia;
+  stateObservation::Vector3 cl, dcl, ddcl;
+  IndexedMatrixArray contactPosV;
+  IndexedMatrixArray contactOriV;
+  IndexedMatrixArray efforts;
+  Vector fc_;
+  Vector tc_;
+  stateObservation::Vector3 gmuz;
 
-    gmuz << 0,
-            0,
-            9.81*56.8;
-    fm.setZero(); tm.setZero();
+  gmuz << 0, 0, 9.81 * 56.8;
+  fm.setZero();
+  tm.setZero();
 
-    oriV = x.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::ori,3);
-    angVel = x.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::angVel,3);
-    rFlex = kine::rotationVectorToRotationMatrix(oriV);
+  oriV = x.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::ori, 3);
+  angVel = x.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::angVel, 3);
+  rFlex = kine::rotationVectorToRotationMatrix(oriV);
 
-    cl = u.segment(0,3);
-    dcl = u.segment(3,3);
-    ddcl = u.segment(6,3);
-    AngMomentum=u.segment<3>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::angMoment);
-    dotAngMomentum=u.segment<3>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::dotAngMoment);
-    buildInertiaTensor(u.segment<6>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::inertia), inertia);
-    buildInertiaTensor(u.segment<6>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::dotInertia), dotInertia);
+  cl = u.segment(0, 3);
+  dcl = u.segment(3, 3);
+  ddcl = u.segment(6, 3);
+  AngMomentum =
+      u.segment<3>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::angMoment);
+  dotAngMomentum =
+      u.segment<3>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::dotAngMoment);
+  buildInertiaTensor(
+      u.segment<6>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::inertia),
+      inertia);
+  buildInertiaTensor(
+      u.segment<6>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::dotInertia),
+      dotInertia);
 
-    for (unsigned i = 0; i<nbContacts ; ++i)
-    {
-        contactPosV.setValue(u.segment<3>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::contacts + 12*i),i);
-        contactOriV.setValue(u.segment<3>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::contacts +12*i+3),i);
-    }
+  for(unsigned i = 0; i < nbContacts; ++i)
+  {
+    contactPosV.setValue(
+        u.segment<3>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::contacts
+                     + 12 * i),
+        i);
+    contactOriV.setValue(
+        u.segment<3>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::input::contacts
+                     + 12 * i + 3),
+        i);
+  }
 
-    for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-    {
-        efforts[i]=x.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::fc+6*i,6);
-        fc_.segment<3>(3*i) = efforts[i].block<3,1>(0,0);
-        tc_.segment<3>(3*i) = efforts[i].block<3,1>(3,0);
-    }
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i)
+  {
+    efforts[i] =
+        x.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::fc + 6 * i, 6);
+    fc_.segment<3>(3 * i) = efforts[i].block<3, 1>(0, 0);
+    tc_.segment<3>(3 * i) = efforts[i].block<3, 1>(3, 0);
+  }
 
-//    est1.getEKF().getFunctor()->computeAccelerations(cl, dcl, ddcl, AngMomentum, dotAngMomentum, inertia, dotInertia,  contactPosV,
-//                                                    contactOriV, pos, vel, acc, oriV, rFlex, angVel, angAcc, fc_, tc_, fm, tm);
+  //    est1.getEKF().getFunctor()->computeAccelerations(cl, dcl, ddcl, AngMomentum, dotAngMomentum, inertia,
+  //    dotInertia,  contactPosV,
+  //                                                    contactOriV, pos, vel, acc, oriV, rFlex, angVel, angAcc, fc_,
+  //                                                    tc_, fm, tm);
 
-    Fc = gmuz + 56.8*(2*kine::skewSymmetric(angVel)*rFlex*dcl+rFlex*ddcl);
+  Fc = gmuz + 56.8 * (2 * kine::skewSymmetric(angVel) * rFlex * dcl + rFlex * ddcl);
 
-    return Fc;
+  return Fc;
 }
 
 int test()
 {
-    std::cout << "Starting" << std::endl;
+  std::cout << "Starting" << std::endl;
 
-    // For measurement vector
-    bool withUnmodeledForces_ = false;
-    bool withForceSensors_=true;
-    bool withAbsolutePose_ = false;
+  // For measurement vector
+  bool withUnmodeledForces_ = false;
+  bool withForceSensors_ = true;
+  bool withAbsolutePose_ = false;
 
-    // For state vector
-    bool withComBias_=false;
+  // For state vector
+  bool withComBias_ = false;
 
-    // Time
-    const double dt=5e-3;
-    const unsigned kinit=10000; //3500; //3758; //
-    const unsigned kmax=11500; //5700; //5100; //
+  // Time
+  const double dt = 5e-3;
+  const unsigned kinit = 10000; // 3500; //3758; //
+  const unsigned kmax = 11500; // 5700; //5100; //
 
-    // Fix sizes
-    const unsigned measurementSizeBase=6;
-    const unsigned inputSizeBase=42;
-    const unsigned stateSize=35;
+  // Fix sizes
+  const unsigned measurementSizeBase = 6;
+  const unsigned inputSizeBase = 42;
+  const unsigned stateSize = 35;
 
-    /// Definitions of input vectors
-     // Measurement
-     IndexedMatrixArray y;
-     std::cout << "Loading measurements file" << std::endl;
-     y.readFromFile("source_measurement.dat",1,30);
+  /// Definitions of input vectors
+  // Measurement
+  IndexedMatrixArray y;
+  std::cout << "Loading measurements file" << std::endl;
+  y.readFromFile("source_measurement.dat", 1, 30);
 
-     // Input
-     IndexedMatrixArray u;
-     std::cout << "Loading input file" << std::endl;
-     u.readFromFile("source_input.dat",1,66);
+  // Input
+  IndexedMatrixArray u;
+  std::cout << "Loading input file" << std::endl;
+  u.readFromFile("source_input.dat", 1, 66);
 
-     // Number of support contacts
-     IndexedMatrixArray nbSupport;
-     std::cout << "Loading the number of supports file" << std::endl;
-     nbSupport.readFromFile("source_nbSupport.dat",1,1);
+  // Number of support contacts
+  IndexedMatrixArray nbSupport;
+  std::cout << "Loading the number of supports file" << std::endl;
+  nbSupport.readFromFile("source_nbSupport.dat", 1, 1);
 
-     // CoM bias
-     IndexedMatrixArray bias;
-     std::cout << "Loading comBias file" << std::endl;
-     bias.readFromFile("source_comBias.dat",1,35);
+  // CoM bias
+  IndexedMatrixArray bias;
+  std::cout << "Loading comBias file" << std::endl;
+  bias.readFromFile("source_comBias.dat", 1, 35);
 
-     // Zmp ref
-     IndexedMatrixArray zmpRef;
-     std::cout << "Loading zmpRef file" << std::endl;
-     zmpRef.readFromFile("source_zmpRef.dat",1,3);
+  // Zmp ref
+  IndexedMatrixArray zmpRef;
+  std::cout << "Loading zmpRef file" << std::endl;
+  zmpRef.readFromFile("source_zmpRef.dat", 1, 3);
 
-    /// Definition of ouptut vectors
-     // State: what we want
-     IndexedMatrixArray x_output;
-     // State: what we want
-     IndexedMatrixArray xPredicted_output;
-     // Measurement
-     IndexedMatrixArray y_output;
-     // Input
-     IndexedMatrixArray u_output;
+  /// Definition of ouptut vectors
+  // State: what we want
+  IndexedMatrixArray x_output;
+  // State: what we want
+  IndexedMatrixArray xPredicted_output;
+  // Measurement
+  IndexedMatrixArray y_output;
+  // Input
+  IndexedMatrixArray u_output;
 
-     // Zmp from sensors
-     IndexedMatrixArray sensorZmp_output;
-     // Zmp from filter
-     IndexedMatrixArray filteredZmp_output;
-     // reference Zmp
-     IndexedMatrixArray referenceZmp_output;
+  // Zmp from sensors
+  IndexedMatrixArray sensorZmp_output;
+  // Zmp from filter
+  IndexedMatrixArray filteredZmp_output;
+  // reference Zmp
+  IndexedMatrixArray referenceZmp_output;
 
-    std::cout << "Creating estimator" <<std::endl;
+  std::cout << "Creating estimator" << std::endl;
 
-    stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU est;
-    est.setSamplingPeriod(dt);
+  stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU est;
+  est.setSamplingPeriod(dt);
 
-    // Model
-    est.setContactModel(1);
-    est.setRobotMass(56.8);
-    est.setKfe(40000*Matrix3::Identity());
-    est.setKte(350*Matrix3::Identity());
-    est.setKfv(600*Matrix3::Identity());
-    est.setKtv(10*Matrix3::Identity());
+  // Model
+  est.setContactModel(1);
+  est.setRobotMass(56.8);
+  est.setKfe(40000 * Matrix3::Identity());
+  est.setKte(350 * Matrix3::Identity());
+  est.setKfv(600 * Matrix3::Identity());
+  est.setKtv(10 * Matrix3::Identity());
 
-    // Config
-    est.setWithUnmodeledForces(withUnmodeledForces_);
-    est.setWithForcesMeasurements(withForceSensors_);
-    est.setWithAbsolutePos(withAbsolutePose_);
-    est.setWithComBias(withComBias_);
+  // Config
+  est.setWithUnmodeledForces(withUnmodeledForces_);
+  est.setWithForcesMeasurements(withForceSensors_);
+  est.setWithAbsolutePos(withAbsolutePose_);
+  est.setWithComBias(withComBias_);
 
-    std::cout << "Setting covariances" << std::endl;
+  std::cout << "Setting covariances" << std::endl;
 
-    // Measurement noise covariance
-    stateObservation::Matrix R_; R_.resize(measurementSizeBase,measurementSizeBase); R_.setIdentity();
-    R_.block(0,0,3,3)*=1.e-3;
-    R_.block(3,3,3,3)*=1.e-6;
-    est.setMeasurementNoiseCovariance(R_);
-    est.setUnmodeledForceVariance(1e-13);
-    est.setForceVariance(1.e-6);
-    est.setAbsolutePosVariance(1e-4);
+  // Measurement noise covariance
+  stateObservation::Matrix R_;
+  R_.resize(measurementSizeBase, measurementSizeBase);
+  R_.setIdentity();
+  R_.block(0, 0, 3, 3) *= 1.e-3;
+  R_.block(3, 3, 3, 3) *= 1.e-6;
+  est.setMeasurementNoiseCovariance(R_);
+  est.setUnmodeledForceVariance(1e-13);
+  est.setForceVariance(1.e-6);
+  est.setAbsolutePosVariance(1e-4);
 
-    // Process noise covariance
-    stateObservation::Matrix Q_; Q_.resize(stateSize,stateSize); Q_.setIdentity();
-    Q_.block(0,0,12,12)*=1.e-8;
-    Q_.block(12,12,12,12)*=1.e-4;
-    Q_.block(24,24,6,6)*=1.e-2;
-    Q_.block(30,30,2,2)*=1.e-7;
-    Q_.block(32,32,3,3)*=1.e-8;
-    est.setProcessNoiseCovariance(Q_);
+  // Process noise covariance
+  stateObservation::Matrix Q_;
+  Q_.resize(stateSize, stateSize);
+  Q_.setIdentity();
+  Q_.block(0, 0, 12, 12) *= 1.e-8;
+  Q_.block(12, 12, 12, 12) *= 1.e-4;
+  Q_.block(24, 24, 6, 6) *= 1.e-2;
+  Q_.block(30, 30, 2, 2) *= 1.e-7;
+  Q_.block(32, 32, 3, 3) *= 1.e-8;
+  est.setProcessNoiseCovariance(Q_);
 
-    // Temporary variables
-    stateObservation::Vector input, measurement;
-    Vector x; x.resize(stateSize);
-    Vector xPredicted; xPredicted.resize(stateSize);
-    unsigned contactNbr;
-    Index inputSize, measurementSize;
+  // Temporary variables
+  stateObservation::Vector input, measurement;
+  Vector x;
+  x.resize(stateSize);
+  Vector xPredicted;
+  xPredicted.resize(stateSize);
+  unsigned contactNbr;
+  Index inputSize, measurementSize;
 
-    stateObservation::IndexedMatrixArray measurementForces, filteredForces, inputFeetPositions;
-    stateObservation::Vector sensorZmp, filteredZmp;
-    stateObservation::Vector6 filteredForcesk, measurementForcesk;
-    stateObservation::Matrix4 inputFeetPositionsk;
+  stateObservation::IndexedMatrixArray measurementForces, filteredForces, inputFeetPositions;
+  stateObservation::Vector sensorZmp, filteredZmp;
+  stateObservation::Vector6 filteredForcesk, measurementForcesk;
+  stateObservation::Matrix4 inputFeetPositionsk;
 
-    std::cout << "Beginning reconstruction "<<std::endl;
+  std::cout << "Beginning reconstruction " << std::endl;
 
-    for (unsigned k=kinit;k<kmax;++k)
+  for(unsigned k = kinit; k < kmax; ++k)
+  {
+    std::cout << "\n" << k << std::endl;
+
+    if(nbSupport[k](0) != est.getContactsNumber())
     {
-        std::cout << "\n" << k << std::endl;
-
-        if(nbSupport[k](0)!=est.getContactsNumber())
-        {
-            contactNbr = unsigned(nbSupport[k](0));
-            est.setContactsNumber(contactNbr);
-        }
-
-        measurementSize = est.getMeasurementSize();
-        measurement.resize(measurementSize);
-        measurement = (y[k].block(0,0,1,measurementSize)).transpose();
-        est.setMeasurement(measurement);
-
-        inputSize = est.getInputSize();
-        input.resize(inputSize);
-        input = (u[k+1].block(0,0,1,inputSize)).transpose();
-        est.setMeasurementInput(input);
-
-        xPredicted = est.getEKF().getFunctor()->stateDynamics(x,(u[k-1].block(0,0,1,inputSize)).transpose(),0);
-        xPredicted.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::fc,12)
-               = x.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::fc,12);
-
-        x = est.getFlexibilityVector();
-
-        // Compute Zmp from sensor and filter
-        for(unsigned i=0;i<contactNbr;++i)
-        {
-            measurementForcesk = y[k].block<1,6>(0,measurementSizeBase+withUnmodeledForces_*6+i*6).transpose();
-            filteredForcesk = x.segment<6>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::fc+i*6);
-            inputFeetPositionsk = kine::vector6ToHomogeneousMatrix(u[k].block<1,6>(0,inputSizeBase+i*12)).transpose();
-
-//            measurementForcesk.segment<3>(0) = inputFeetPositionsk.block(0,0,3,3).transpose()*measurementForcesk.segment<3>(0);
-//            measurementForcesk.segment<3>(3) = inputFeetPositionsk.block(0,0,3,3).transpose()*measurementForcesk.segment<3>(3)
-//                                               +kine::skewSymmetric(inputFeetPositionsk.block(0,0,3,3).transpose()*inputFeetPositionsk.block(0,3,3,1))*measurementForcesk.segment<3>(0);
-//
-//            filteredForcesk.segment<3>(0) = inputFeetPositionsk.block(0,0,3,3).transpose()*filteredForcesk.segment<3>(0);
-//            filteredForcesk.segment<3>(3) = inputFeetPositionsk.block(0,0,3,3).transpose()*filteredForcesk.segment<3>(3)
-//                                               -kine::skewSymmetric(inputFeetPositionsk.block(0,0,3,3).transpose()*inputFeetPositionsk.block(0,3,3,1))*filteredForcesk.segment<3>(0);
-
-            measurementForces.setValue(measurementForcesk,i);
-            filteredForces.setValue(filteredForcesk,i);
-            stateObservation::Matrix4 identity(stateObservation::Matrix4::Identity());
-            inputFeetPositions.setValue(identity,TimeIndex(i));
-        }
-        sensorZmp=computeZmp(contactNbr, measurementForces, inputFeetPositions);
-        filteredZmp=computeZmp(contactNbr, filteredForces, inputFeetPositions);
-
-        x_output.setValue(x,k);
-        xPredicted_output.setValue(xPredicted,k);
-        y_output.setValue(y[k],k);
-        u_output.setValue(u[k],k);
-        sensorZmp_output.setValue(sensorZmp,k);
-        filteredZmp_output.setValue(filteredZmp,k);
-        referenceZmp_output.setValue(zmpRef[k],k);
+      contactNbr = unsigned(nbSupport[k](0));
+      est.setContactsNumber(contactNbr);
     }
 
-    std::cout << "Completed "<<std::endl;
+    measurementSize = est.getMeasurementSize();
+    measurement.resize(measurementSize);
+    measurement = (y[k].block(0, 0, 1, measurementSize)).transpose();
+    est.setMeasurement(measurement);
 
-    x_output.writeInFile("state.dat");
-    xPredicted_output.writeInFile("statePredicted.dat");
-    y_output.writeInFile("measurement.dat");
-    u_output.writeInFile("input.dat");
-    sensorZmp_output.writeInFile("sensorZmp.dat");
-    filteredZmp_output.writeInFile("filteredZmp.dat");
-    referenceZmp_output.writeInFile("referenceZmp.dat");
+    inputSize = est.getInputSize();
+    input.resize(inputSize);
+    input = (u[k + 1].block(0, 0, 1, inputSize)).transpose();
+    est.setMeasurementInput(input);
 
-    return 1;
+    xPredicted = est.getEKF().getFunctor()->stateDynamics(x, (u[k - 1].block(0, 0, 1, inputSize)).transpose(), 0);
+    xPredicted.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::fc, 12) =
+        x.segment(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::fc, 12);
+
+    x = est.getFlexibilityVector();
+
+    // Compute Zmp from sensor and filter
+    for(unsigned i = 0; i < contactNbr; ++i)
+    {
+      measurementForcesk = y[k].block<1, 6>(0, measurementSizeBase + withUnmodeledForces_ * 6 + i * 6).transpose();
+      filteredForcesk =
+          x.segment<6>(stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::fc + i * 6);
+      inputFeetPositionsk = kine::vector6ToHomogeneousMatrix(u[k].block<1, 6>(0, inputSizeBase + i * 12)).transpose();
+
+      //            measurementForcesk.segment<3>(0) =
+      //            inputFeetPositionsk.block(0,0,3,3).transpose()*measurementForcesk.segment<3>(0);
+      //            measurementForcesk.segment<3>(3) =
+      //            inputFeetPositionsk.block(0,0,3,3).transpose()*measurementForcesk.segment<3>(3)
+      //                                               +kine::skewSymmetric(inputFeetPositionsk.block(0,0,3,3).transpose()*inputFeetPositionsk.block(0,3,3,1))*measurementForcesk.segment<3>(0);
+      //
+      //            filteredForcesk.segment<3>(0) =
+      //            inputFeetPositionsk.block(0,0,3,3).transpose()*filteredForcesk.segment<3>(0);
+      //            filteredForcesk.segment<3>(3) =
+      //            inputFeetPositionsk.block(0,0,3,3).transpose()*filteredForcesk.segment<3>(3)
+      //                                               -kine::skewSymmetric(inputFeetPositionsk.block(0,0,3,3).transpose()*inputFeetPositionsk.block(0,3,3,1))*filteredForcesk.segment<3>(0);
+
+      measurementForces.setValue(measurementForcesk, i);
+      filteredForces.setValue(filteredForcesk, i);
+      stateObservation::Matrix4 identity(stateObservation::Matrix4::Identity());
+      inputFeetPositions.setValue(identity, TimeIndex(i));
+    }
+    sensorZmp = computeZmp(contactNbr, measurementForces, inputFeetPositions);
+    filteredZmp = computeZmp(contactNbr, filteredForces, inputFeetPositions);
+
+    x_output.setValue(x, k);
+    xPredicted_output.setValue(xPredicted, k);
+    y_output.setValue(y[k], k);
+    u_output.setValue(u[k], k);
+    sensorZmp_output.setValue(sensorZmp, k);
+    filteredZmp_output.setValue(filteredZmp, k);
+    referenceZmp_output.setValue(zmpRef[k], k);
+  }
+
+  std::cout << "Completed " << std::endl;
+
+  x_output.writeInFile("state.dat");
+  xPredicted_output.writeInFile("statePredicted.dat");
+  y_output.writeInFile("measurement.dat");
+  u_output.writeInFile("input.dat");
+  sensorZmp_output.writeInFile("sensorZmp.dat");
+  filteredZmp_output.writeInFile("filteredZmp.dat");
+  referenceZmp_output.writeInFile("referenceZmp.dat");
+
+  return 1;
 }
 
 int main()
 {
-    return test();
+  return test();
 }

--- a/misc-tools/zmpEstimation.cpp
+++ b/misc-tools/zmpEstimation.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 //#include <state-observation/noise/gaussian-white-noise.hpp>
 //#include <state-observation/examples/offline-ekf-flexibility-estimation.hpp>
@@ -14,346 +14,302 @@ using namespace stateObservation;
 
 timespec diff(const timespec & start, const timespec & end)
 {
-        timespec temp;
-        if ((end.tv_nsec-start.tv_nsec)<0) {
-                temp.tv_sec = end.tv_sec-start.tv_sec-1;
-                temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
-        } else {
-                temp.tv_sec = end.tv_sec-start.tv_sec;
-                temp.tv_nsec = end.tv_nsec-start.tv_nsec;
-        }
-        return temp;
+  timespec temp;
+  if((end.tv_nsec - start.tv_nsec) < 0)
+  {
+    temp.tv_sec = end.tv_sec - start.tv_sec - 1;
+    temp.tv_nsec = 1000000000 + end.tv_nsec - start.tv_nsec;
+  }
+  else
+  {
+    temp.tv_sec = end.tv_sec - start.tv_sec;
+    temp.tv_nsec = end.tv_nsec - start.tv_nsec;
+  }
+  return temp;
 }
 
-Vector computeZmp (Vector& forces, Matrix& sensorPosition1, Matrix& sensorPosition2, unsigned contactNbr)
+Vector computeZmp(Vector & forces, Matrix & sensorPosition1, Matrix & sensorPosition2, unsigned contactNbr)
 {
-    double fnormal = 0;
-    double sumZmpx = 0;
-    double sumZmpy = 0;
-    double sumZmpz = 0;
-    Vector zmp;
-    zmp.resize (3);
+  double fnormal = 0;
+  double sumZmpx = 0;
+  double sumZmpy = 0;
+  double sumZmpz = 0;
+  Vector zmp;
+  zmp.resize(3);
 
-    for (unsigned int i=0; i<contactNbr; ++i) {
-      const Vector& f = forces.block(i*6,0,6,1);
-      // Check that force is of dimension 6
-      if (f.size () != 6) {
-        zmp.fill (0.);
-        return zmp;
-      }
-
-      Matrix M;
-      M.resize(4,4);
-      if (i==0)
-      {
-        M = sensorPosition1;
-
-      }
-      if (i==1)
-      {
-        M = sensorPosition2;
-
-      }
-
-     double fx = M (0,0) * f (0) + M(0,1) * f (1) + M (0,2) * f (2);
-     double fy = M (1,0) * f (0) + M(1,1) * f (1) + M (1,2) * f (2);
-     double fz = M (2,0) * f (0) + M(2,1) * f (1) + M (2,2) * f (2);
-
-      if (fz > 0) {
-    double Mx = M (0,0)*f(3) + M (0,1)*f(4) + M (0,2)*f(5)
-                + M (1,3)*fz - M (2,3)*fy;
-        double My = M (1,0)*f(3) + M (1,1)*f(4) + M (1,2)*f(5)
-                + M (2,3)*fx - M (0,3)*fz;
-        fnormal += fz;
-        sumZmpx -= My;
-        sumZmpy += Mx;
-        sumZmpz += fz * M (2,3);
-      }
+  for(unsigned int i = 0; i < contactNbr; ++i)
+  {
+    const Vector & f = forces.block(i * 6, 0, 6, 1);
+    // Check that force is of dimension 6
+    if(f.size() != 6)
+    {
+      zmp.fill(0.);
+      return zmp;
     }
-    if (fnormal != 0) {
-      zmp (0) = sumZmpx / fnormal;
-      zmp (1) = sumZmpy / fnormal;
-      zmp (2) = sumZmpz / fnormal;
-    } else {
-        zmp.fill (0.);
+
+    Matrix M;
+    M.resize(4, 4);
+    if(i == 0)
+    {
+      M = sensorPosition1;
     }
-    return zmp;
+    if(i == 1)
+    {
+      M = sensorPosition2;
+    }
+
+    double fx = M(0, 0) * f(0) + M(0, 1) * f(1) + M(0, 2) * f(2);
+    double fy = M(1, 0) * f(0) + M(1, 1) * f(1) + M(1, 2) * f(2);
+    double fz = M(2, 0) * f(0) + M(2, 1) * f(1) + M(2, 2) * f(2);
+
+    if(fz > 0)
+    {
+      double Mx = M(0, 0) * f(3) + M(0, 1) * f(4) + M(0, 2) * f(5) + M(1, 3) * fz - M(2, 3) * fy;
+      double My = M(1, 0) * f(3) + M(1, 1) * f(4) + M(1, 2) * f(5) + M(2, 3) * fx - M(0, 3) * fz;
+      fnormal += fz;
+      sumZmpx -= My;
+      sumZmpy += Mx;
+      sumZmpz += fz * M(2, 3);
+    }
+  }
+  if(fnormal != 0)
+  {
+    zmp(0) = sumZmpx / fnormal;
+    zmp(1) = sumZmpy / fnormal;
+    zmp(2) = sumZmpz / fnormal;
+  }
+  else
+  {
+    zmp.fill(0.);
+  }
+  return zmp;
 }
 
 int test()
 {
-    std::cout << "Starting" << std::endl;
+  std::cout << "Starting" << std::endl;
 
   /// sampling period
-    const double dt=5e-3;
+  const double dt = 5e-3;
 
-    stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU est;
+  stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU est;
 
   /// Measurement noise covariance
-    Matrix Cov;
-    Cov.resize(6,6);
-    double unitCov1 = 1e6;
-    double unitCov2 = 1e6;
-    Cov <<  unitCov1,0,0,0,0,0,
-            0,unitCov1,0,0,0,0,
-            0,0,unitCov1,0,0,0,
-            0,0,0,unitCov2,0,0,
-            0,0,0,0,unitCov2,0,
-            0,0,0,0,0,unitCov2;
+  Matrix Cov;
+  Cov.resize(6, 6);
+  double unitCov1 = 1e6;
+  double unitCov2 = 1e6;
+  Cov << unitCov1, 0, 0, 0, 0, 0, 0, unitCov1, 0, 0, 0, 0, 0, 0, unitCov1, 0, 0, 0, 0, 0, 0, unitCov2, 0, 0, 0, 0, 0, 0,
+      unitCov2, 0, 0, 0, 0, 0, 0, unitCov2;
 
   /// Initializations
-    // Dimensions
-    const unsigned long kinit=0;
-    const unsigned long kmax=42761;
-    const unsigned measurementSize=6;
+  // Dimensions
+  const unsigned long kinit = 0;
+  const unsigned long kmax = 42761;
+  const unsigned measurementSize = 6;
 
-    const unsigned stateSize=18;
-    unsigned contactNbr = 2;
-    // State initialization => not used here because it is set in model-base-ekf-flex-estimator-imu
+  const unsigned stateSize = 18;
+  unsigned contactNbr = 2;
+  // State initialization => not used here because it is set in model-base-ekf-flex-estimator-imu
 
+  const Index inputSize = est.getInputSize();
 
-    const Index inputSize=est.getInputSize();
+  // Input initialization
+  Vector u0 = Vector::Zero(inputSize - 6 * contactNbr, 1);
+  u0 << 0.0135672, 0.001536, 0.80771, -2.50425e-06, -1.03787e-08, 5.4317e-08, -2.50434e-06, -1.03944e-08, 5.45321e-08,
+      48.1348, 46.9498, 1.76068, -0.0863332, -0.59487, -0.0402246, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.098,
+      -1.21619e-10, 1.1174, 3.06752e-22, -1.06094e-20, 7.75345e-22, -2.84609e-06, -1.18496e-08, -4.52691e-18,
+      2.95535e-20, -1.0346e-18, 7.58731e-20, -0.000284609, -1.18496e-06, -4.52691e-16;
 
-     // Input initialization
-    Vector u0=Vector::Zero(inputSize-6*contactNbr,1);
-    u0 <<   0.0135672,
-            0.001536,
-            0.80771,
-            -2.50425e-06,
-            -1.03787e-08,
-            5.4317e-08,
-            -2.50434e-06,
-            -1.03944e-08,
-            5.45321e-08,
-            48.1348,
-            46.9498,
-            1.76068,
-            -0.0863332,
-            -0.59487,
-            -0.0402246,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            -0.098,
-            -1.21619e-10,
-            1.1174,
-            3.06752e-22,
-            -1.06094e-20,
-            7.75345e-22,
-            -2.84609e-06,
-            -1.18496e-08,
-            -4.52691e-18,
-            2.95535e-20,
-            -1.0346e-18,
-            7.58731e-20,
-            -0.000284609,
-            -1.18496e-06,
-            -4.52691e-16;
+  est.setSamplingPeriod(dt);
 
+  est.setInput(u0);
+  est.setMeasurementInput(u0);
 
-    est.setSamplingPeriod(dt);
+  est.setKfe(40000 * Matrix3::Identity());
+  est.setKfv(600 * Matrix3::Identity());
+  est.setKte(400 * Matrix3::Identity());
+  est.setKtv(10 * Matrix3::Identity());
 
-    est.setInput(u0);
-    est.setMeasurementInput(u0);
+  /// Definitions of input vectors
+  // Measurement
+  IndexedMatrixArray y;
+  std::cout << "Loading measurements file" << std::endl;
+  y.readFromFile("data/source_measurement.dat", 1, measurementSize);
+  // Input
+  IndexedMatrixArray u;
+  std::cout << "Loading input file" << std::endl;
+  u.readFromFile("data/source_input.dat", 1, inputSize);
+  // state
+  IndexedMatrixArray xRef;
+  std::cout << "Loading reference state file" << std::endl;
+  xRef.readFromFile("data/source_state.dat", stateSize, 1);
 
+  // zmp estimated ref
+  IndexedMatrixArray zmpEstimatedRef;
+  std::cout << "Loading reference zmpEstimated file" << std::endl;
+  zmpEstimatedRef.readFromFile("data/source_zmpestimated.dat", 3, 1);
+  // zmp
+  IndexedMatrixArray zmpRef;
+  std::cout << "Loading reference zmp file" << std::endl;
+  zmpRef.readFromFile("data/source_zmp.dat", 3, 1);
+  // forcesAndMoments
+  IndexedMatrixArray forcesAndMomentsRef;
+  std::cout << "Loading reference forcesAndMoments file" << std::endl;
+  forcesAndMomentsRef.readFromFile("data/source_forcesAndMoments.dat", 12, 1);
+  // forceLLEG
+  IndexedMatrixArray forceLLEGRef;
+  std::cout << "Loading reference forceLLEG file" << std::endl;
+  forceLLEGRef.readFromFile("data/source_forceLLEG.dat", 6, 1);
+  // forceRLEG
+  IndexedMatrixArray forceRLEGRef;
+  std::cout << "Loading reference forceRLEG file" << std::endl;
+  forceRLEGRef.readFromFile("data/source_forceRLEG.dat", 6, 1);
+  // forceLLEG estimated
+  IndexedMatrixArray forceLLEGEst;
+  std::cout << "Loading estimated forceLLEG file" << std::endl;
+  forceLLEGEst.readFromFile("data/source_forcesSupport1.dat", 6, 1);
+  // forceRLEG estimated
+  IndexedMatrixArray forceRLEGEst;
+  std::cout << "Loading estimated forceRLEG file" << std::endl;
+  forceRLEGEst.readFromFile("data/source_forcesSupport2.dat", 6, 1);
 
-    est.setKfe(40000*Matrix3::Identity());
-    est.setKfv(600*Matrix3::Identity());
-    est.setKte(400*Matrix3::Identity());
-    est.setKtv(10*Matrix3::Identity());
+  /// Definition of ouptut vectors
+  // State: what we want
+  IndexedMatrixArray x_output;
+  // Measurement
+  IndexedMatrixArray y_output;
+  // Input
+  IndexedMatrixArray u_output;
 
-   /// Definitions of input vectors
-     // Measurement
-     IndexedMatrixArray y;
-     std::cout << "Loading measurements file" << std::endl;
-     y.readFromFile("data/source_measurement.dat",1,measurementSize);
-     // Input
-     IndexedMatrixArray u;
-     std::cout << "Loading input file" << std::endl;
-     u.readFromFile("data/source_input.dat",1,inputSize);
-     //state
-     IndexedMatrixArray xRef;
-     std::cout << "Loading reference state file" << std::endl;
-     xRef.readFromFile("data/source_state.dat",stateSize,1);
+  // ZMP estimated
+  IndexedMatrixArray zmpEstimated_output;
+  IndexedMatrixArray zmpReEstimated_output;
+  // ZMP
+  IndexedMatrixArray zmp_output;
+  // force LLEG
+  IndexedMatrixArray forceLLEG_output;
+  // force RLEG
+  IndexedMatrixArray forceRLEG_output;
+  // forcesAndMoments
+  IndexedMatrixArray forcesAndMoments_output;
 
+  IndexedMatrixArray deltax_output;
 
-     //zmp estimated ref
-     IndexedMatrixArray zmpEstimatedRef;
-     std::cout << "Loading reference zmpEstimated file" << std::endl;
-     zmpEstimatedRef.readFromFile("data/source_zmpestimated.dat",3,1);
-     //zmp
-     IndexedMatrixArray zmpRef;
-     std::cout << "Loading reference zmp file" << std::endl;
-     zmpRef.readFromFile("data/source_zmp.dat",3,1);
-     //forcesAndMoments
-     IndexedMatrixArray forcesAndMomentsRef;
-     std::cout << "Loading reference forcesAndMoments file" << std::endl;
-     forcesAndMomentsRef.readFromFile("data/source_forcesAndMoments.dat",12,1);
-     //forceLLEG
-     IndexedMatrixArray forceLLEGRef;
-     std::cout << "Loading reference forceLLEG file" << std::endl;
-     forceLLEGRef.readFromFile("data/source_forceLLEG.dat",6,1);
-     //forceRLEG
-     IndexedMatrixArray forceRLEGRef;
-     std::cout << "Loading reference forceRLEG file" << std::endl;
-     forceRLEGRef.readFromFile("data/source_forceRLEG.dat",6,1);
-     //forceLLEG estimated
-     IndexedMatrixArray forceLLEGEst;
-     std::cout << "Loading estimated forceLLEG file" << std::endl;
-     forceLLEGEst.readFromFile("data/source_forcesSupport1.dat",6,1);
-     //forceRLEG estimated
-     IndexedMatrixArray forceRLEGEst;
-     std::cout << "Loading estimated forceRLEG file" << std::endl;
-     forceRLEGEst.readFromFile("data/source_forcesSupport2.dat",6,1);
+  est.setMeasurementNoiseCovariance(Cov);
+  est.setContactsNumber(contactNbr);
 
-   /// Definition of ouptut vectors
-     // State: what we want
-     IndexedMatrixArray x_output;
-     // Measurement
-     IndexedMatrixArray y_output;
-     // Input
-     IndexedMatrixArray u_output;
+  Vector flexibility;
+  flexibility.resize(18);
+  Vector xdifference(flexibility);
 
-     // ZMP estimated
-     IndexedMatrixArray zmpEstimated_output;
-     IndexedMatrixArray zmpReEstimated_output;
-     // ZMP
-     IndexedMatrixArray zmp_output;
-     // force LLEG
-     IndexedMatrixArray forceLLEG_output;
-     // force RLEG
-     IndexedMatrixArray forceRLEG_output;
-     // forcesAndMoments
-     IndexedMatrixArray forcesAndMoments_output;
+  Vector forcesAndMoments_source;
+  forcesAndMoments_source.resize(12);
 
-     IndexedMatrixArray deltax_output;
+  Vector forcesAndMomentsReference;
+  forcesAndMomentsReference.resize(12);
 
-     est.setMeasurementNoiseCovariance(Cov);
-     est.setContactsNumber(contactNbr);
+  stateObservation::Vector forcesAndMoments;
+  forcesAndMoments.resize(12);
+  Vector forcesAndMomentsReal;
+  forcesAndMomentsReal.resize(12);
+  Vector zmpEstimated, zmpReEstimated;
+  zmpEstimated.resize(3), zmpReEstimated.resize(3);
+  Vector zmp;
+  zmp.resize(3);
 
-    Vector flexibility;
-    flexibility.resize(18);
-    Vector xdifference(flexibility);
+  est.setContactModel(
+      stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU::contactModel::elasticContact);
 
-    Vector forcesAndMoments_source;
-    forcesAndMoments_source.resize(12);
+  Matrix sensorPosition1, sensorPosition2, sensorPosition1Est, sensorPosition2Est;
+  sensorPosition1.resize(4, 4);
+  sensorPosition2.resize(4, 4);
+  sensorPosition1Est.resize(4, 4);
+  sensorPosition2Est.resize(4, 4);
 
-    Vector forcesAndMomentsReference;
-    forcesAndMomentsReference.resize(12);
+  std::cout << "Beginning reconstruction " << std::endl;
+  for(unsigned long k = kinit + 2; k < kmax; ++k)
+  {
+    est.setMeasurement(y[k].transpose());
+    est.setMeasurementInput(u[k].transpose());
 
-    stateObservation::Vector forcesAndMoments;
-    forcesAndMoments.resize(12);
-    Vector forcesAndMomentsReal;
-    forcesAndMomentsReal.resize(12);
-    Vector zmpEstimated, zmpReEstimated;
-    zmpEstimated.resize(3), zmpReEstimated.resize(3);
-    Vector zmp;
-    zmp.resize(3);
+    flexibility = est.getFlexibilityVector();
 
-    est.setContactModel(stateObservation::flexibilityEstimation::
-                ModelBaseEKFFlexEstimatorIMU::contactModel::elasticContact);
+    x_output.setValue(flexibility, k);
+    y_output.setValue(y[k], k);
+    u_output.setValue(u[k], k);
 
-    Matrix sensorPosition1, sensorPosition2, sensorPosition1Est, sensorPosition2Est;
-    sensorPosition1.resize(4,4);
-    sensorPosition2.resize(4,4);
-    sensorPosition1Est.resize(4,4);
-    sensorPosition2Est.resize(4,4);
+    forcesAndMomentsReference = forcesAndMomentsRef[k];
+    forcesAndMoments = est.getForcesAndMoments();
+    //        forcesAndMoments.block(0,0,6,1)=forceRLEGEst[k];
+    //        forcesAndMoments.block(6,0,6,1)=forceLLEGEst[k];
 
-    std::cout << "Beginning reconstruction "<<std::endl;
-    for (unsigned long k=kinit+2;k<kmax;++k)
+    // Compute forces and ZMP estimated in this code
+    sensorPosition1 = kine::vector6ToHomogeneousMatrix((u[k].block(0, 42, 1, 6)).transpose());
+    sensorPosition2 = kine::vector6ToHomogeneousMatrix((u[k].block(0, 48, 1, 6)).transpose());
+    zmpReEstimated = computeZmp(forcesAndMoments, sensorPosition1, sensorPosition2, contactNbr);
+
+    //        // Compute forces and ZMP estimated
+    //        sensorPosition1Est=kine::vector6ToHomogeneousMatrix((u[k].block(0,42,1,6)).transpose());
+    //        sensorPosition2Est=kine::vector6ToHomogeneousMatrix((u[k].block(0,48,1,6)).transpose());
+    //        sensorPosition1Est(0,3)=0;
+    //        sensorPosition2Est(0,3)=0;
+    //        zmpEstimated=computeZmp (forcesAndMoments, sensorPosition1Est, sensorPosition2Est, contactNbr);
+
+    //        // Compute ZMP real
+    //        forcesAndMoments_source.block(0,0,6,1)=forceRLEGRef[k];
+    //        forcesAndMoments_source.block(6,0,6,1)=forceLLEGRef[k];
+    //        zmp=computeZmp (forcesAndMoments_source, sensorPosition1, sensorPosition2, contactNbr);
+
+    if(zmpEstimated(0) > 100)
     {
-        est.setMeasurement(y[k].transpose());
-        est.setMeasurementInput(u[k].transpose());
-
-        flexibility = est.getFlexibilityVector();
-
-        x_output.setValue(flexibility,k);
-        y_output.setValue(y[k],k);
-        u_output.setValue(u[k],k);
-
-        forcesAndMomentsReference=forcesAndMomentsRef[k];
-        forcesAndMoments = est.getForcesAndMoments();
-//        forcesAndMoments.block(0,0,6,1)=forceRLEGEst[k];
-//        forcesAndMoments.block(6,0,6,1)=forceLLEGEst[k];
-
-        // Compute forces and ZMP estimated in this code
-        sensorPosition1=kine::vector6ToHomogeneousMatrix((u[k].block(0,42,1,6)).transpose());
-        sensorPosition2=kine::vector6ToHomogeneousMatrix((u[k].block(0,48,1,6)).transpose());
-        zmpReEstimated=computeZmp (forcesAndMoments, sensorPosition1, sensorPosition2, contactNbr);
-
-//        // Compute forces and ZMP estimated
-//        sensorPosition1Est=kine::vector6ToHomogeneousMatrix((u[k].block(0,42,1,6)).transpose());
-//        sensorPosition2Est=kine::vector6ToHomogeneousMatrix((u[k].block(0,48,1,6)).transpose());
-//        sensorPosition1Est(0,3)=0;
-//        sensorPosition2Est(0,3)=0;
-//        zmpEstimated=computeZmp (forcesAndMoments, sensorPosition1Est, sensorPosition2Est, contactNbr);
-
-//        // Compute ZMP real
-//        forcesAndMoments_source.block(0,0,6,1)=forceRLEGRef[k];
-//        forcesAndMoments_source.block(6,0,6,1)=forceLLEGRef[k];
-//        zmp=computeZmp (forcesAndMoments_source, sensorPosition1, sensorPosition2, contactNbr);
-
-        if(zmpEstimated(0)>100)
-        {
-            zmpEstimated(0)=100;
-        }
-        if(zmpEstimated(1)>100)
-        {
-            zmpEstimated(1)=100;
-        }
-        if(zmpEstimated(2)>100)
-        {
-            zmpEstimated(2)=100;
-        }
-        if(zmpEstimated(0)<-100)
-        {
-            zmpEstimated(0)=-100;
-        }
-        if(zmpEstimated(1)<-100)
-        {
-            zmpEstimated(1)=-100;
-        }
-        if(zmpEstimated(2)<-100)
-        {
-            zmpEstimated(2)=-100;
-        }
-
-        forcesAndMoments_output.setValue(forcesAndMoments,k);
-        zmpReEstimated_output.setValue(zmpReEstimated,k);
-        //zmp_output.setValue(zmp,k);
-
+      zmpEstimated(0) = 100;
+    }
+    if(zmpEstimated(1) > 100)
+    {
+      zmpEstimated(1) = 100;
+    }
+    if(zmpEstimated(2) > 100)
+    {
+      zmpEstimated(2) = 100;
+    }
+    if(zmpEstimated(0) < -100)
+    {
+      zmpEstimated(0) = -100;
+    }
+    if(zmpEstimated(1) < -100)
+    {
+      zmpEstimated(1) = -100;
+    }
+    if(zmpEstimated(2) < -100)
+    {
+      zmpEstimated(2) = -100;
     }
 
-    std::cout << "Completed "<<std::endl;
+    forcesAndMoments_output.setValue(forcesAndMoments, k);
+    zmpReEstimated_output.setValue(zmpReEstimated, k);
+    // zmp_output.setValue(zmp,k);
+  }
 
-    x_output.writeInFile("state.dat");
-    std::cout << "coucou" << std::endl;
-    y_output.writeInFile("measurement.dat");
-    std::cout << "coucou" << std::endl;
-    u_output.writeInFile("input.dat");
-    std::cout << "coucou" << std::endl;
-    forcesAndMoments_output.writeInFile("forcesAndMoments.dat");
-    std::cout << "coucou" << std::endl;
-    zmpReEstimated_output.writeInFile("zmpReEstimated.dat");
-    std::cout << "coucou" << std::endl;
-    //zmp_output.writeInFile("zmp.dat");
+  std::cout << "Completed " << std::endl;
 
-    return 0;
+  x_output.writeInFile("state.dat");
+  std::cout << "coucou" << std::endl;
+  y_output.writeInFile("measurement.dat");
+  std::cout << "coucou" << std::endl;
+  u_output.writeInFile("input.dat");
+  std::cout << "coucou" << std::endl;
+  forcesAndMoments_output.writeInFile("forcesAndMoments.dat");
+  std::cout << "coucou" << std::endl;
+  zmpReEstimated_output.writeInFile("zmpReEstimated.dat");
+  std::cout << "coucou" << std::endl;
+  // zmp_output.writeInFile("zmp.dat");
 
+  return 0;
 }
 
 int main()
 {
 
-    return test();
-
+  return test();
 }

--- a/src/accelerometer-gyrometer-magnetometer.cpp
+++ b/src/accelerometer-gyrometer-magnetometer.cpp
@@ -2,71 +2,63 @@
 
 namespace stateObservation
 {
-    AccelerometerGyrometerMagnetometer::AccelerometerGyrometerMagnetometer():
-    r_(Matrix3::Zero()),
-    acc_(Vector3::Zero()),
-    omega_(Vector3::Zero()),
-    magne_(Vector3::Zero()),
-    output_(Vector::Zero(measurementSize_,1)),
-    currentStateSize_(stateSize_)
-    {
+AccelerometerGyrometerMagnetometer::AccelerometerGyrometerMagnetometer()
+: r_(Matrix3::Zero()), acc_(Vector3::Zero()), omega_(Vector3::Zero()), magne_(Vector3::Zero()),
+  output_(Vector::Zero(measurementSize_, 1)), currentStateSize_(stateSize_)
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-      std::cout<<std::endl<<"AccelerometerGyrometerMagnetometer Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+  std::cout << std::endl << "AccelerometerGyrometerMagnetometer Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
 
-      matrixMode_=false;
+  matrixMode_ = false;
 
-      // This is the magnetic field in Toulouse, in uT.
-      magne_ [0] = 0;
-      magne_ [1] = 32;
-      magne_ [2] = -37;
-    }
-
-
-    Index AccelerometerGyrometerMagnetometer::getStateSize_() const
-    {
-        return currentStateSize_;
-    }
-
-    Index AccelerometerGyrometerMagnetometer::getMeasurementSize_() const
-    {
-        return measurementSize_;
-    }
-
-    Vector AccelerometerGyrometerMagnetometer::computeNoiselessMeasurement_()
-    {
-      if (!matrixMode_)
-      {
-        Quaternion q(state_.head<4>());
-        r_=q.toRotationMatrix();
-
-        acc_= state_.segment(4,3);
-        omega_= state_.tail(3);
-      }
-      else
-      {
-        r_=Eigen::Map<Matrix3>(&state_[0]);
-        acc_= state_.segment<3>(9);
-        omega_ = state_.tail<3>();
-      }
-
-      output_.head<3>()=accelerationMeasure(acc_,r_);
-      output_.segment<3>(3)=rotationVelocityMeasure(omega_, r_);
-      output_.tail<3>()=magneticFieldMeasure(r_);
-
-      return output_;
-    }
-
-    void AccelerometerGyrometerMagnetometer::setMatrixMode(bool matrixMode)
-    {
-      matrixMode_=matrixMode;
-      if (!matrixMode_)
-        currentStateSize_= stateSize_;
-      else
-        currentStateSize_= stateSizeMatrix_;
-
-
-    }
-
-
+  // This is the magnetic field in Toulouse, in uT.
+  magne_[0] = 0;
+  magne_[1] = 32;
+  magne_[2] = -37;
 }
+
+Index AccelerometerGyrometerMagnetometer::getStateSize_() const
+{
+  return currentStateSize_;
+}
+
+Index AccelerometerGyrometerMagnetometer::getMeasurementSize_() const
+{
+  return measurementSize_;
+}
+
+Vector AccelerometerGyrometerMagnetometer::computeNoiselessMeasurement_()
+{
+  if(!matrixMode_)
+  {
+    Quaternion q(state_.head<4>());
+    r_ = q.toRotationMatrix();
+
+    acc_ = state_.segment(4, 3);
+    omega_ = state_.tail(3);
+  }
+  else
+  {
+    r_ = Eigen::Map<Matrix3>(&state_[0]);
+    acc_ = state_.segment<3>(9);
+    omega_ = state_.tail<3>();
+  }
+
+  output_.head<3>() = accelerationMeasure(acc_, r_);
+  output_.segment<3>(3) = rotationVelocityMeasure(omega_, r_);
+  output_.tail<3>() = magneticFieldMeasure(r_);
+
+  return output_;
+}
+
+void AccelerometerGyrometerMagnetometer::setMatrixMode(bool matrixMode)
+{
+  matrixMode_ = matrixMode;
+  if(!matrixMode_)
+    currentStateSize_ = stateSize_;
+  else
+    currentStateSize_ = stateSizeMatrix_;
+}
+
+} // namespace stateObservation

--- a/src/accelerometer-gyrometer.cpp
+++ b/src/accelerometer-gyrometer.cpp
@@ -2,62 +2,57 @@
 
 namespace stateObservation
 {
-    AccelerometerGyrometer::AccelerometerGyrometer():
-    r_(Matrix3::Zero()),
-    acc_(Vector3::Zero()),
-    omega_(Vector3::Zero()),
-    output_(Vector::Zero(measurementSize_,1)),
-    currentStateSize_(stateSize_)
-    {
+AccelerometerGyrometer::AccelerometerGyrometer()
+: r_(Matrix3::Zero()), acc_(Vector3::Zero()), omega_(Vector3::Zero()), output_(Vector::Zero(measurementSize_, 1)),
+  currentStateSize_(stateSize_)
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-      std::cout<<std::endl<<"AccelerometerGyrometer Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+  std::cout << std::endl << "AccelerometerGyrometer Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
 
-      matrixMode_=false;
-    }
-
-
-    Index AccelerometerGyrometer::getStateSize_() const
-    {
-        return currentStateSize_;
-    }
-
-    Index AccelerometerGyrometer::getMeasurementSize_() const
-    {
-        return measurementSize_;
-    }
-
-    Vector AccelerometerGyrometer::computeNoiselessMeasurement_()
-    {
-      if (!matrixMode_)
-      {
-        Quaternion q(state_.head<4>());
-
-        r_=q.toRotationMatrix();
-        acc_= state_.segment(4,3);
-        omega_= state_.tail(3);
-      }
-      else
-      {
-        r_=Eigen::Map<Matrix3>(&state_[0]);
-        acc_= state_.segment<3>(9);
-        omega_ = state_.tail<3>();
-      }
-
-      output_.head<3>()=accelerationMeasure(acc_,r_);
-      output_.tail<3>()=rotationVelocityMeasure(omega_, r_);
-
-      return output_;
-    }
-
-    void AccelerometerGyrometer::setMatrixMode(bool matrixMode)
-    {
-      matrixMode_=matrixMode;
-      if (!matrixMode_)
-        currentStateSize_= stateSize_;
-      else
-        currentStateSize_= stateSizeMatrix_;
-    }
-
-
+  matrixMode_ = false;
 }
+
+Index AccelerometerGyrometer::getStateSize_() const
+{
+  return currentStateSize_;
+}
+
+Index AccelerometerGyrometer::getMeasurementSize_() const
+{
+  return measurementSize_;
+}
+
+Vector AccelerometerGyrometer::computeNoiselessMeasurement_()
+{
+  if(!matrixMode_)
+  {
+    Quaternion q(state_.head<4>());
+
+    r_ = q.toRotationMatrix();
+    acc_ = state_.segment(4, 3);
+    omega_ = state_.tail(3);
+  }
+  else
+  {
+    r_ = Eigen::Map<Matrix3>(&state_[0]);
+    acc_ = state_.segment<3>(9);
+    omega_ = state_.tail<3>();
+  }
+
+  output_.head<3>() = accelerationMeasure(acc_, r_);
+  output_.tail<3>() = rotationVelocityMeasure(omega_, r_);
+
+  return output_;
+}
+
+void AccelerometerGyrometer::setMatrixMode(bool matrixMode)
+{
+  matrixMode_ = matrixMode;
+  if(!matrixMode_)
+    currentStateSize_ = stateSize_;
+  else
+    currentStateSize_ = stateSizeMatrix_;
+}
+
+} // namespace stateObservation

--- a/src/algebraic-sensor.cpp
+++ b/src/algebraic-sensor.cpp
@@ -2,92 +2,87 @@
 
 namespace stateObservation
 {
-    AlgebraicSensor::AlgebraicSensor()
-        :time_(0), concat_(0),
-        storedNoisyMeasurement_(),
-        storedNoiselessMeasurement_(false)
-    {
-    }
-
-    void AlgebraicSensor::setState(const Vector & state, TimeIndex k)
-    {
-        directInputToOutput_ = state.tail(concat_);
-        state_=state.head(getStateSize_());
-        storedNoisyMeasurement_=false;
-        storedNoiselessMeasurement_=false;
-
-        time_=k;
-    }
-
-
-    Index AlgebraicSensor::getStateSize() const
-    {
-        return getStateSize_()+concat_;
-    }
-
-    Index AlgebraicSensor::getMeasurementSize() const
-    {
-        return getMeasurementSize_()+concat_;
-    }
-
-    Vector AlgebraicSensor::getMeasurements(bool noisy)
-    {
-        if (noisy && noise_!=0x0)
-        {
-            if (!storedNoisyMeasurement_)
-            {
-                noisyMeasurement_ =  computeNoisyMeasurement_();
-                storedNoisyMeasurement_=true;
-            }
-            return noisyMeasurement_;
-        }
-        else
-        {
-            if (!storedNoiselessMeasurement_)
-            {
-                if (concat_>0)
-                  noiselessMeasurement_<< computeNoiselessMeasurement_() ,directInputToOutput_;
-                else
-                  noiselessMeasurement_= computeNoiselessMeasurement_();
-
-                storedNoiselessMeasurement_=true;
-            }
-            return noiselessMeasurement_;
-        }
-    }
-
-    void AlgebraicSensor::checkState_(const Vector & v)
-    {
-        (void)v;//avoid warning
-        BOOST_ASSERT( checkStateVector(v) && "ERROR: The state vector is incorrectly set.");
-    }
-
-    TimeIndex AlgebraicSensor::getTime() const
-    {
-        return time_;
-    }
-
-    Vector AlgebraicSensor::computeNoisyMeasurement_()
-    {
-        if (!storedNoiselessMeasurement_)
-        {
-            BOOST_ASSERT(checkStateVector(state_)&& "The state is not set or incorrectly set");
-
-            if (concat_>0)
-              noiselessMeasurement_<< computeNoiselessMeasurement_() ,directInputToOutput_;
-            else
-              noiselessMeasurement_= computeNoiselessMeasurement_();
-            storedNoiselessMeasurement_=true;
-        }
-
-        return noise_->getNoisy( noiselessMeasurement_);
-    }
-
-
-    Index AlgebraicSensor::concatenateWithInput( Index n)
-    {
-        concat_ = n;
-        noiselessMeasurement_.resize(getMeasurementSize());
-        return getMeasurementSize();
-    }
+AlgebraicSensor::AlgebraicSensor() : time_(0), concat_(0), storedNoisyMeasurement_(), storedNoiselessMeasurement_(false)
+{
 }
+
+void AlgebraicSensor::setState(const Vector & state, TimeIndex k)
+{
+  directInputToOutput_ = state.tail(concat_);
+  state_ = state.head(getStateSize_());
+  storedNoisyMeasurement_ = false;
+  storedNoiselessMeasurement_ = false;
+
+  time_ = k;
+}
+
+Index AlgebraicSensor::getStateSize() const
+{
+  return getStateSize_() + concat_;
+}
+
+Index AlgebraicSensor::getMeasurementSize() const
+{
+  return getMeasurementSize_() + concat_;
+}
+
+Vector AlgebraicSensor::getMeasurements(bool noisy)
+{
+  if(noisy && noise_ != 0x0)
+  {
+    if(!storedNoisyMeasurement_)
+    {
+      noisyMeasurement_ = computeNoisyMeasurement_();
+      storedNoisyMeasurement_ = true;
+    }
+    return noisyMeasurement_;
+  }
+  else
+  {
+    if(!storedNoiselessMeasurement_)
+    {
+      if(concat_ > 0)
+        noiselessMeasurement_ << computeNoiselessMeasurement_(), directInputToOutput_;
+      else
+        noiselessMeasurement_ = computeNoiselessMeasurement_();
+
+      storedNoiselessMeasurement_ = true;
+    }
+    return noiselessMeasurement_;
+  }
+}
+
+void AlgebraicSensor::checkState_(const Vector & v)
+{
+  (void)v; // avoid warning
+  BOOST_ASSERT(checkStateVector(v) && "ERROR: The state vector is incorrectly set.");
+}
+
+TimeIndex AlgebraicSensor::getTime() const
+{
+  return time_;
+}
+
+Vector AlgebraicSensor::computeNoisyMeasurement_()
+{
+  if(!storedNoiselessMeasurement_)
+  {
+    BOOST_ASSERT(checkStateVector(state_) && "The state is not set or incorrectly set");
+
+    if(concat_ > 0)
+      noiselessMeasurement_ << computeNoiselessMeasurement_(), directInputToOutput_;
+    else
+      noiselessMeasurement_ = computeNoiselessMeasurement_();
+    storedNoiselessMeasurement_ = true;
+  }
+
+  return noise_->getNoisy(noiselessMeasurement_);
+}
+
+Index AlgebraicSensor::concatenateWithInput(Index n)
+{
+  concat_ = n;
+  noiselessMeasurement_.resize(getMeasurementSize());
+  return getMeasurementSize();
+}
+} // namespace stateObservation

--- a/src/bidim-elastic-inv-pendulum-dyn-sys.cpp
+++ b/src/bidim-elastic-inv-pendulum-dyn-sys.cpp
@@ -3,126 +3,120 @@
 namespace stateObservation
 {
 
-    using stateObservation::cst::gravityConstant;
+using stateObservation::cst::gravityConstant;
 
-    BidimElasticInvPendulum::BidimElasticInvPendulum()
-    :m_(1),h_(1),processNoise_(0x0),dt_(1)
-    {
+BidimElasticInvPendulum::BidimElasticInvPendulum() : m_(1), h_(1), processNoise_(0x0), dt_(1)
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-        std::cout<<std::endl<<"IMUFixedContactDynamicalSystem Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
-        //ctor
-    }
-
-    BidimElasticInvPendulum::~BidimElasticInvPendulum()
-    {
-        //dtor
-    }
-
-    Vector BidimElasticInvPendulum::stateDynamics
-        (const Vector& x, const Vector& u, TimeIndex)
-    {
-        assertStateVector_(x);
-        assertInputVector_(u);
-
-
-
-        //x_{k+1}
-        Vector xk1=Vector::Zero(stateSize_,1);
-
-        double p = x[0];
-        double pdot = x[2];
-        double pdotdot = u[0];
-        double theta = x[1];
-        double thetadot = x[3];
-        double thetadotdot = (1/(m_*(p*p + h_*h_)))
-            *(- k_*theta - m_*gravityConstant*( cos(theta)*p - sin(theta)*h_ )
-              + m_* ( h_*pdotdot - 2*thetadot*( h_*pdot )));
-
-        xk1[0]= p + dt_*pdot;
-        xk1[1]= theta + dt_*thetadot;
-        xk1[2]= pdot + dt_*pdotdot;
-        xk1[3]= thetadot + dt_*thetadotdot;
-
-        if (processNoise_!=0x0)
-            return processNoise_->getNoisy(xk1);
-        else
-            return xk1;
-
-    }
-
-    /// set the height of the com of the pendulum
-    void BidimElasticInvPendulum::setHeight(const double & h)
-    {
-        h_ = h;
-    }
-
-    /// set the mass of the pendulum
-    void BidimElasticInvPendulum::setMass(const double &m)
-    {
-        m_ = m;
-    }
-
-    /// set the elasticity of the pendulum
-    void BidimElasticInvPendulum::setElasticity(const double &k)
-    {
-        k_=k;
-    }
-
-
-    Vector BidimElasticInvPendulum::measureDynamics (const Vector& , const Vector& , TimeIndex )
-    {
-        ///There is no measurements
-        return Vector::Zero(0);
-    }
-
-    void BidimElasticInvPendulum::setProcessNoise( NoiseBase * n)
-    {
-        processNoise_=n;
-    }
-
-    void BidimElasticInvPendulum::resetProcessNoise()
-    {
-        processNoise_=0x0;
-    }
-
-    void BidimElasticInvPendulum::setMeasurementNoise( NoiseBase * )
-    {
-        //there is no measurement
-    }
-
-    void BidimElasticInvPendulum::resetMeasurementNoise()
-    {
-        //there is no measurement
-    }
-
-    void BidimElasticInvPendulum::setSamplingPeriod(double dt)
-    {
-        dt_=dt;
-    }
-
-    Index BidimElasticInvPendulum::getStateSize() const
-    {
-        return stateSize_;
-    }
-
-    Index BidimElasticInvPendulum::getInputSize() const
-    {
-        return inputSize_;
-    }
-
-    Index BidimElasticInvPendulum::getMeasurementSize() const
-    {
-        return measurementSize_;
-    }
-
-    NoiseBase * BidimElasticInvPendulum::getProcessNoise() const
-    {
-        return processNoise_;
-    }
-
-    NoiseBase * BidimElasticInvPendulum::getMeasurementNoise() const
-    {
-        return 0x0;
-    }
+  std::cout << std::endl << "IMUFixedContactDynamicalSystem Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+       // ctor
 }
+
+BidimElasticInvPendulum::~BidimElasticInvPendulum()
+{
+  // dtor
+}
+
+Vector BidimElasticInvPendulum::stateDynamics(const Vector & x, const Vector & u, TimeIndex)
+{
+  assertStateVector_(x);
+  assertInputVector_(u);
+
+  // x_{k+1}
+  Vector xk1 = Vector::Zero(stateSize_, 1);
+
+  double p = x[0];
+  double pdot = x[2];
+  double pdotdot = u[0];
+  double theta = x[1];
+  double thetadot = x[3];
+  double thetadotdot = (1 / (m_ * (p * p + h_ * h_)))
+                       * (-k_ * theta - m_ * gravityConstant * (cos(theta) * p - sin(theta) * h_)
+                          + m_ * (h_ * pdotdot - 2 * thetadot * (h_ * pdot)));
+
+  xk1[0] = p + dt_ * pdot;
+  xk1[1] = theta + dt_ * thetadot;
+  xk1[2] = pdot + dt_ * pdotdot;
+  xk1[3] = thetadot + dt_ * thetadotdot;
+
+  if(processNoise_ != 0x0)
+    return processNoise_->getNoisy(xk1);
+  else
+    return xk1;
+}
+
+/// set the height of the com of the pendulum
+void BidimElasticInvPendulum::setHeight(const double & h)
+{
+  h_ = h;
+}
+
+/// set the mass of the pendulum
+void BidimElasticInvPendulum::setMass(const double & m)
+{
+  m_ = m;
+}
+
+/// set the elasticity of the pendulum
+void BidimElasticInvPendulum::setElasticity(const double & k)
+{
+  k_ = k;
+}
+
+Vector BidimElasticInvPendulum::measureDynamics(const Vector &, const Vector &, TimeIndex)
+{
+  /// There is no measurements
+  return Vector::Zero(0);
+}
+
+void BidimElasticInvPendulum::setProcessNoise(NoiseBase * n)
+{
+  processNoise_ = n;
+}
+
+void BidimElasticInvPendulum::resetProcessNoise()
+{
+  processNoise_ = 0x0;
+}
+
+void BidimElasticInvPendulum::setMeasurementNoise(NoiseBase *)
+{
+  // there is no measurement
+}
+
+void BidimElasticInvPendulum::resetMeasurementNoise()
+{
+  // there is no measurement
+}
+
+void BidimElasticInvPendulum::setSamplingPeriod(double dt)
+{
+  dt_ = dt;
+}
+
+Index BidimElasticInvPendulum::getStateSize() const
+{
+  return stateSize_;
+}
+
+Index BidimElasticInvPendulum::getInputSize() const
+{
+  return inputSize_;
+}
+
+Index BidimElasticInvPendulum::getMeasurementSize() const
+{
+  return measurementSize_;
+}
+
+NoiseBase * BidimElasticInvPendulum::getProcessNoise() const
+{
+  return processNoise_;
+}
+
+NoiseBase * BidimElasticInvPendulum::getMeasurementNoise() const
+{
+  return 0x0;
+}
+} // namespace stateObservation

--- a/src/definitions.cpp
+++ b/src/definitions.cpp
@@ -1,84 +1,81 @@
 #include <fstream>
 #include <sstream>
-#include <stdexcept>
 #include <state-observation/tools/definitions.hpp>
-
+#include <stdexcept>
 
 namespace stateObservation
 {
-  namespace tools
+namespace tools
+{
+std::string matrixToString(const Matrix & mat)
+{
+  std::stringstream ss;
+  ss << mat;
+  return ss.str();
+}
+
+namespace detail
+{
+
+} // namespace detail
+
+std::string vectorToString(const Vector & v)
+{
+  return matrixToString(v.transpose());
+}
+
+Matrix stringToMatrix(const std::string & str, Index rows, Index cols)
+{
+  Matrix m(Matrix::Zero(rows, cols));
+  std::stringstream ss;
+  ss << str;
+
+  for(Index i = 0; i < rows; ++i)
   {
-    std::string matrixToString(const Matrix& mat)
+    for(Index j = 0; j < cols; ++j)
     {
-      std::stringstream ss;
-      ss << mat;
-      return ss.str();
-    }
-
-    namespace detail
-    {
-
-
-    } // namespace detail
-
-
-    std::string vectorToString(const Vector& v)
-    {
-      return matrixToString(v.transpose());
-    }
-
-    Matrix stringToMatrix(const std::string& str, Index rows, Index cols)
-    {
-      Matrix m(Matrix::Zero(rows,cols));
-      std::stringstream ss;
-      ss << str;
-
-      for (Index i = 0 ; i<rows; ++i)
-      {
-        for (Index j = 0 ; j<cols; ++j)
-        {
-          ss >> m(i,j);
-        }
-      }
-
-      return m;
-    }
-
-    Vector stringToVector(const std::string& str, Index length)
-    {
-      return stringToMatrix(str,length,1);
-    }
-
-    Vector stringToVector(const std::string& str)
-    {
-      Vector v;
-      std::stringstream ss;
-      ss << str;
-
-      std::vector<double> doublecontainer;
-      double component;
-      bool readingVector = true;
-      while (readingVector)
-      {
-        ss>> component;
-
-        if (ss.fail())
-        {
-          readingVector=false;
-        }
-        else
-        {
-          doublecontainer.push_back(component);
-        }
-      }
-      v.resize(Index(doublecontainer.size()));
-      for (Index i=0 ; i<Index(doublecontainer.size()) ; ++i)
-      {
-        v(i)=doublecontainer[size_t(i)];
-      }
-
-      return v;
+      ss >> m(i, j);
     }
   }
 
+  return m;
 }
+
+Vector stringToVector(const std::string & str, Index length)
+{
+  return stringToMatrix(str, length, 1);
+}
+
+Vector stringToVector(const std::string & str)
+{
+  Vector v;
+  std::stringstream ss;
+  ss << str;
+
+  std::vector<double> doublecontainer;
+  double component;
+  bool readingVector = true;
+  while(readingVector)
+  {
+    ss >> component;
+
+    if(ss.fail())
+    {
+      readingVector = false;
+    }
+    else
+    {
+      doublecontainer.push_back(component);
+    }
+  }
+  v.resize(Index(doublecontainer.size()));
+  for(Index i = 0; i < Index(doublecontainer.size()); ++i)
+  {
+    v(i) = doublecontainer[size_t(i)];
+  }
+
+  return v;
+}
+} // namespace tools
+
+} // namespace stateObservation

--- a/src/dynamical-system-functor-base.cpp
+++ b/src/dynamical-system-functor-base.cpp
@@ -3,28 +3,27 @@
 namespace stateObservation
 {
 
-    DynamicalSystemFunctorBase::DynamicalSystemFunctorBase()
-    {
+DynamicalSystemFunctorBase::DynamicalSystemFunctorBase()
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-       std::cout<<std::endl<<"DynamicalSystemFunctorBase Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-        //ctor
-    }
-
-    DynamicalSystemFunctorBase::~DynamicalSystemFunctorBase()
-    {
-        //dtor
-    }
-
-    bool DynamicalSystemFunctorBase::checkStateVector(const Vector & v)
-    {
-        return (v.rows()==getStateSize() && v.cols()==1);
-    }
-
-    bool DynamicalSystemFunctorBase::checkInputvector(const Vector & v)
-    {
-        return (v.rows()==getInputSize() && v.cols()==1);
-    }
-
-
+  std::cout << std::endl << "DynamicalSystemFunctorBase Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTORS
+       // ctor
 }
+
+DynamicalSystemFunctorBase::~DynamicalSystemFunctorBase()
+{
+  // dtor
+}
+
+bool DynamicalSystemFunctorBase::checkStateVector(const Vector & v)
+{
+  return (v.rows() == getStateSize() && v.cols() == 1);
+}
+
+bool DynamicalSystemFunctorBase::checkInputvector(const Vector & v)
+{
+  return (v.rows() == getInputSize() && v.cols() == 1);
+}
+
+} // namespace stateObservation

--- a/src/dynamical-system-simulator.cpp
+++ b/src/dynamical-system-simulator.cpp
@@ -2,136 +2,126 @@
 
 namespace stateObservation
 {
-    DynamicalSystemSimulator::DynamicalSystemSimulator():
-            f_(0x0)
-    {
-        //ctor
-    }
-
-    DynamicalSystemSimulator::~DynamicalSystemSimulator()
-    {
-        //dtor
-    }
-
-    void DynamicalSystemSimulator::setDynamicsFunctor(DynamicalSystemFunctorBase * f)
-    {
-        f_=f;
-    }
-
-    void DynamicalSystemSimulator::setState( const Vector & x, TimeIndex k)
-    {
-        BOOST_ASSERT((x_.size()==0 || (x_.getFirstIndex()<=k && x_.getNextIndex()>=k)) &&
-            "ERROR: Only consecutive states can be set. If you want to restart a new dynamics please call resetDynamics before");
-        x_.truncateAfter(k-1);
-        x_.setValue(x,k);
-    }
-
-    void DynamicalSystemSimulator::setInput( const Vector & u, TimeIndex k)
-    {
-        u_.insert(std::pair<TimeIndex,Vector>(k,u));
-    }
-
-    Vector DynamicalSystemSimulator::getMeasurement( TimeIndex k )
-    {
-        BOOST_ASSERT((y_.size()==0 || y_.getFirstIndex()<k) &&
-            "ERROR: Only future measurements can be obtained");
-        if (y_.getNextIndex()<k)
-            simulateDynamicsTo(k);
-
-        return y_[k];
-    }
-
-    Vector DynamicalSystemSimulator::getState( TimeIndex k )
-    {
-        BOOST_ASSERT((x_.size()==0 || x_.getFirstIndex()<=k) &&
-            "ERROR: Only future measurements can be obtained");
-        if (x_.getLastIndex()<TimeIndex(k))
-            simulateDynamicsTo(k-1);
-
-        return x_[k];
-    }
-
-    Vector DynamicalSystemSimulator::getCurrentState() const
-    {
-        return x_[TimeIndex(x_.getLastIndex())];
-    }
-
-    TimeIndex DynamicalSystemSimulator::getCurrentTime() const
-    {
-        return x_.getLastIndex();
-    }
-
-    Vector DynamicalSystemSimulator::getInput(TimeIndex k)const
-    {
-        BOOST_ASSERT(u_.size()>0 && "ERROR: the input is not set");
-        std::map<TimeIndex,Vector>::const_iterator i=u_.upper_bound(k);
-
-        --i;
-
-        BOOST_ASSERT(i->first<=k &&
-                "ERROR: the input is not set for the current time");
-
-        return i->second;
-
-    }
-
-    void DynamicalSystemSimulator::simulateDynamics()
-    {
-        BOOST_ASSERT(f_!=0x0 &&
-            "ERROR: A dynamics functor must be set");
-
-        TimeIndex k(x_.getLastIndex());
-        Vector u=getInput(k);
-        y_.setValue(f_->measureDynamics(x_[k],u,k),k);
-        x_.setValue(f_->stateDynamics(x_[k],u,k),k+1);
-
-    }
-
-    void DynamicalSystemSimulator::simulateDynamicsTo(TimeIndex k)
-    {
-        for (TimeIndex i=x_.getLastIndex(); i <k ; ++i)
-        {
-            simulateDynamics();
-        }
-    }
-
-    IndexedVectorArray DynamicalSystemSimulator::getMeasurementArray
-                    (TimeIndex startingTime, TimeSize duration)
-    {
-        BOOST_ASSERT(startingTime>y_.getFirstIndex() && "ERROR: The starting time is too early, try later starting time");
-        IndexedVectorArray a;
-
-        for (TimeIndex i= startingTime; i<startingTime+TimeIndex(duration);++i)
-        {
-            a.setValue(getMeasurement(i),i);
-        }
-        return a;
-    }
-
-    IndexedVectorArray DynamicalSystemSimulator::getStateArray
-                    (TimeIndex startingTime, TimeSize duration)
-    {
-        BOOST_ASSERT(startingTime>x_.getFirstIndex() && "ERROR: The starting time is too early, try later starting time");
-
-        IndexedVectorArray a;
-
-        for (TimeIndex i= startingTime; i<startingTime+TimeIndex(duration);++i)
-        {
-            a.setValue(getState(i),i);
-        }
-        return a;
-    }
-
-    void DynamicalSystemSimulator::resetDynamics()
-    {
-        x_.reset();
-        y_.reset();
-        u_.clear();
-    }
-
-    void DynamicalSystemSimulator::resetSimulator()
-    {
-        resetDynamics();
-        f_=0x0;
-    }
+DynamicalSystemSimulator::DynamicalSystemSimulator() : f_(0x0)
+{
+  // ctor
 }
+
+DynamicalSystemSimulator::~DynamicalSystemSimulator()
+{
+  // dtor
+}
+
+void DynamicalSystemSimulator::setDynamicsFunctor(DynamicalSystemFunctorBase * f)
+{
+  f_ = f;
+}
+
+void DynamicalSystemSimulator::setState(const Vector & x, TimeIndex k)
+{
+  BOOST_ASSERT((x_.size() == 0 || (x_.getFirstIndex() <= k && x_.getNextIndex() >= k))
+               && "ERROR: Only consecutive states can be set. If you want to restart a new dynamics please call "
+                  "resetDynamics before");
+  x_.truncateAfter(k - 1);
+  x_.setValue(x, k);
+}
+
+void DynamicalSystemSimulator::setInput(const Vector & u, TimeIndex k)
+{
+  u_.insert(std::pair<TimeIndex, Vector>(k, u));
+}
+
+Vector DynamicalSystemSimulator::getMeasurement(TimeIndex k)
+{
+  BOOST_ASSERT((y_.size() == 0 || y_.getFirstIndex() < k) && "ERROR: Only future measurements can be obtained");
+  if(y_.getNextIndex() < k) simulateDynamicsTo(k);
+
+  return y_[k];
+}
+
+Vector DynamicalSystemSimulator::getState(TimeIndex k)
+{
+  BOOST_ASSERT((x_.size() == 0 || x_.getFirstIndex() <= k) && "ERROR: Only future measurements can be obtained");
+  if(x_.getLastIndex() < TimeIndex(k)) simulateDynamicsTo(k - 1);
+
+  return x_[k];
+}
+
+Vector DynamicalSystemSimulator::getCurrentState() const
+{
+  return x_[TimeIndex(x_.getLastIndex())];
+}
+
+TimeIndex DynamicalSystemSimulator::getCurrentTime() const
+{
+  return x_.getLastIndex();
+}
+
+Vector DynamicalSystemSimulator::getInput(TimeIndex k) const
+{
+  BOOST_ASSERT(u_.size() > 0 && "ERROR: the input is not set");
+  std::map<TimeIndex, Vector>::const_iterator i = u_.upper_bound(k);
+
+  --i;
+
+  BOOST_ASSERT(i->first <= k && "ERROR: the input is not set for the current time");
+
+  return i->second;
+}
+
+void DynamicalSystemSimulator::simulateDynamics()
+{
+  BOOST_ASSERT(f_ != 0x0 && "ERROR: A dynamics functor must be set");
+
+  TimeIndex k(x_.getLastIndex());
+  Vector u = getInput(k);
+  y_.setValue(f_->measureDynamics(x_[k], u, k), k);
+  x_.setValue(f_->stateDynamics(x_[k], u, k), k + 1);
+}
+
+void DynamicalSystemSimulator::simulateDynamicsTo(TimeIndex k)
+{
+  for(TimeIndex i = x_.getLastIndex(); i < k; ++i)
+  {
+    simulateDynamics();
+  }
+}
+
+IndexedVectorArray DynamicalSystemSimulator::getMeasurementArray(TimeIndex startingTime, TimeSize duration)
+{
+  BOOST_ASSERT(startingTime > y_.getFirstIndex() && "ERROR: The starting time is too early, try later starting time");
+  IndexedVectorArray a;
+
+  for(TimeIndex i = startingTime; i < startingTime + TimeIndex(duration); ++i)
+  {
+    a.setValue(getMeasurement(i), i);
+  }
+  return a;
+}
+
+IndexedVectorArray DynamicalSystemSimulator::getStateArray(TimeIndex startingTime, TimeSize duration)
+{
+  BOOST_ASSERT(startingTime > x_.getFirstIndex() && "ERROR: The starting time is too early, try later starting time");
+
+  IndexedVectorArray a;
+
+  for(TimeIndex i = startingTime; i < startingTime + TimeIndex(duration); ++i)
+  {
+    a.setValue(getState(i), i);
+  }
+  return a;
+}
+
+void DynamicalSystemSimulator::resetDynamics()
+{
+  x_.reset();
+  y_.reset();
+  u_.clear();
+}
+
+void DynamicalSystemSimulator::resetSimulator()
+{
+  resetDynamics();
+  f_ = 0x0;
+}
+} // namespace stateObservation

--- a/src/ekf-flexibility-estimator-base.cpp
+++ b/src/ekf-flexibility-estimator-base.cpp
@@ -3,187 +3,176 @@ namespace stateObservation
 {
 namespace flexibilityEstimation
 {
-    EKFFlexibilityEstimatorBase::EKFFlexibilityEstimatorBase(Index stateSize,
-                                    Index measurementSize,
-                                    Index inputSize,
-                                    const Vector & dx):
-        FlexibilityEstimatorBase(),
-        ekf_(stateSize,measurementSize,inputSize),
-        finiteDifferencesJacobians_(true),
-        dx_(dx),
-        k_(0)
-    {
-        //ctor
-    }
-
-    EKFFlexibilityEstimatorBase::~EKFFlexibilityEstimatorBase()
-    {
-        //dtor
-    }
-
-    void EKFFlexibilityEstimatorBase::setFlexibilityCovariance
-                                                            (const Matrix & P)
-    {
-        ekf_.setStateCovariance(P);
-    }
-
-    Matrix EKFFlexibilityEstimatorBase::getFlexibilityCovariance
-                                                            () const
-    {
-        return ekf_.getStateCovariance();
-    }
-
-    void EKFFlexibilityEstimatorBase::setMeasurement(const Vector & y)
-    {
-        ekf_.setMeasurement(y,k_+1);
-    }
-
-    Vector EKFFlexibilityEstimatorBase::getMeasurement()
-    {
-        return ekf_.getMeasurement(k_+1);
-    }
-
-    void EKFFlexibilityEstimatorBase::setProcessNoiseCovariance(const Matrix & Q)
-    {
-        ekf_.setQ(Q);
-    }
-
-    void EKFFlexibilityEstimatorBase::setMeasurementNoiseCovariance(const Matrix & R)
-    {
-        ekf_.setR(R);
-    }
-
-    ///gets the covariance matrices for the process noises
-    Matrix EKFFlexibilityEstimatorBase::getProcessNoiseCovariance() const
-    {
-        return ekf_.getQ();
-    }
-
-    ///gets the covariance matrices for the sensor noises
-    Matrix EKFFlexibilityEstimatorBase::getMeasurementNoiseCovariance() const
-    {
-        return ekf_.getR();
-    }
-
-    void EKFFlexibilityEstimatorBase::useFiniteDifferencesJacobians(Vector x)
-    {
-        finiteDifferencesJacobians_= true ;
-        dx_ = x;
-    }
-
-    void EKFFlexibilityEstimatorBase::setJacobians
-                                          (const Matrix & A, const Matrix & C)
-    {
-        finiteDifferencesJacobians_= false ;
-        ekf_.setA(A);
-        ekf_.setC(C);
-    }
-
-    void EKFFlexibilityEstimatorBase::setInput(const Vector & u)
-    {
-        ekf_.setInput(u,k_);
-    }
-
-
-    void EKFFlexibilityEstimatorBase::setMeasurementInput(const Vector & u)
-    {
-        if (ekf_.getInputsNumber()==0)
-          ekf_.setInput(u,k_);
-        ekf_.setInput(u,k_+1);
-    }
-
-    Vector EKFFlexibilityEstimatorBase::getInput()
-    {
-        return ekf_.getInput(k_);
-    }
-
-
-    Vector EKFFlexibilityEstimatorBase::getMeasurementInput()
-    {
-        return ekf_.getInput(k_+1);
-    }
-
-    const Vector & EKFFlexibilityEstimatorBase::getFlexibilityVector()
-    {
-        if (ekf_.getMeasurementsNumber()>0)
-        {
-            k_=ekf_.getMeasurementTime();
-           // std::cout << "\n\n\n\n\n k " << k_ << std::endl;
-
-            for (TimeIndex i=ekf_.getCurrentTime()+1; i<=k_; ++i)
-            {
-                if (finiteDifferencesJacobians_)
-                {
-                  ekf_.setA(ekf_.getAMatrixFD(dx_));
-                  ekf_.setC(ekf_.getCMatrixFD(dx_));
-                }
-                ekf_.getEstimatedState(i);
-            }
-
-            Vector x(ekf_.getEstimatedState(k_));
-
-            if (x==x)//detect NaN values
-            {
-                lastX_=x;
-            }
-            else //delete NaN values
-            {
-                ekf_.setState(lastX_,k_);
-               // std::cout << "\n\n\n\n\n Need to reset covariance matrix \n\n\n\n\n" << std::endl;
-//                std::cout << "k_: " << k_ << std::endl;
-                if(k_>1) //the first iteration give always nan without initialization
-                {
-                    resetCovarianceMatrices();
-                }
-            }
-        }
-        return lastX_;
-    }
-
-    const stateObservation::ExtendedKalmanFilter &
-        EKFFlexibilityEstimatorBase::getEKF() const
-    {
-        return ekf_;
-    }
-
-    stateObservation::ExtendedKalmanFilter & EKFFlexibilityEstimatorBase::getEKF()
-    {
-        return ekf_;
-    }
-
-    Vector EKFFlexibilityEstimatorBase::getSimulatedMeasurement()
-    {
-
-        getFlexibilityVector();
-
-        return ekf_.getSimulatedMeasurement(ekf_.getCurrentTime());
-    }
-
-    Vector EKFFlexibilityEstimatorBase::getInnovation()
-    {
-        return ekf_.getInnovation();
-    }
-
-    Vector EKFFlexibilityEstimatorBase::getPredictedMeasurement()
-    {
-        return ekf_.updateStateAndMeasurementPrediction();
-    }
-
-    Vector EKFFlexibilityEstimatorBase::getPrediction()
-    {
-        return ekf_.updateStatePrediction();
-    }
-
-
-    Vector EKFFlexibilityEstimatorBase::getLastPredictedMeasurement()
-    {
-        return ekf_.getLastPredictedMeasurement();
-    }
-
-    Vector EKFFlexibilityEstimatorBase::getLastPrediction()
-    {
-        return ekf_.getLastPrediction();
-    }
-
+EKFFlexibilityEstimatorBase::EKFFlexibilityEstimatorBase(Index stateSize,
+                                                         Index measurementSize,
+                                                         Index inputSize,
+                                                         const Vector & dx)
+: FlexibilityEstimatorBase(), ekf_(stateSize, measurementSize, inputSize), finiteDifferencesJacobians_(true), dx_(dx),
+  k_(0)
+{
+  // ctor
 }
+
+EKFFlexibilityEstimatorBase::~EKFFlexibilityEstimatorBase()
+{
+  // dtor
 }
+
+void EKFFlexibilityEstimatorBase::setFlexibilityCovariance(const Matrix & P)
+{
+  ekf_.setStateCovariance(P);
+}
+
+Matrix EKFFlexibilityEstimatorBase::getFlexibilityCovariance() const
+{
+  return ekf_.getStateCovariance();
+}
+
+void EKFFlexibilityEstimatorBase::setMeasurement(const Vector & y)
+{
+  ekf_.setMeasurement(y, k_ + 1);
+}
+
+Vector EKFFlexibilityEstimatorBase::getMeasurement()
+{
+  return ekf_.getMeasurement(k_ + 1);
+}
+
+void EKFFlexibilityEstimatorBase::setProcessNoiseCovariance(const Matrix & Q)
+{
+  ekf_.setQ(Q);
+}
+
+void EKFFlexibilityEstimatorBase::setMeasurementNoiseCovariance(const Matrix & R)
+{
+  ekf_.setR(R);
+}
+
+/// gets the covariance matrices for the process noises
+Matrix EKFFlexibilityEstimatorBase::getProcessNoiseCovariance() const
+{
+  return ekf_.getQ();
+}
+
+/// gets the covariance matrices for the sensor noises
+Matrix EKFFlexibilityEstimatorBase::getMeasurementNoiseCovariance() const
+{
+  return ekf_.getR();
+}
+
+void EKFFlexibilityEstimatorBase::useFiniteDifferencesJacobians(Vector x)
+{
+  finiteDifferencesJacobians_ = true;
+  dx_ = x;
+}
+
+void EKFFlexibilityEstimatorBase::setJacobians(const Matrix & A, const Matrix & C)
+{
+  finiteDifferencesJacobians_ = false;
+  ekf_.setA(A);
+  ekf_.setC(C);
+}
+
+void EKFFlexibilityEstimatorBase::setInput(const Vector & u)
+{
+  ekf_.setInput(u, k_);
+}
+
+void EKFFlexibilityEstimatorBase::setMeasurementInput(const Vector & u)
+{
+  if(ekf_.getInputsNumber() == 0) ekf_.setInput(u, k_);
+  ekf_.setInput(u, k_ + 1);
+}
+
+Vector EKFFlexibilityEstimatorBase::getInput()
+{
+  return ekf_.getInput(k_);
+}
+
+Vector EKFFlexibilityEstimatorBase::getMeasurementInput()
+{
+  return ekf_.getInput(k_ + 1);
+}
+
+const Vector & EKFFlexibilityEstimatorBase::getFlexibilityVector()
+{
+  if(ekf_.getMeasurementsNumber() > 0)
+  {
+    k_ = ekf_.getMeasurementTime();
+    // std::cout << "\n\n\n\n\n k " << k_ << std::endl;
+
+    for(TimeIndex i = ekf_.getCurrentTime() + 1; i <= k_; ++i)
+    {
+      if(finiteDifferencesJacobians_)
+      {
+        ekf_.setA(ekf_.getAMatrixFD(dx_));
+        ekf_.setC(ekf_.getCMatrixFD(dx_));
+      }
+      ekf_.getEstimatedState(i);
+    }
+
+    Vector x(ekf_.getEstimatedState(k_));
+
+    if(x == x) // detect NaN values
+    {
+      lastX_ = x;
+    }
+    else // delete NaN values
+    {
+      ekf_.setState(lastX_, k_);
+      // std::cout << "\n\n\n\n\n Need to reset covariance matrix \n\n\n\n\n" << std::endl;
+      //                std::cout << "k_: " << k_ << std::endl;
+      if(k_ > 1) // the first iteration give always nan without initialization
+      {
+        resetCovarianceMatrices();
+      }
+    }
+  }
+  return lastX_;
+}
+
+const stateObservation::ExtendedKalmanFilter & EKFFlexibilityEstimatorBase::getEKF() const
+{
+  return ekf_;
+}
+
+stateObservation::ExtendedKalmanFilter & EKFFlexibilityEstimatorBase::getEKF()
+{
+  return ekf_;
+}
+
+Vector EKFFlexibilityEstimatorBase::getSimulatedMeasurement()
+{
+
+  getFlexibilityVector();
+
+  return ekf_.getSimulatedMeasurement(ekf_.getCurrentTime());
+}
+
+Vector EKFFlexibilityEstimatorBase::getInnovation()
+{
+  return ekf_.getInnovation();
+}
+
+Vector EKFFlexibilityEstimatorBase::getPredictedMeasurement()
+{
+  return ekf_.updateStateAndMeasurementPrediction();
+}
+
+Vector EKFFlexibilityEstimatorBase::getPrediction()
+{
+  return ekf_.updateStatePrediction();
+}
+
+Vector EKFFlexibilityEstimatorBase::getLastPredictedMeasurement()
+{
+  return ekf_.getLastPredictedMeasurement();
+}
+
+Vector EKFFlexibilityEstimatorBase::getLastPrediction()
+{
+  return ekf_.getLastPrediction();
+}
+
+} // namespace flexibilityEstimation
+} // namespace stateObservation

--- a/src/extended-kalman-filter.cpp
+++ b/src/extended-kalman-filter.cpp
@@ -2,237 +2,223 @@
 
 namespace stateObservation
 {
-    ExtendedKalmanFilter::ExtendedKalmanFilter(Index n,Index m)
-        :KalmanFilterBase(n,m,0),
-        directInputOutputFeedthrough_(false),
-        directInputStateProcessFeedthrough_(false), f_(0x0)
+ExtendedKalmanFilter::ExtendedKalmanFilter(Index n, Index m)
+: KalmanFilterBase(n, m, 0), directInputOutputFeedthrough_(false), directInputStateProcessFeedthrough_(false), f_(0x0)
 
-    {
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-            std::cout<<std::endl<<"ExtendedKalmanFilter Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+  std::cout << std::endl << "ExtendedKalmanFilter Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+}
 
-    }
-
-
-    ExtendedKalmanFilter::ExtendedKalmanFilter(Index n,Index m,Index p,
-            bool directInputOutputFeedthrough,
-            bool directInputStateProcessFeedthrough)
-        :KalmanFilterBase(n,m,p),
-        directInputOutputFeedthrough_(directInputOutputFeedthrough),
-        directInputStateProcessFeedthrough_(directInputStateProcessFeedthrough), f_(0x0)
-    {
+ExtendedKalmanFilter::ExtendedKalmanFilter(Index n,
+                                           Index m,
+                                           Index p,
+                                           bool directInputOutputFeedthrough,
+                                           bool directInputStateProcessFeedthrough)
+: KalmanFilterBase(n, m, p), directInputOutputFeedthrough_(directInputOutputFeedthrough),
+  directInputStateProcessFeedthrough_(directInputStateProcessFeedthrough), f_(0x0)
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-        std::cout<<std::endl<<"ExtendedKalmanFilter Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+  std::cout << std::endl << "ExtendedKalmanFilter Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
 
-        if (p==0)
-        {
-            directInputOutputFeedthrough_=false;
-            directInputStateProcessFeedthrough_=false;
-        }
-    }
+  if(p == 0)
+  {
+    directInputOutputFeedthrough_ = false;
+    directInputStateProcessFeedthrough_ = false;
+  }
+}
 
-    ExtendedKalmanFilter::ExtendedKalmanFilter(Index n, Index nt, Index  m, Index mt, Index p,
-            bool directInputOutputFeedthrough,
-            bool directInputStateProcessFeedthrough):
-        KalmanFilterBase(n,nt,m,mt,p),
-        directInputOutputFeedthrough_(directInputOutputFeedthrough),
-        directInputStateProcessFeedthrough_(directInputStateProcessFeedthrough), f_(0x0)
-    {
+ExtendedKalmanFilter::ExtendedKalmanFilter(Index n,
+                                           Index nt,
+                                           Index m,
+                                           Index mt,
+                                           Index p,
+                                           bool directInputOutputFeedthrough,
+                                           bool directInputStateProcessFeedthrough)
+: KalmanFilterBase(n, nt, m, mt, p), directInputOutputFeedthrough_(directInputOutputFeedthrough),
+  directInputStateProcessFeedthrough_(directInputStateProcessFeedthrough), f_(0x0)
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-        std::cout<<std::endl<<"ExtendedKalmanFilter Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+  std::cout << std::endl << "ExtendedKalmanFilter Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
 
-        if (p==0)
-        {
-            directInputOutputFeedthrough_=false;
-            directInputStateProcessFeedthrough_=false;
-        }
-    }
+  if(p == 0)
+  {
+    directInputOutputFeedthrough_ = false;
+    directInputStateProcessFeedthrough_ = false;
+  }
+}
 
+void ExtendedKalmanFilter::setFunctor(DynamicalSystemFunctorBase * f)
+{
+  f_ = f;
+  // f_->reset();
+}
 
-    void ExtendedKalmanFilter::setFunctor(DynamicalSystemFunctorBase* f)
-    {
-        f_=f;
-        //f_->reset();
+DynamicalSystemFunctorBase * ExtendedKalmanFilter::getFunctor(void) const
+{
+  return f_;
+}
 
-    }
+void ExtendedKalmanFilter::clearFunctor()
+{
+  f_ = 0x0;
+}
 
-    DynamicalSystemFunctorBase* ExtendedKalmanFilter::getFunctor(void) const
-    {
-        return f_;
+void ExtendedKalmanFilter::setDirectInputOutputFeedthrough(bool b)
+{
+  if(p_ > 0)
+  {
+    directInputOutputFeedthrough_ = b;
+  }
+}
 
-    }
+void ExtendedKalmanFilter::setDirectInputStateFeedthrough(bool b)
+{
+  if(p_ > 0)
+  {
+    directInputStateProcessFeedthrough_ = b;
+  }
+}
 
-    void ExtendedKalmanFilter::clearFunctor()
-    {
-        f_=0x0;
-    }
-
-    void ExtendedKalmanFilter::setDirectInputOutputFeedthrough(bool b)
-    {
-        if (p_>0)
-        {
-            directInputOutputFeedthrough_=b;
-        }
-    }
-
-    void ExtendedKalmanFilter::setDirectInputStateFeedthrough(bool b)
-    {
-        if (p_>0)
-        {
-            directInputStateProcessFeedthrough_=b;
-        }
-    }
-
-    ObserverBase::StateVector ExtendedKalmanFilter::prediction_(TimeIndex k)
-    {
-        if (!xbar_.isSet() || xbar_.getTime()!=k)
-        {
-            if ((p_>0) && (directInputStateProcessFeedthrough_))
-            {
-
-                BOOST_ASSERT(this->u_.size()>0 && this->u_.checkIndex(k-1) &&
-                                        "ERROR: The input vector is not set");
-                opt.u_=this->u_[k-1];
-            }
-            else
-            {
-                opt.u_ = inputVectorZero();
-            }
-            BOOST_ASSERT (f_!=0x0 && "ERROR: The Kalman filter functor is not set");
-            xbar_.set(f_->stateDynamics(
-                      this->x_(),
-                      opt.u_,
-                      this->x_.getTime()),
-                      k);
-        }
-
-        return xbar_();
-    }
-
-    ObserverBase::MeasureVector ExtendedKalmanFilter::predictSensor_(TimeIndex k)
+ObserverBase::StateVector ExtendedKalmanFilter::prediction_(TimeIndex k)
+{
+  if(!xbar_.isSet() || xbar_.getTime() != k)
+  {
+    if((p_ > 0) && (directInputStateProcessFeedthrough_))
     {
 
-        if (!this->ybar_.isSet() || this->ybar_.getTime()!=k)
-        {
-            ybar_.set(simulateSensor_(xbar_(),k),k);
-        }
-
-        return ybar_();
+      BOOST_ASSERT(this->u_.size() > 0 && this->u_.checkIndex(k - 1) && "ERROR: The input vector is not set");
+      opt.u_ = this->u_[k - 1];
     }
-
-    ObserverBase::MeasureVector ExtendedKalmanFilter::simulateSensor_(const ObserverBase::StateVector& x, TimeIndex k)
+    else
     {
-        BOOST_ASSERT (f_!=0x0 && "ERROR: The Kalman filter functor is not set");
+      opt.u_ = inputVectorZero();
+    }
+    BOOST_ASSERT(f_ != 0x0 && "ERROR: The Kalman filter functor is not set");
+    xbar_.set(f_->stateDynamics(this->x_(), opt.u_, this->x_.getTime()), k);
+  }
 
-        if (p_>0)
-        {
-            if (directInputOutputFeedthrough_)
-            {
-                BOOST_ASSERT(u_.checkIndex(k) &&
-                "ERROR: The input feedthrough of the measurements is not set \
+  return xbar_();
+}
+
+ObserverBase::MeasureVector ExtendedKalmanFilter::predictSensor_(TimeIndex k)
+{
+
+  if(!this->ybar_.isSet() || this->ybar_.getTime() != k)
+  {
+    ybar_.set(simulateSensor_(xbar_(), k), k);
+  }
+
+  return ybar_();
+}
+
+ObserverBase::MeasureVector ExtendedKalmanFilter::simulateSensor_(const ObserverBase::StateVector & x, TimeIndex k)
+{
+  BOOST_ASSERT(f_ != 0x0 && "ERROR: The Kalman filter functor is not set");
+
+  if(p_ > 0)
+  {
+    if(directInputOutputFeedthrough_)
+    {
+      BOOST_ASSERT(u_.checkIndex(k) && "ERROR: The input feedthrough of the measurements is not set \
 (the measurement at time k needs the input at time k which was not given) \
 if you don't need the input in the computation of measurement, you \
 must set directInputOutputFeedthrough to 'false' in the constructor");
-            }
-
-            if (u_.checkIndex(k))
-            {
-                opt.u_=u_[k];
-            }
-            else
-            {
-                opt.u_=inputVectorZero();
-            }
-        }
-
-        return f_->measureDynamics(x,opt.u_,k);
     }
 
-    KalmanFilterBase::Amatrix// ExtendedKalmanFilter<n,m,p>::Amatrix does not work
-    ExtendedKalmanFilter::getAMatrixFD(const Vector
-                                       &dx)
+    if(u_.checkIndex(k))
     {
-        TimeIndex k=this->x_.getTime();
-        opt.a_.resize(nt_,nt_);
-        updateStatePrediction();
-
-
-        opt.x_=this->x_();
-        opt.dx_.resize(nt_);
-
-        if (p_>0)
-        {
-            if (directInputStateProcessFeedthrough_)
-                opt.u_=this->u_[k];
-            else
-                opt.u_=inputVectorZero();
-        }
-
-        for (Index i=0;i< nt_;++i)
-        {
-
-            opt.dx_.setZero();
-            opt.dx_[i]=dx[i];
-
-            arithm_->stateSum(this->x_(),opt.dx_,opt.x_);
-
-
-            opt.xp_=f_->stateDynamics(opt.x_,opt.u_,k);
-
-            arithm_->stateDifference(opt.xp_,xbar_(),opt.dx_);
-
-            opt.dx_/=dx[i];
-
-            opt.a_.col(i)=opt.dx_;
-        }
-
-        return opt.a_;
+      opt.u_ = u_[k];
     }
-
-    KalmanFilterBase::Cmatrix
-    ExtendedKalmanFilter::getCMatrixFD(const Vector  &dx)
+    else
     {
-        TimeIndex k=this->x_.getTime();
-
-        opt.c_.resize(m_,nt_);
-
-        updateStateAndMeasurementPrediction();
-
-        xbar_.set(prediction_(k+1),k+1);
-
-        opt.dx_.resize(nt_);
-
-        for (Index i=0;i<nt_;++i)
-        {
-            opt.dx_.setZero();
-            opt.dx_[i]=dx[i];
-
-            arithm_->stateSum(xbar_(),opt.dx_,opt.xp_);
-
-            opt.yp_=simulateSensor_(opt.xp_, k+1);
-
-            opt.yp_-=ybar_();
-            opt.yp_/=dx[i];
-
-            opt.c_.col(i)=opt.yp_;
-        }
-
-        return opt.c_;
+      opt.u_ = inputVectorZero();
     }
+  }
 
-    void ExtendedKalmanFilter::reset()
-    {
-        KalmanFilterBase::reset();
-        if (f_!=0x0)
-            f_->reset();
-    }
-
-    DynamicalSystemFunctorBase* ExtendedKalmanFilter::functor() const
-    {
-        return f_;
-    }
-
+  return f_->measureDynamics(x, opt.u_, k);
 }
+
+KalmanFilterBase::Amatrix // ExtendedKalmanFilter<n,m,p>::Amatrix does not work
+    ExtendedKalmanFilter::getAMatrixFD(const Vector & dx)
+{
+  TimeIndex k = this->x_.getTime();
+  opt.a_.resize(nt_, nt_);
+  updateStatePrediction();
+
+  opt.x_ = this->x_();
+  opt.dx_.resize(nt_);
+
+  if(p_ > 0)
+  {
+    if(directInputStateProcessFeedthrough_)
+      opt.u_ = this->u_[k];
+    else
+      opt.u_ = inputVectorZero();
+  }
+
+  for(Index i = 0; i < nt_; ++i)
+  {
+
+    opt.dx_.setZero();
+    opt.dx_[i] = dx[i];
+
+    arithm_->stateSum(this->x_(), opt.dx_, opt.x_);
+
+    opt.xp_ = f_->stateDynamics(opt.x_, opt.u_, k);
+
+    arithm_->stateDifference(opt.xp_, xbar_(), opt.dx_);
+
+    opt.dx_ /= dx[i];
+
+    opt.a_.col(i) = opt.dx_;
+  }
+
+  return opt.a_;
+}
+
+KalmanFilterBase::Cmatrix ExtendedKalmanFilter::getCMatrixFD(const Vector & dx)
+{
+  TimeIndex k = this->x_.getTime();
+
+  opt.c_.resize(m_, nt_);
+
+  updateStateAndMeasurementPrediction();
+
+  xbar_.set(prediction_(k + 1), k + 1);
+
+  opt.dx_.resize(nt_);
+
+  for(Index i = 0; i < nt_; ++i)
+  {
+    opt.dx_.setZero();
+    opt.dx_[i] = dx[i];
+
+    arithm_->stateSum(xbar_(), opt.dx_, opt.xp_);
+
+    opt.yp_ = simulateSensor_(opt.xp_, k + 1);
+
+    opt.yp_ -= ybar_();
+    opt.yp_ /= dx[i];
+
+    opt.c_.col(i) = opt.yp_;
+  }
+
+  return opt.c_;
+}
+
+void ExtendedKalmanFilter::reset()
+{
+  KalmanFilterBase::reset();
+  if(f_ != 0x0) f_->reset();
+}
+
+DynamicalSystemFunctorBase * ExtendedKalmanFilter::functor() const
+{
+  return f_;
+}
+
+} // namespace stateObservation

--- a/src/flexibility-estimator-base.cpp
+++ b/src/flexibility-estimator-base.cpp
@@ -5,10 +5,6 @@ namespace stateObservation
 namespace flexibilityEstimation
 {
 
-    FlexibilityEstimatorBase::FlexibilityEstimatorBase
-            ()
-    {
-
-    }
-}
-}
+FlexibilityEstimatorBase::FlexibilityEstimatorBase() {}
+} // namespace flexibilityEstimation
+} // namespace stateObservation

--- a/src/gaussian-white-noise.cpp
+++ b/src/gaussian-white-noise.cpp
@@ -1,82 +1,75 @@
-#include <Eigen/Cholesky>
 #include <boost/assert.hpp>
+#include <Eigen/Cholesky>
 #include <state-observation/noise/gaussian-white-noise.hpp>
 #include <state-observation/tools/probability-law-simulation.hpp>
-
 
 namespace stateObservation
 {
 
-
-    GaussianWhiteNoise::GaussianWhiteNoise(Index dimension):
-            dim_(dimension),
-            std_(Matrix::Identity(dimension, dimension)),
-            bias_(Vector::Zero(dimension,1)),
-            sum_(detail::defaultSum)
-    {
-    }
-
-    GaussianWhiteNoise::GaussianWhiteNoise():
-            dim_(0),
-            sum_(detail::defaultSum)
-    {
-    }
-
-    Vector GaussianWhiteNoise::getNoisy(const Vector & v)
-    {
-        checkVector_(v);
-
-        sum_(v,tools::ProbabilityLawSimulation::getGaussianVector(std_, bias_,dim_),noisy_);
-
-        return noisy_;
-
-    }
-
-    void GaussianWhiteNoise::setStandardDeviation(const Matrix & std)
-    {
-        checkMatrix_(std);
-        std_=std;
-    }
-
-    void GaussianWhiteNoise::setCovarianceMatrix(const Matrix & cov)
-    {
-        checkMatrix_(cov);
-        Matrix L( cov.llt().matrixL());
-        std_=L;
-    }
-
-    void GaussianWhiteNoise::setBias(const Vector & bias)
-    {
-        checkVector_(bias);
-        bias_=bias;
-    }
-
-    Index GaussianWhiteNoise::getDimension() const
-    {
-        return dim_;
-    }
-
-    void GaussianWhiteNoise::setDimension(Index dim)
-    {
-        dim_=dim;
-        bias_=Vector::Zero(dim,1);
-        std_=Matrix::Identity(dim, dim);
-    }
-
-    void GaussianWhiteNoise::checkMatrix_(const Matrix & m) const
-    {
-        (void)m;//avoid warning
-        BOOST_ASSERT(m.rows()==dim_ && m.cols()==dim_ && "ERROR: Matrix incorrecly dimemsioned");
-    }
-
-    void GaussianWhiteNoise::checkVector_(const Vector & v) const
-    {
-        (void)v;//avoid warning
-        BOOST_ASSERT(v.rows()==dim_ && v.cols()==1 && "ERROR: Vector incorrecly dimemsioned");
-    }
-
-    void GaussianWhiteNoise::setSumFunction(void (* sum)(const  Vector& stateVector, const Vector& tangentVector, Vector& result))
-    {
-      sum_=sum;
-    }
+GaussianWhiteNoise::GaussianWhiteNoise(Index dimension)
+: dim_(dimension), std_(Matrix::Identity(dimension, dimension)), bias_(Vector::Zero(dimension, 1)),
+  sum_(detail::defaultSum)
+{
 }
+
+GaussianWhiteNoise::GaussianWhiteNoise() : dim_(0), sum_(detail::defaultSum) {}
+
+Vector GaussianWhiteNoise::getNoisy(const Vector & v)
+{
+  checkVector_(v);
+
+  sum_(v, tools::ProbabilityLawSimulation::getGaussianVector(std_, bias_, dim_), noisy_);
+
+  return noisy_;
+}
+
+void GaussianWhiteNoise::setStandardDeviation(const Matrix & std)
+{
+  checkMatrix_(std);
+  std_ = std;
+}
+
+void GaussianWhiteNoise::setCovarianceMatrix(const Matrix & cov)
+{
+  checkMatrix_(cov);
+  Matrix L(cov.llt().matrixL());
+  std_ = L;
+}
+
+void GaussianWhiteNoise::setBias(const Vector & bias)
+{
+  checkVector_(bias);
+  bias_ = bias;
+}
+
+Index GaussianWhiteNoise::getDimension() const
+{
+  return dim_;
+}
+
+void GaussianWhiteNoise::setDimension(Index dim)
+{
+  dim_ = dim;
+  bias_ = Vector::Zero(dim, 1);
+  std_ = Matrix::Identity(dim, dim);
+}
+
+void GaussianWhiteNoise::checkMatrix_(const Matrix & m) const
+{
+  (void)m; // avoid warning
+  BOOST_ASSERT(m.rows() == dim_ && m.cols() == dim_ && "ERROR: Matrix incorrecly dimemsioned");
+}
+
+void GaussianWhiteNoise::checkVector_(const Vector & v) const
+{
+  (void)v; // avoid warning
+  BOOST_ASSERT(v.rows() == dim_ && v.cols() == 1 && "ERROR: Vector incorrecly dimemsioned");
+}
+
+void GaussianWhiteNoise::setSumFunction(void (*sum)(const Vector & stateVector,
+                                                    const Vector & tangentVector,
+                                                    Vector & result))
+{
+  sum_ = sum;
+}
+} // namespace stateObservation

--- a/src/imu-dynamical-system.cpp
+++ b/src/imu-dynamical-system.cpp
@@ -1,154 +1,147 @@
 #include <state-observation/dynamical-system/imu-dynamical-system.hpp>
 
-
 #include <state-observation/tools/miscellaneous-algorithms.hpp>
 
 namespace stateObservation
 {
 
-    IMUDynamicalSystem::IMUDynamicalSystem()
-    :processNoise_(0x0),dt_(1),orientationVector_(Vector3::Zero()),
-        quaternion_(Quaternion::Identity())
-    {
+IMUDynamicalSystem::IMUDynamicalSystem()
+: processNoise_(0x0), dt_(1), orientationVector_(Vector3::Zero()), quaternion_(Quaternion::Identity())
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-       std::cout<<std::endl<<"IMUFixedContactDynamicalSystem Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
-        //ctor
-    }
-
-    IMUDynamicalSystem::~IMUDynamicalSystem()
-    {
-        //dtor
-    }
-
-    Vector IMUDynamicalSystem::stateDynamics
-        (const Vector& x, const Vector& u, TimeIndex)
-    {
-        assertStateVector_(x);
-        assertInputVector_(u);
-
-        Vector3 position=x.segment(indexes::pos,3);
-        Vector3 velocity=x.segment(indexes::linVel,3);
-        Vector3 acceleration=x.segment(indexes::linAcc,3);
-
-        Vector3 orientationV=x.segment(indexes::ori,3);
-        Vector3 angularVelocity=x.segment(indexes::angVel,3);
-        Vector3 angularAcceleration=x.segment(indexes::angAcc,3);
-
-        Quaternion orientation=computeQuaternion_(orientationV);
-
-        kine::integrateKinematics
-                (position, velocity, acceleration, orientation, angularVelocity,
-                        angularAcceleration, dt_);
-
-        //x_{k+1}
-        Vector xk1=Vector::Zero(18,1);
-
-        xk1.segment(indexes::pos,3) = position;
-        xk1.segment(indexes::linVel,3) = velocity;
-
-        AngleAxis orientationAA(orientation);
-
-        orientationV=orientationAA.angle()*orientationAA.axis();
-
-        xk1.segment(indexes::ori,3) =  orientationV;
-        xk1.segment(indexes::angVel,3) = angularVelocity;
-
-
-        //inputs
-        Vector3 accelerationInput =u.head(3);
-        Vector3 angularAccelerationInput =u.tail(3);
-
-        xk1.segment(indexes::linAcc,3)+=accelerationInput;
-        xk1.segment(indexes::angAcc,3)+=angularAccelerationInput;
-
-        if (processNoise_!=0x0)
-            return processNoise_->getNoisy(xk1);
-        else
-            return xk1;
-
-    }
-
-    Quaternion IMUDynamicalSystem::computeQuaternion_(const Vector3 & x)
-    {
-        if (orientationVector_!=x)
-        {
-            quaternion_ = kine::rotationVectorToAngleAxis(x);
-            orientationVector_=x;
-        }
-
-        return quaternion_;
-    }
-
-    Vector IMUDynamicalSystem::measureDynamics (const Vector& x, const Vector& , TimeIndex k)
-    {
-        assertStateVector_(x);
-
-        Vector3 acceleration=x.segment(indexes::linAcc,3);
-
-        Vector3 orientationV=x.segment(indexes::ori,3);
-        Vector3 angularVelocity=x.segment(indexes::angVel,3);
-
-        Quaternion q=computeQuaternion_(orientationV);
-
-        Vector v=Vector::Zero(10,1);
-
-        v.head<4>() = q.coeffs();
-
-        v.segment(4,3)=acceleration;
-        v.tail(3)=angularVelocity;
-
-        sensor_.setState(v,k);
-
-        return sensor_.getMeasurements();
-    }
-
-    void IMUDynamicalSystem::setProcessNoise( NoiseBase * n)
-    {
-        processNoise_=n;
-    }
-
-    void IMUDynamicalSystem::resetProcessNoise()
-    {
-        processNoise_=0x0;
-    }
-
-    void IMUDynamicalSystem::setMeasurementNoise( NoiseBase * n)
-    {
-        sensor_.setNoise(n);
-    }
-    void IMUDynamicalSystem::resetMeasurementNoise()
-    {
-        sensor_.resetNoise();
-    }
-
-    void IMUDynamicalSystem::setSamplingPeriod(double dt)
-    {
-        dt_=dt;
-    }
-
-    Index IMUDynamicalSystem::getStateSize() const
-    {
-        return stateSize_;
-    }
-
-    Index IMUDynamicalSystem::getInputSize() const
-    {
-        return inputSize_;
-    }
-
-    Index IMUDynamicalSystem::getMeasurementSize() const
-    {
-        return measurementSize_;
-    }
-
-    NoiseBase * IMUDynamicalSystem::getProcessNoise() const
-    {
-        return processNoise_;
-    }
-
-    NoiseBase * IMUDynamicalSystem::getMeasurementNoise() const
-    {
-        return sensor_.getNoise();
-    }
+  std::cout << std::endl << "IMUFixedContactDynamicalSystem Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+       // ctor
 }
+
+IMUDynamicalSystem::~IMUDynamicalSystem()
+{
+  // dtor
+}
+
+Vector IMUDynamicalSystem::stateDynamics(const Vector & x, const Vector & u, TimeIndex)
+{
+  assertStateVector_(x);
+  assertInputVector_(u);
+
+  Vector3 position = x.segment(indexes::pos, 3);
+  Vector3 velocity = x.segment(indexes::linVel, 3);
+  Vector3 acceleration = x.segment(indexes::linAcc, 3);
+
+  Vector3 orientationV = x.segment(indexes::ori, 3);
+  Vector3 angularVelocity = x.segment(indexes::angVel, 3);
+  Vector3 angularAcceleration = x.segment(indexes::angAcc, 3);
+
+  Quaternion orientation = computeQuaternion_(orientationV);
+
+  kine::integrateKinematics(position, velocity, acceleration, orientation, angularVelocity, angularAcceleration, dt_);
+
+  // x_{k+1}
+  Vector xk1 = Vector::Zero(18, 1);
+
+  xk1.segment(indexes::pos, 3) = position;
+  xk1.segment(indexes::linVel, 3) = velocity;
+
+  AngleAxis orientationAA(orientation);
+
+  orientationV = orientationAA.angle() * orientationAA.axis();
+
+  xk1.segment(indexes::ori, 3) = orientationV;
+  xk1.segment(indexes::angVel, 3) = angularVelocity;
+
+  // inputs
+  Vector3 accelerationInput = u.head(3);
+  Vector3 angularAccelerationInput = u.tail(3);
+
+  xk1.segment(indexes::linAcc, 3) += accelerationInput;
+  xk1.segment(indexes::angAcc, 3) += angularAccelerationInput;
+
+  if(processNoise_ != 0x0)
+    return processNoise_->getNoisy(xk1);
+  else
+    return xk1;
+}
+
+Quaternion IMUDynamicalSystem::computeQuaternion_(const Vector3 & x)
+{
+  if(orientationVector_ != x)
+  {
+    quaternion_ = kine::rotationVectorToAngleAxis(x);
+    orientationVector_ = x;
+  }
+
+  return quaternion_;
+}
+
+Vector IMUDynamicalSystem::measureDynamics(const Vector & x, const Vector &, TimeIndex k)
+{
+  assertStateVector_(x);
+
+  Vector3 acceleration = x.segment(indexes::linAcc, 3);
+
+  Vector3 orientationV = x.segment(indexes::ori, 3);
+  Vector3 angularVelocity = x.segment(indexes::angVel, 3);
+
+  Quaternion q = computeQuaternion_(orientationV);
+
+  Vector v = Vector::Zero(10, 1);
+
+  v.head<4>() = q.coeffs();
+
+  v.segment(4, 3) = acceleration;
+  v.tail(3) = angularVelocity;
+
+  sensor_.setState(v, k);
+
+  return sensor_.getMeasurements();
+}
+
+void IMUDynamicalSystem::setProcessNoise(NoiseBase * n)
+{
+  processNoise_ = n;
+}
+
+void IMUDynamicalSystem::resetProcessNoise()
+{
+  processNoise_ = 0x0;
+}
+
+void IMUDynamicalSystem::setMeasurementNoise(NoiseBase * n)
+{
+  sensor_.setNoise(n);
+}
+void IMUDynamicalSystem::resetMeasurementNoise()
+{
+  sensor_.resetNoise();
+}
+
+void IMUDynamicalSystem::setSamplingPeriod(double dt)
+{
+  dt_ = dt;
+}
+
+Index IMUDynamicalSystem::getStateSize() const
+{
+  return stateSize_;
+}
+
+Index IMUDynamicalSystem::getInputSize() const
+{
+  return inputSize_;
+}
+
+Index IMUDynamicalSystem::getMeasurementSize() const
+{
+  return measurementSize_;
+}
+
+NoiseBase * IMUDynamicalSystem::getProcessNoise() const
+{
+  return processNoise_;
+}
+
+NoiseBase * IMUDynamicalSystem::getMeasurementNoise() const
+{
+  return sensor_.getNoise();
+}
+} // namespace stateObservation

--- a/src/imu-elastic-local-frame-dynamical-system.cpp
+++ b/src/imu-elastic-local-frame-dynamical-system.cpp
@@ -12,1408 +12,1370 @@
 namespace stateObservation
 {
 
-  inline Matrix3 buildInertiaTensor(const Vector6 inputInertia, Matrix3& inertiaTensor)
+inline Matrix3 buildInertiaTensor(const Vector6 inputInertia, Matrix3 & inertiaTensor)
+{
+
+  const double & Ixx = inputInertia[0];
+  const double & Iyy = inputInertia[1];
+  const double & Izz = inputInertia[2];
+  const double & Ixy = inputInertia[3];
+  const double & Ixz = inputInertia[4];
+  const double & Iyz = inputInertia[5];
+
+  inertiaTensor << Ixx, Ixy, Ixz, Ixy, Iyy, Iyz, Ixz, Iyz, Izz;
+
+  return inertiaTensor;
+}
+
+namespace flexibilityEstimation
+{
+using namespace stateObservation;
+
+IMUElasticLocalFrameDynamicalSystem::IMUElasticLocalFrameDynamicalSystem(double dt)
+: processNoise_(0x0), dt_(dt), robotMass_(hrp2::m), robotMassInv_(1 / hrp2::m), measurementSize_(measurementSizeBase_),
+  withForceMeasurements_(false), withComBias_(false), withAbsolutePos_(false), withUnmodeledForces_(false),
+  marginalStabilityFactor_(0.9999)
+{
+#ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
+  // std::cout<<std::endl<<"IMUElasticLocalFrameDynamicalSystem Constructor"<<std::endl;
+
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+  Kfe_ = 40000 * Matrix3::Identity();
+  Kte_ = 600 * Matrix3::Identity();
+  Kfv_ = 600 * Matrix3::Identity();
+  Ktv_ = 60 * Matrix3::Identity();
+
+  KfeRopes_ = 40000 * Matrix3::Identity();
+  KteRopes_ = 600 * Matrix3::Identity();
+  KfvRopes_ = 600 * Matrix3::Identity();
+  KtvRopes_ = 60 * Matrix3::Identity();
+
+  sensor_.setMatrixMode(true);
+
+  contactModel_ = contactModel::none;
+
+  nbContacts_ = 0;
+  inputSize_ = input::sizeBase;
+
+  kcurrent_ = -1;
+
+  fc_.resize(hrp2::contact::nbModeledMax * 3);
+  fc_.setZero();
+  tc_.resize(hrp2::contact::nbModeledMax * 3);
+  tc_.setZero();
+
+  printed_ = false;
+  pe.setZero();
+}
+
+IMUElasticLocalFrameDynamicalSystem::~IMUElasticLocalFrameDynamicalSystem()
+{
+  // dtor
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setRobotMass(double m)
+{
+  robotMass_ = m;
+  robotMassInv_ = 1 / m;
+}
+
+double IMUElasticLocalFrameDynamicalSystem::getRobotMass() const
+{
+  return robotMass_;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setContactModel(unsigned nb)
+{
+  contactModel_ = nb;
+}
+
+Vector IMUElasticLocalFrameDynamicalSystem::getMomentaDotFromForces(const Vector & x, const Vector & u)
+{
+  assertStateVector_(x);
+  assertInputVector_(u);
+
+  // Getting flexibility
+  op_.positionFlex = x.segment(state::pos, 3);
+  op_.orientationFlexV = x.segment(state::ori, 3);
+  op_.rFlex = computeRotation_(op_.orientationFlexV, 0);
+
+  // Getting contact forces
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i) op_.efforts.setValue(x.segment(state::fc + 6 * i, 6), i);
+
+  op_.fm = x.segment(state::unmodeledForces, 3);
+  op_.tm = x.segment(state::unmodeledForces + 3, 3);
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i)
   {
-
-    const double & Ixx=inputInertia[0];
-    const double & Iyy=inputInertia[1];
-    const double & Izz=inputInertia[2];
-    const double & Ixy=inputInertia[3];
-    const double & Ixz=inputInertia[4];
-    const double & Iyz=inputInertia[5];
-
-    inertiaTensor   <<    Ixx, Ixy, Ixz,
-                    Ixy, Iyy, Iyz,
-                    Ixz, Iyz, Izz;
-
-    return inertiaTensor;
+    fc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(0, 0);
+    tc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(3, 0);
   }
 
-  namespace flexibilityEstimation
+  // Getting CoM
+  op_.positionComBias << x.segment(state::comBias, 2),
+      0; // the bias of the com along the z axis is assumed 0.
+  op_.positionCom = u.segment<3>(input::posCom);
+  if(withComBias_) op_.positionCom -= op_.positionComBias;
+
+  // Getting contact positions
+  unsigned nbContacts(getContactsNumber());
+  for(unsigned i = 0; i < nbContacts; ++i)
   {
-    using namespace stateObservation;
-
-   IMUElasticLocalFrameDynamicalSystem::
-    	IMUElasticLocalFrameDynamicalSystem(double dt):
-        processNoise_(0x0), dt_(dt),
-        robotMass_(hrp2::m),
-        robotMassInv_(1/hrp2::m),
-        measurementSize_(measurementSizeBase_),
-        withForceMeasurements_(false), withComBias_(false), withAbsolutePos_(false),
-        withUnmodeledForces_(false),
-        marginalStabilityFactor_(0.9999)
-    {
-#ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-      // std::cout<<std::endl<<"IMUElasticLocalFrameDynamicalSystem Constructor"<<std::endl;
-
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
-      Kfe_=40000*Matrix3::Identity();
-      Kte_=600*Matrix3::Identity();
-      Kfv_=600*Matrix3::Identity();
-      Ktv_=60*Matrix3::Identity();
-
-      KfeRopes_=40000*Matrix3::Identity();
-      KteRopes_=600*Matrix3::Identity();
-      KfvRopes_=600*Matrix3::Identity();
-      KtvRopes_=60*Matrix3::Identity();
-
-      sensor_.setMatrixMode(true);
-
-      contactModel_=contactModel::none;
-
-      nbContacts_=0;
-      inputSize_=input::sizeBase;
-
-      kcurrent_=-1;
-
-      fc_.resize(hrp2::contact::nbModeledMax*3);
-      fc_.setZero();
-      tc_.resize(hrp2::contact::nbModeledMax*3);
-      tc_.setZero();
-
-      printed_ = false;
-      pe.setZero();
-
-    }
-
-    IMUElasticLocalFrameDynamicalSystem::
-                    ~IMUElasticLocalFrameDynamicalSystem()
-    {
-        //dtor
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setRobotMass(double m)
-    {
-      robotMass_ = m;
-      robotMassInv_=1/m;
-    }
-
-    double IMUElasticLocalFrameDynamicalSystem::getRobotMass() const
-    {
-      return robotMass_;
-    }
-
-
-    void IMUElasticLocalFrameDynamicalSystem::setContactModel(unsigned nb)
-    {
-      contactModel_=nb;
-    }
-
-
-    Vector IMUElasticLocalFrameDynamicalSystem::getMomentaDotFromForces(const Vector& x, const Vector& u)
-    {
-      assertStateVector_(x);
-      assertInputVector_(u);
-
-      // Getting flexibility
-      op_.positionFlex=x.segment(state::pos,3);
-      op_.orientationFlexV=x.segment(state::ori,3);
-      op_.rFlex = computeRotation_(op_.orientationFlexV,0);
-
-      // Getting contact forces
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-        op_.efforts.setValue(x.segment(state::fc+6*i,6),i);
-
-      op_.fm=x.segment(state::unmodeledForces,3);
-      op_.tm=x.segment(state::unmodeledForces+3,3);
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-      {
-        fc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(0,0);
-        tc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(3,0);
-      }
-
-      // Getting CoM
-      op_.positionComBias <<  x.segment(state::comBias,2),
-                          0;// the bias of the com along the z axis is assumed 0.
-      op_.positionCom=u.segment<3>(input::posCom);
-      if(withComBias_) op_.positionCom-=op_.positionComBias;
-
-
-      // Getting contact positions
-      unsigned nbContacts(getContactsNumber());
-      for (unsigned i = 0; i<nbContacts ; ++i)
-      {
-        // Positions
-        op_.contactPosV.setValue(u.segment<3>(input::contacts + 12*i),i);
-        op_.contactOriV.setValue(u.segment<3>(input::contacts +12*i+3),i);
-      }
-
-      op_.addForce = u.segment<3>(input::additionalForces);
-      op_.addMoment = u.segment<3>(input::additionalForces+3);
-
-      computeContactWrench(op_.rFlex, op_.positionFlex, op_.contactPosV, op_.contactOriV,
-                           fc_, tc_, op_.fm, op_.tm, op_.addForce, op_.addMoment);
-
-
-      op_.momentaDot.segment<3>(0) = op_.f - hrp2::m*cst::gravity;
-      op_.momentaDot.segment<3>(3) = op_.t - kine::skewSymmetric(op_.rFlex*op_.positionCom+op_.positionFlex)*hrp2::m*cst::gravity;
-
-      return op_.momentaDot;
-    }
-
-    Vector IMUElasticLocalFrameDynamicalSystem::getMomentaDotFromKinematics(const Vector& x, const Vector& u)
-    {
-      assertStateVector_(x);
-      assertInputVector_(u);
-
-      op_.positionFlex=x.segment(state::pos,3);
-      op_.orientationFlexV=x.segment(state::ori,3);
-      op_.rFlex = computeRotation_(op_.orientationFlexV,0);
-      op_.rFlexT = computeRotation_(op_.orientationFlexV,0).transpose();
-      op_.velocityFlex=x.segment(state::linVel,3);
-      op_.angularVelocityFlex=x.segment(state::angVel,3);
-
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-      {
-        op_.efforts.setValue(x.segment(state::fc+6*i,6),i);
-        fc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(0,0);
-        tc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(3,0);
-      }
-      op_.fm=x.segment(state::unmodeledForces,3);
-      op_.tm=x.segment(state::unmodeledForces+3,3);
-
-      op_.positionCom=u.segment<3>(input::posCom);
-      op_.velocityCom=u.segment<3>(input::velCom);
-      op_.accelerationCom=u.segment<3>(input::accCom);
-      if(withComBias_)
-      {
-        op_.positionComBias <<  x.segment(state::comBias,2),
-                            0;// the bias of the com along the z axis is assumed 0.
-        op_.positionCom-=op_.positionComBias;
-      }
-
-      buildInertiaTensor(u.segment<6>(input::inertia),op_.inertia);
-      buildInertiaTensor(u.segment<6>(input::dotInertia),op_.dotInertia);
-      op_.AngMomentum=u.segment<3>(input::angMoment);
-      op_.dotAngMomentum=u.segment<3>(input::dotAngMoment);
-
-      unsigned nbContacts(getContactsNumber());
-
-      for (unsigned i = 0; i<nbContacts ; ++i)
-      {
-        // Positions
-        op_.contactPosV.setValue(u.segment<3>(input::contacts + 12*i),i);
-        op_.contactOriV.setValue(u.segment<3>(input::contacts +12*i+3),i);
-
-        // Velocities
-        op_.contactVelArray.setValue(u.segment<3>(input::contacts + 12*i +6),i);
-        op_.contactAngVelArray.setValue(u.segment<3>(input::contacts +12*i +9),i);
-
-      }
-
-      op_.addForce = u.segment<3>(input::additionalForces);
-      op_.addMoment = u.segment<3>(input::additionalForces+3);
-
-
-      computeAccelerations (op_.positionCom, op_.velocityCom, op_. accelerationCom,
-                            op_.AngMomentum, op_.dotAngMomentum, op_.inertia, op_.dotInertia,
-                            op_.contactPosV, op_.contactOriV,
-                            op_.positionFlex, op_.velocityFlex, op_.linearAcceleration,
-                            op_.orientationFlexV, op_.rFlex, op_.velocityFlex, op_.angularAcceleration,
-                            fc_, tc_, op_.fm, op_.tm,op_.addForce,op_.addMoment);
-
-      op_.momentaDot.segment<3>(0) = hrp2::m*(kine::skewSymmetric(op_.angularAcceleration)*op_.rFlex*op_.positionCom
-                                              +kine::skewSymmetric2(op_.angularVelocityFlex)*op_.rFlex*op_.positionCom
-                                              +2*kine::skewSymmetric(op_.angularVelocityFlex)*op_.rFlex*op_.velocityCom
-                                              +op_.rFlex*op_.accelerationCom+op_.linearAcceleration);
-      op_.momentaDot.segment<3>(3) = kine::skewSymmetric(op_.angularVelocityFlex)*op_.rFlex*op_.inertia*op_.rFlexT*op_.angularVelocityFlex
-                                     +op_.rFlex*op_.dotInertia*op_.rFlexT*op_.angularVelocityFlex+op_.rFlex*op_.inertia*op_.rFlexT*op_.angularAcceleration
-                                     +kine::skewSymmetric(op_.angularVelocityFlex)*op_.rFlex*op_.AngMomentum+op_.rFlex*op_.dotAngMomentum
-                                     +kine::skewSymmetric(op_.positionFlex)*op_.momentaDot.segment<3>(0)+hrp2::m*kine::skewSymmetric(op_.rFlex*op_.positionCom)*op_.linearAcceleration;
-
-      return op_.momentaDot;
-    }
-
-    Vector IMUElasticLocalFrameDynamicalSystem::getForcesAndMoments()
-    {
-      unsigned nbContacts(getContactsNumber());
-      Vector x(6*nbContacts);
-      x.setZero();
-
-      for (unsigned int i=0; i<nbContacts; ++i)
-      {
-        x.segment<3>(6*i) = fc_.segment<3>(3*i);
-        x.segment<3>(6*i+3) = tc_.segment<3>(3*i);
-      }
-
-      return x;
-    }
-
-    Vector IMUElasticLocalFrameDynamicalSystem::getForcesAndMoments(const Vector& x, const Vector& u)
-    {
-      computeForcesAndMoments(x,u);
-      return getForcesAndMoments();
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::computeElastContactForcesAndMoments
-                              (const IndexedVectorArray& contactPosArray,
-                               const IndexedVectorArray& contactOriArray,
-                               const IndexedVectorArray& contactVelArray,
-                               const IndexedVectorArray& contactAngVelArray,
-                               const Vector3& position, const Vector3& linVelocity,
-                               const Vector3& oriVector, const Matrix3& orientation,
-                               const Vector3& angVel,
-                               Vector& fc, Vector& tc)
-    {
-
-      (void)contactAngVelArray; //avoid warnings
-      unsigned nbContacts(getContactsNumber());
-      fc.setZero();
-      tc.setZero();
-
-      op_.Rt = orientation.transpose();
-
-      for (unsigned i = 0; i<nbContacts ; ++i)
-      {
-        op_.contactPos = contactPosArray[i];
-        op_.contactVel = contactVelArray[i];
-
-        op_.Rci = computeRotation_(contactOriArray[i],i+2);
-        op_.Rcit.noalias()= op_.Rci.transpose();
-
-        op_.RciContactPos.noalias()= orientation*op_.contactPos;
-
-        op_.globalContactPos = position;
-        op_.globalContactPos.noalias() += op_.RciContactPos ;
-
-        op_.forcei.noalias() = - Kfe_*op_.Rcit*op_.Rt*(op_.globalContactPos-op_.contactPos);
-
-        op_.forcei.noalias() += - Kfv_*op_.Rcit*op_.Rt*(kine::skewSymmetric(angVel)*op_.RciContactPos
-                                +linVelocity + orientation*op_.contactVel);
-
-        //std::cout << "RciContactPos " << op_.RciContactPos.transpose() <<std::endl;
-        //std::cout << "linVelocity " << linVelocity.transpose() <<std::endl;
-        //std::cout << "kine::skewSymmetric(angVel)*op_.RciContactPos +linVelocity + orientation*op_.contactVel " << (kine::skewSymmetric(angVel)*op_.RciContactPos
-        //                          +linVelocity + orientation*op_.contactVel).transpose() <<std::endl;
-
-        //std::cout << "forcei " << op_.forcei.transpose() <<std::endl;
-
-        fc.segment<3>(3*i)= op_.forcei;
-
-        op_.momenti.noalias() = -Kte_*op_.Rcit*op_.Rt*oriVector;
-        op_.momenti.noalias() += -Ktv_*op_.Rcit*op_.Rt*angVel;
-
-        tc.segment<3>(3*i)= op_.momenti;
-      }
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::computeElastPendulumForcesAndMoments
-                              (const IndexedVectorArray& PrArray,
-                               const Vector3& position, const Vector3& linVelocity,
-                               const Vector3& oriVector, const Matrix3& orientation,
-                               const Vector3& angVel,
-                               Vector& forces, Vector& moments)
-    {
-      unsigned nbContacts(getContactsNumber());
-      forces.setZero();
-      moments.setZero();
-
-      Vector3 forcei;
-      Vector3 momenti;
-      Vector3 globalContactPos;
-
-      Vector3 contactOriUnitVector;
-
-      double ropeLength;
-      double modifiedRopeLength;
-
-      for (unsigned i = 0; i<nbContacts ; ++i)
-      {
-        globalContactPos = position ;
-        globalContactPos.noalias() += orientation*PrArray[i] ;
-
-        ropeLength=(PrArray[i]-pe).norm();
-        modifiedRopeLength=(globalContactPos-pe).norm();
-        contactOriUnitVector= (globalContactPos-pe)/modifiedRopeLength;
-
-        forcei = -(modifiedRopeLength-ropeLength)*KfeRopes_*contactOriUnitVector;
-        forces.segment<3>(0) += forcei;
-
-        momenti=kine::skewSymmetric(globalContactPos)*forcei;
-
-        if(printed_==false)
-        {
-          //            std::cout << "globalContactPos=" << globalContactPos.transpose() << std::endl;
-          //            std::cout << "ropeLength=" << ropeLength << std::endl;
-          //            std::cout << "rope deformation=" << modifiedRopeLength-ropeLength << std::endl;
-          //            std::cout << "contactOriUnitVector=" << contactOriUnitVector.transpose() << std::endl;
-          //            std::cout << "forcei=" << forcei.transpose() << std::endl;
-          //            std::cout << "momenti=" << momenti.transpose() << std::endl;
-          printed_=true;
-        }
-
-      }
-
-      moments.segment<3>(0) << 0,
-                      0,
-                      -KteRopes_(2,2)*oriVector(2);
-      moments.segment<3>(0).noalias() += - KtvRopes_*angVel;
-      forces.segment<3>(0).noalias() += -KfvRopes_*linVelocity;
-    }
-
-
-    inline void IMUElasticLocalFrameDynamicalSystem::computeForcesAndMoments
-                          (const IndexedVectorArray& contactpos,
-                           const IndexedVectorArray& contactori,
-                           const IndexedVectorArray& contactvel,
-                           const IndexedVectorArray& contactangvel,
-                           const Vector3& position, const Vector3& linVelocity,
-                           const Vector3& oriVector, const Matrix3& orientation,
-                           const Vector3& angVel,
-                           Vector& fc, Vector& tc)
-    {
-      switch(contactModel_)
-      {
-      case contactModel::elasticContact :
-        computeElastContactForcesAndMoments(contactpos, contactori, contactvel, contactangvel, position, linVelocity, oriVector, orientation, angVel, fc, tc);
-        break;
-
-      case contactModel::pendulum :
-        computeElastPendulumForcesAndMoments(contactpos, position, linVelocity, oriVector, orientation, angVel, fc, tc);
-        break;
-
-      default:
-        throw std::invalid_argument("IMUElasticLocalFrameDynamicalSystem: the contact model is incorrectly set.");
-      }
-    }
-
-    inline void IMUElasticLocalFrameDynamicalSystem::computeForcesAndMoments (const Vector& x,const Vector& u)
-    {
-
-      op_.positionFlex=x.segment(state::pos,3);
-      op_.velocityFlex=x.segment(state::linVel,3);
-      op_.orientationFlexV=x.segment(state::ori,3);
-      op_.angularVelocityFlex=x.segment(state::angVel,3);
-      op_.rFlex = computeRotation_(op_.orientationFlexV,0);
-
-      unsigned nbContacts(getContactsNumber());
-
-      for (unsigned i = 0; i<nbContacts ; ++i)
-      {
-        // Positions
-        op_.contactPosV.setValue(u.segment<3>(input::contacts + 12*i),i);
-        op_.contactOriV.setValue(u.segment<3>(input::contacts +12*i+3),i);
-
-        // Velocities
-        op_.contactVelArray.setValue(u.segment<3>(input::contacts + 12*i +6),i);
-        op_.contactAngVelArray.setValue(u.segment<3>(input::contacts +12*i +9),i);
-      }
-
-      computeForcesAndMoments (op_.contactPosV, op_.contactOriV, op_.contactVelArray, op_.contactAngVelArray,
-                               op_.positionFlex, op_.velocityFlex, op_.orientationFlexV, op_.rFlex,
-                               op_.angularVelocityFlex, fc_, tc_);
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::computeContactWrench
-            (const Matrix3& orientation, const Vector3& position,
-             const IndexedVectorArray& contactPosV, const IndexedVectorArray& contactOriV,
-             const Vector& fc, const Vector& tc, const Vector3 & fm, const Vector3& tm,
-             const Vector3& addForce,const Vector3& addMoment)
-    {
-      //from local to global frame
-      op_.f=orientation*addForce;
-      op_.t=orientation*addMoment+position.cross(op_.f);
-
-      op_.f+=fm;
-      op_.t+=tm;
-
-      if(contactModel_==contactModel::elasticContact)
-      {
-        for (unsigned i = 0; i<getContactsNumber() ; ++i)
-        {
-          op_.Rci = kine::rotationVectorToAngleAxis(contactOriV[i]).toRotationMatrix();
-          op_.globalContactPos.noalias() = orientation*contactPosV[i] + position ;
-          op_.fi=orientation*op_.Rci*fc.segment<3>(i*3);
-          op_.f+= op_.fi;
-          op_.t+= orientation*op_.Rci*tc.segment<3>(i*3)+op_.globalContactPos.cross(op_.fi);
-        }
-      }
-      else
-      {
-        op_.f+=fc.segment<3>(0);
-        op_.t+=tc.segment<3>(0);
-      }
-    }
-
-    stateObservation::Vector IMUElasticLocalFrameDynamicalSystem::computeAccelerations(const Vector& x,const Vector& u)
-    {
-      assertStateVector_(x);
-      assertInputVector_(u);
-
-      op_.positionFlex=x.segment(state::pos,3);
-      op_.orientationFlexV=x.segment(state::ori,3);
-      op_.rFlex = computeRotation_(op_.orientationFlexV,0);
-      op_.velocityFlex=x.segment(state::linVel,3);
-      op_.angularVelocityFlex=x.segment(state::angVel,3);
-
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-      {
-        op_.efforts.setValue(x.segment(state::fc+6*i,6),i);
-        fc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(0,0);
-        tc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(3,0);
-      }
-
-      op_.positionComBias <<  x.segment(state::comBias,2),
-                          0;// the bias of the com along the z axis is assumed 0.
-      op_.fm=x.segment(state::unmodeledForces,3);
-      op_.tm=x.segment(state::unmodeledForces+3,3);
-
-      buildInertiaTensor(u.segment<6>(input::inertia),op_.inertia);
-      buildInertiaTensor(u.segment<6>(input::dotInertia),op_.dotInertia);
-
-      unsigned nbContacts(getContactsNumber());
-
-      for (unsigned i = 0; i<nbContacts ; ++i)
-      {
-        // Positions
-        op_.contactPosV.setValue(u.segment<3>(input::contacts + 12*i),i);
-        op_.contactOriV.setValue(u.segment<3>(input::contacts +12*i+3),i);
-
-        // Velocities
-        op_.contactVelArray.setValue(u.segment<3>(input::contacts + 12*i +6),i);
-        op_.contactAngVelArray.setValue(u.segment<3>(input::contacts +12*i +9),i);
-
-      }
-
-      op_.positionCom=u.segment<3>(input::posCom);
-      if(withComBias_) op_.positionCom-=op_.positionComBias;
-      op_.velocityCom=u.segment<3>(input::velCom);
-      op_.accelerationCom=u.segment<3>(input::accCom);
-      op_.AngMomentum=u.segment<3>(input::angMoment);
-      op_.dotAngMomentum=u.segment<3>(input::dotAngMoment);
-
-      op_.addForce = u.segment<3>(input::additionalForces);
-      op_.addMoment = u.segment<3>(input::additionalForces+3);
-
-
-      computeAccelerations
-      (op_.positionCom, op_.velocityCom, op_.accelerationCom,
-       op_.AngMomentum, op_.dotAngMomentum, op_.inertia, op_.dotInertia,
-       op_.contactPosV, op_.contactOriV,
-       op_.positionFlex, op_.velocityFlex, op_.linearAcceleration,
-       op_.orientationFlexV, op_.rFlex,
-       op_.angularVelocityFlex, op_.angularAcceleration,
-       fc_, tc_, op_.fm, op_.tm,op_.addForce,op_.addMoment);
-
-      stateObservation::Vector6 acceleration;
-      acceleration << op_.linearAcceleration,
-                   op_.angularAcceleration;
-      return acceleration;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::computeAccelerations
-       (const Vector3& positionCom, const Vector3& velocityCom,
-        const Vector3& accelerationCom, const Vector3& AngMomentum,
-        const Vector3& dotAngMomentum,
-        const Matrix3& Inertia, const Matrix3& dotInertia,
-        const IndexedVectorArray& contactPosV,
-        const IndexedVectorArray& contactOriV,
-        const Vector3& position, const Vector3& linVelocity, Vector3& linearAcceleration,
-        const Vector3 &oriVector ,const Matrix3& orientation,
-        const Vector3& angularVel, Vector3& angularAcceleration,
-        const Vector& fc, const Vector& tc,
-        const Vector3 & fm, const Vector3& tm,
-        const Vector3 & addForces, const Vector3& addMoments)
-    {
-
-      (void) linVelocity;
-      (void) oriVector; //
-
-      kine::skewSymmetric(angularVel,op_.skewV);
-      kine::skewSymmetric2(angularVel,op_.skewV2);
-      op_.skewVR.noalias()=op_.skewV * orientation;
-      op_.skewV2R.noalias()=op_.skewV2 * orientation;
-
-      op_.rFlexT.noalias()=orientation.transpose();
-
-      computeContactWrench(orientation, position, contactPosV, contactOriV,
-                           fc, tc, fm, tm, addForces, addMoments);
-
-      op_.wx2Rc.noalias()=op_.skewV2R*positionCom;
-      op_._2wxRv.noalias()=2*op_.skewVR*velocityCom;
-      op_.Ra.noalias() = orientation*accelerationCom;
-      op_.Rc.noalias() = orientation * positionCom;
-      op_.Rcp.noalias() = op_.Rc+position;
-      op_.RIRT.noalias() = orientation*Inertia*op_.rFlexT;
-
-      op_.vf.noalias() =robotMassInv_*op_.f;
-
-      op_.vf.noalias() -= op_.Ra;
-      op_.vf.noalias() -= op_._2wxRv;
-      op_.vf.noalias() -= op_.wx2Rc;
-      op_.vf.noalias() -= cst::gravity;
-
-      op_.vt =op_.t;
-      op_.vt.noalias() -= op_.skewV * (op_.RIRT * angularVel);
-      op_.vt.noalias() -= orientation * (dotInertia * (op_.rFlexT * angularVel)+dotAngMomentum) ;
-      op_.vt.noalias() -= op_.skewVR * AngMomentum;
-      op_.vt.noalias() -= robotMass_* (kine::skewSymmetric(position) *
-                                       (op_.wx2Rc+ op_._2wxRv + op_.Ra ));
-      op_.vt.noalias() -= robotMass_* kine::skewSymmetric(op_.Rcp) * cst::gravity;
-
-      op_.orinertia.noalias() = op_.RIRT + robotMass_*kine::skewSymmetric2(op_.Rc);
-      op_.invinertia.compute(op_.orinertia);
-
-      angularAcceleration.noalias() = op_.vt - robotMass_*op_.Rcp.cross(op_.vf);
-
-      op_.invinertia.matrixL().solveInPlace(angularAcceleration);
-      op_.invinertia.matrixL().transpose().solveInPlace(angularAcceleration);
-
-      //angularAcceleration = ( op_.RIRT + robotMass_*kine::skewSymmetric2(op_.Rc)).llt().solve(
-      //                        (op_.vt - robotMass_*kine::skewSymmetric(op_.Rcp)*op_.vf));
-
-      linearAcceleration = op_.vf;
-      linearAcceleration += kine::skewSymmetric(op_.Rc)*angularAcceleration;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::iterateDynamicsEuler
-    (const Vector3& positionCom, const Vector3& velocityCom,
-     const Vector3& accelerationCom, const Vector3& AngMomentum,
-     const Vector3& dotAngMomentum,
-     const Matrix3& inertia, const Matrix3& dotInertia,
-     const IndexedVectorArray& contactPos,
-     const IndexedVectorArray& contactOri,
-     Vector3& position, Vector3& linVelocity, Vector& fc,
-     Vector3 &oriVector, Vector3& angularVel, Vector& tc,
-     const Vector3 & fm, const Vector3& tm, const Vector3 &addiForces,
-     const Vector3 & addiMoments,
-     double dt)
-    {
-
-      op_.rFlex = computeRotation_(oriVector,0);
-      //compute new acceleration with the current flex position and velocity and input
-
-//        computeForcesAndMoments (contactPos, contactOri, op_.contactVelArray, op_.contactAngVelArray,
-//                          position, linVelocity, oriVector, op_.rFlex,
-//                             angularVel, fc, tc);
-
-      computeAccelerations (positionCom, velocityCom,
-                            accelerationCom, AngMomentum, dotAngMomentum,
-                            inertia, dotInertia,  contactPos, contactOri, position, linVelocity, op_.linearAcceleration,
-                            oriVector, op_.rFlex, angularVel, op_.angularAcceleration,
-                            fc, tc, fm,tm, addiForces, addiMoments);
-
-      ///integrate kinematics with the last acceleration
-      kine::integrateKinematics(position, linVelocity, op_.linearAcceleration,
-                          op_.rFlex,angularVel, op_.angularAcceleration, dt);
-
-
-      ///Adding a kinematic coupling to improve estimation of the velocities
-//        Vector3 constrainedLinVel;
-//        constrainedLinVel.setZero();
-//
-//        for(int i=0; i<getContactsNumber();++i)
-//        {
-//          constrainedLinVel += Vector3(op_.rFlex*contactPos[i]).cross(angularVel);
-//        }
-//        constrainedLinVel=constrainedLinVel/getContactsNumber();
-//
-//        double alphaLin=0.1; ///kinematic coupling weight
-//        linVelocity=alphaLin*linVelocity + (1-alphaLin) * constrainedLinVel;
-//        ///
-//
-//        Vector3 constrainedAngVel=angularVel;
-//        if (getContactsNumber()==2)
-//        {
-//
-//            Vector3 interlegAxis = contactPos[1]-contactPos[0];
-//            constrainedAngVel -= (angularVel.dot(interlegAxis) * interlegAxis)/interlegAxis.squaredNorm();
-//        }
-//        else if (getContactsNumber()>2)
-//        {
-//            constrainedAngVel.setZero();
-//        }
-//        double alphaAng = 0.1;
-//        angularVel = alphaAng*angularVel + (1-alphaAng)*constrainedAngVel;
-
-
-
-
-
-      op_.orientationAA=op_.rFlex;
-      oriVector.noalias()=op_.orientationAA.angle()*op_.orientationAA.axis();
-
-      computeForcesAndMoments (contactPos, contactOri, op_.contactVelArray, op_.contactAngVelArray,
-                               position, linVelocity, oriVector, op_.rFlex,
-                               angularVel, fc, tc);
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::iterateDynamicsRK4
-             (const Vector3& positionCom, const Vector3& velocityCom,
-              const Vector3& accelerationCom, const Vector3& AngMomentum,
-              const Vector3& dotAngMomentum,
-              const Matrix3& inertia, const Matrix3& dotInertia,
-              const IndexedVectorArray& contactPos,
-              const IndexedVectorArray& contactOri,
-              Vector3& position, Vector3& linVelocity, Vector& fc,
-              Vector3 &oriVector, Vector3& angularVel, Vector& tc,
-              const Vector3 & fm, const Vector3& tm,
-              const Vector3 & addForces, const Vector3& addMoments,
-              double dt)
-    {
-
-      Matrix3 orientationFlex(computeRotation_(oriVector,0));
-
-      Vector3 linAcc1;
-      Vector3 angAcc1;
-
-
-      Vector3 pos2;
-      Vector3 oriv2;
-      AngleAxis oriaa2;
-      Matrix3 ori2;
-
-      Vector3 linVelocity2;
-      Vector3 angVelocity2;
-
-      Vector3 linAcc2;
-      Vector3 angAcc2;
-
-
-      Vector3 pos3;
-      Vector3 oriv3;
-      AngleAxis oriaa3;
-      Matrix3 ori3;
-
-      Vector3 linVelocity3;
-      Vector3 angVelocity3;
-
-      Vector3 linAcc3;
-      Vector3 angAcc3;
-
-
-      Vector3 pos4;
-      Vector3 oriv4;
-      AngleAxis oriaa4;
-      Matrix3 ori4;
-
-      Vector3 linVelocity4;
-      Vector3 angVelocity4;
-
-      Vector3 linAcc4;
-      Vector3 angAcc4;
-
-        //////////1st/////////////
-        computeAccelerations (positionCom, velocityCom,
-                        accelerationCom, AngMomentum, dotAngMomentum,
-                        inertia, dotInertia,  contactPos, contactOri,
-                        position, linVelocity, linAcc1, oriVector,
-                        orientationFlex, angularVel, angAcc1,
-                        fc, tc, fm, tm, addForces, addMoments);
-
-
-      //////////2nd//////////////
-      pos2 = position;
-      ori2 = orientationFlex;
-
-      kine::integrateKinematics(pos2, linVelocity, ori2, angularVel, dt/2);
-
-      oriaa2.fromRotationMatrix(ori2);
-      oriv2 = oriaa2.angle()*oriaa2.axis();
-
-      linVelocity2 = linVelocity + (dt/2)*linAcc1;
-      angVelocity2 = angularVel + (dt/2)*angAcc1;
-
-
-      computeAccelerations (positionCom, velocityCom,
-                            accelerationCom, AngMomentum, dotAngMomentum,
-                            inertia, dotInertia,  contactPos, contactOri,
-                            pos2, linVelocity2, linAcc2, oriv2,
-                            ori2, angVelocity2, angAcc2,
-                            fc, tc, fm, tm, addForces, addMoments);
-
-      ////////////3rd/////////////
-
-      pos3 = position;
-      ori3 = orientationFlex;
-
-      kine::integrateKinematics( pos3, linVelocity2, ori3, angVelocity2, dt/2);
-
-      oriaa3.fromRotationMatrix(ori3);
-      oriv3 = oriaa3.angle()*oriaa3.axis();
-
-      linVelocity3 = linVelocity + (dt/2)*linAcc2;
-      angVelocity3 = angularVel + (dt/2)*angAcc2;
-
-      computeAccelerations (positionCom, velocityCom,
-                            accelerationCom, AngMomentum, dotAngMomentum,
-                            inertia, dotInertia,  contactPos, contactOri,
-                            pos3, linVelocity3, linAcc3, oriv3,
-                            ori3, angVelocity3, angAcc3,
-                            tc, fc, fm, tm,
-                            addForces, addMoments);
-
-
-      ////////////4th/////////////
-      pos4 = position;
-      ori4 = orientationFlex;
-
-      kine::integrateKinematics( pos4, linVelocity3, ori4, angVelocity3, dt);
-
-      oriaa4.fromRotationMatrix(ori4);
-      oriv4 = oriaa4.angle()*oriaa4.axis();
-
-      linVelocity4 = linVelocity + (dt)*linAcc3;
-      angVelocity4 = angularVel + (dt)*angAcc3;
-
-      computeAccelerations (positionCom, velocityCom,
-                            accelerationCom, AngMomentum, dotAngMomentum,
-                            inertia, dotInertia,  contactPos, contactOri,
-                            pos4, linVelocity4, linAcc4, oriv4,
-                            ori4, angVelocity4, angAcc4,
-                            fc, tc, fm, tm,
-                            addForces, addMoments);
-
-      /////////////////////////////
-
-      kine::integrateKinematics( position, linVelocity, orientationFlex, angularVel, dt/6);
-      kine::integrateKinematics( position, linVelocity2, orientationFlex, angVelocity2, dt/3);
-      kine::integrateKinematics( position, linVelocity3, orientationFlex, angVelocity3, dt/3);
-      kine::integrateKinematics( position, linVelocity4, orientationFlex, angVelocity4, dt/6);
-
-      linVelocity+= (dt/6)*(linAcc1+2*linAcc2+2*linAcc3+linAcc4);
-      angularVel+= (dt/6)*(angAcc1+2*angAcc2+2*angAcc3+angAcc4);
-
-      AngleAxis orientationAA(orientationFlex);
-      oriVector=orientationAA.angle()*orientationAA.axis();
-
-      // Getting forces
-      op_.rFlex = computeRotation_(oriVector,0);
-      computeForcesAndMoments (contactPos, contactOri, op_.contactVelArray, op_.contactAngVelArray,
-                               position, linVelocity, oriVector, op_.rFlex,
-                               angularVel, fc, tc);
-    }
-
-    Vector IMUElasticLocalFrameDynamicalSystem::stateDynamics
-    (const Vector& x, const Vector& u, TimeIndex)
-    {
-
-      assertStateVector_(x);
-      assertInputVector_(u);
-
-      xk_=x;
-      uk_=u;
-
-      op_.positionFlex=x.segment(state::pos,3);
-      op_.orientationFlexV=x.segment(state::ori,3);
-      op_.velocityFlex=x.segment(state::linVel,3);
-      op_.angularVelocityFlex=x.segment(state::angVel,3);
-
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-        op_.efforts.setValue(x.segment(state::fc+6*i,6),i);
-
-      op_.positionComBias <<  x.segment(state::comBias,2),
-                          0;// the bias of the com along the z axis is assumed 0.
-      op_.fm=x.segment(state::unmodeledForces,3);
-      op_.tm=x.segment(state::unmodeledForces+3,3);
-
-      buildInertiaTensor(u.segment<6>(input::inertia),op_.inertia);
-      buildInertiaTensor(u.segment<6>(input::dotInertia),op_.dotInertia);
-
-      unsigned nbContacts(getContactsNumber());
-
-      for (unsigned i = 0; i<nbContacts ; ++i)
-      {
-        // Positions
-        op_.contactPosV.setValue(u.segment<3>(input::contacts + 12*i),i);
-        op_.contactOriV.setValue(u.segment<3>(input::contacts +12*i+3),i);
-
-        // Velocities
-        op_.contactVelArray.setValue(u.segment<3>(input::contacts + 12*i +6),i);
-        op_.contactAngVelArray.setValue(u.segment<3>(input::contacts +12*i +9),i);
-
-      }
-
-      op_.positionCom=u.segment<3>(input::posCom);
-      if(withComBias_) op_.positionCom-=op_.positionComBias;
-      op_.velocityCom=u.segment<3>(input::velCom);
-      op_.accelerationCom=u.segment<3>(input::accCom);
-      op_.AngMomentum=u.segment<3>(input::angMoment);
-      op_.dotAngMomentum=u.segment<3>(input::dotAngMoment);
-
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-      {
-        fc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(0,0);
-        tc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(3,0);
-      }
-
-      op_.addForce = u.segment<3>(input::additionalForces);
-      op_.addMoment = u.segment<3>(input::additionalForces+3);
-
-      const int subsample=1;
-      for (int i=0; i<subsample; ++i)
-      {
-        iterateDynamicsEuler (
-          op_.positionCom, op_.velocityCom,
-          op_.accelerationCom, op_.AngMomentum, op_.dotAngMomentum,
-          op_.inertia, op_.dotInertia,  op_.contactPosV, op_.contactOriV,
-          op_.positionFlex, op_.velocityFlex, fc_,
-          op_.orientationFlexV, op_.angularVelocityFlex,
-          tc_, op_.fm, op_.tm,op_.addForce,op_.addMoment,
-          dt_/subsample);
-      }
-      //x_{k+1}
-
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-      {
-        //std::cout << "Contact " << i << std::endl
-        //          << fc_.segment<3>(3*i).transpose() << std::endl
-        //          << tc_.segment<3>(3*i).transpose()<< std::endl;
-        op_.efforts[i].block<3,1>(0,0) = fc_.segment<3>(3*i);
-        op_.efforts[i].block<3,1>(3,0) = tc_.segment<3>(3*i);
-      }
-
-      xk1_=x;
-
-      xk1_.segment<3>(state::pos) = op_.positionFlex;
-      xk1_.segment<3>(state::ori) =  op_.orientationFlexV;
-
-      xk1_.segment<3>(state::linVel) = op_.velocityFlex;
-      xk1_.segment<3>(state::angVel) = op_.angularVelocityFlex;
-
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-        xk1_.segment(state::fc+6*i,6) = op_.efforts[i].col(0);
-
-      // xk1_.segment<2>(state::comBias) = op_.positionComBias.head<2>();
-
-      if (withUnmodeledForces_)
-      {
-        xk1_.segment<3>(state::unmodeledForces) =
-          marginalStabilityFactor_*op_.fm;
-        xk1_.segment<3>(state::unmodeledForces+3) =
-          marginalStabilityFactor_*op_.tm;
-      }
-      else
-      {
-        xk1_.segment<6>(state::unmodeledForces).setZero();
-      }
-
-      if (processNoise_!=0x0)
-        return processNoise_->getNoisy(op_.xk1);
-      else
-        return xk1_;
-    }
-
-
-    inline Matrix3& IMUElasticLocalFrameDynamicalSystem::computeRotation_
-    (const Vector3 & x, int i)
-    {
-      Vector3 & oriV = op_.orientationVector(i);
-      Matrix3 & oriR = op_.curRotation(i);
-      if (oriV!=x)
-      {
-        oriV = x;
-        oriR = kine::rotationVectorToAngleAxis(x).toRotationMatrix();
-      }
-
-      return oriR;
-    }
-
-    Vector IMUElasticLocalFrameDynamicalSystem::measureDynamics
-    (const Vector& x, const Vector& u, TimeIndex k)
-    {
-      assertStateVector_(x);
-      assertInputVector_(u);
-
-      xk_fory_=x;
-      uk_fory_=u;
-      op_.k_fory=k;
-
-      op_.positionFlex=x.segment(state::pos,3);
-      op_.velocityFlex=x.segment(state::linVel,3);
-      op_.orientationFlexV=x.segment(state::ori,3);
-      op_.angularVelocityFlex=x.segment(state::angVel,3);
-
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-        op_.efforts[i]=x.segment(state::fc+6*i,6);
-
-      op_.fm=x.segment(state::unmodeledForces,3);
-      op_.tm=x.segment(state::unmodeledForces+3,3);
-      op_.drift=x.segment<3>(state::drift);
-
-      op_.rFlex =computeRotation_(op_.orientationFlexV,0);
-
-      buildInertiaTensor(u.segment<6>(input::inertia),op_.inertia);
-      buildInertiaTensor(u.segment<6>(input::dotInertia),op_.dotInertia);
-      unsigned nbContacts(getContactsNumber());
-      for (unsigned i = 0; i<nbContacts ; ++i)
-      {
-        // Positions
-        op_.contactPosV.setValue(u.segment<3>(input::contacts + 12*i),i);
-        op_.contactOriV.setValue(u.segment<3>(input::contacts +12*i+3),i);
-      }
-      op_.positionCom=u.segment<3>(input::posCom);
-
-      if(withComBias_)
-      {
-        op_.positionComBias <<  x.segment(state::comBias,2),
-                              0;// the bias of the com along the z axis is assumed 0.
-        op_.positionCom-=op_.positionComBias;
-      }
-
-      op_.velocityCom=u.segment<3>(input::velCom);
-      op_.accelerationCom=u.segment<3>(input::accCom);
-      op_.AngMomentum=u.segment<3>(input::angMoment);
-      op_.dotAngMomentum=u.segment<3>(input::dotAngMoment);
-
-      op_.positionControl=u.segment(input::posIMU,3);
-      op_.velocityControl=u.segment(input::linVelIMU,3);
-      op_.accelerationControl=u.segment(input::linAccIMU,3);
-      op_.orientationControlV=u.segment(input::oriIMU,3);
-      op_.angularVelocityControl=u.segment(input::angVelIMU,3);
-
-      op_.rControl=computeRotation_(op_.orientationControlV,1);
-
-      op_.rimu = op_.rFlex * op_.rControl;
-
-      for (unsigned i=0; i<hrp2::contact::nbModeledMax; ++i)
-      {
-        fc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(0,0);
-        tc_.segment<3>(3*i) = op_.efforts[i].block<3,1>(3,0);
-      }
-
-      op_.addForce = u.segment<3>(input::additionalForces);
-      op_.addMoment = u.segment<3>(input::additionalForces+3);
-
-      // Get acceleration
-      computeAccelerations (op_.positionCom, op_.velocityCom,
-                            op_.accelerationCom, op_.AngMomentum, op_.dotAngMomentum,
-                            op_.inertia, op_.dotInertia,  op_.contactPosV, op_.contactOriV,
-                            op_.positionFlex, op_.velocityFlex, op_.linearAcceleration,
-                            op_.orientationFlexV, op_.rFlex, op_.angularVelocityFlex,
-                            op_.angularAcceleration, fc_, tc_, op_.fm,op_.tm,
-                            op_.addForce,op_.addMoment);
-
-      // Translation sensor dynamic
-      op_.imuAcc = 2*kine::skewSymmetric(op_.angularVelocityFlex) * op_.rFlex * op_.velocityControl;
-      op_.imuAcc += op_.linearAcceleration + op_.rFlex * op_.accelerationControl;
-      op_.imuAcc += (
-                      kine::skewSymmetric(op_.angularAcceleration)
-                      + tools::square(kine::skewSymmetric(op_.angularVelocityFlex))
-                    )*op_.rFlex * op_.positionControl;
-
-      // Rotation sensor dynamic
-      op_.imuOmega = op_.angularVelocityFlex + op_.rFlex * op_.angularVelocityControl;
-
-      // Set sensor state before measurement
-
-      op_.sensorState.resize(sensor_.getStateSize());
-      op_.sensorState.head<9>() = Eigen::Map<Eigen::Matrix<double, 9, 1> >(&op_.rimu(0,0));
-      op_.sensorState.segment<3>(9)=op_.imuAcc;
-      op_.sensorState.segment<3>(12)=op_.imuOmega;
-
-      index_=15;
-
-      if (withForceMeasurements_)
-      {
-        for (unsigned int i=0; i<nbContacts_; ++i)
-        {
-          op_.sensorState.segment(index_,6) = x.segment(state::fc+i*6,6);
-          // the last part of the measurement is force torque, it is
-          // computes by the current functor and not the sensor_.
-          // (see AlgebraicSensor::concatenateWithInput
-          // for more details
-          index_+=6;
-        }
-      }
-
-      if (withAbsolutePos_)
-      {
-        op_.cy=cos(op_.drift(2));
-        op_.sy=sin(op_.drift(2));
-        op_.rdrift<< op_.cy, -op_.sy, 0,
-                   op_.sy,  op_.cy, 0,
-                   0,       0,      1;
-        op_.rtotal.noalias() = op_.rdrift*op_.rFlex;
-
-        op_.ptotal << op_.drift(0),op_.drift(1),0;
-        op_.ptotal.noalias() += op_.rdrift*op_.positionFlex;
-
-        op_.aatotal = op_.rtotal;
-        op_.oritotal.noalias() = op_.aatotal.angle()*op_.aatotal.axis();
-
-        op_.sensorState.segment<3>(index_) = op_.ptotal;
-        op_.sensorState.segment<3>(index_+3) = op_.oritotal;
-      }
-
-      sensor_.setState(op_.sensorState,k);
-
-      //measurements
-      yk_=sensor_.getMeasurements();
-
-      return yk_;
-    }
-
-    stateObservation::Matrix IMUElasticLocalFrameDynamicalSystem::measureDynamicsJacobian()
-    {
-      op_.Jy.resize(getMeasurementSize(),getStateSize());
-      op_.Jy.setZero();
-
-      op_.xdx = xk_fory_;
-      op_.xk_fory = xk_fory_;
-      op_.yk = yk_;
-
-      Index sizeAfterComBias=getStateSize()-state::comBias-2;
-
-      for (Index i=0; i<state::unmodeledForces; ++i)
-      {
-        op_.xdx[i]+= dx_[i];
-
-        op_.ykdy=measureDynamics(op_.xdx,uk_fory_, op_.k_fory);
-        op_.ykdy-=op_.yk;
-        op_.ykdy/=dx_[i];
-
-        op_.Jy.col(i)=op_.ykdy;
-        op_.xdx[i]=op_.xk_fory[i];
-      }
-
-      if(!withUnmodeledForces_)
-      {
-        op_.Jy.block(0,state::unmodeledForces,getMeasurementSize(),6).setZero();
-      }
-      else
-      {
-        for (Index i=state::unmodeledForces; i<state::unmodeledForces+6; ++i)
-        {
-          op_.xdx[i]+= dx_[i];
-
-          op_.ykdy=measureDynamics(op_.xdx,uk_fory_, op_.k_fory);
-          op_.ykdy-=op_.yk;
-          op_.ykdy/=dx_[i];
-
-          op_.Jy.col(i)=op_.ykdy;
-          op_.xdx[i]=op_.xk_fory[i];
-        }
-      }
-
-      if(!withComBias_)
-      {
-        op_.Jy.block(0,state::comBias,getMeasurementSize(),2).setZero();
-      }
-      else
-      {
-        for (Index i=state::comBias; i<state::comBias+2; ++i)
-        {
-          op_.xdx[i]+= dx_[i];
-
-          op_.ykdy=measureDynamics(op_.xdx,uk_fory_, op_.k_fory);
-          op_.ykdy-=op_.yk;
-          op_.ykdy/=dx_[i];
-
-          op_.Jy.col(i)=op_.ykdy;
-          op_.xdx[i]=op_.xk_fory[i];
-        }
-      }
-
-      if (!withAbsolutePos_)
-      {
-        op_.Jy.block(0,state::drift,getMeasurementSize(),3).setZero();
-      }
-      else
-      {
-        for (Index i=state::comBias+2; i<state::comBias+2+sizeAfterComBias; ++i)
-        {
-          op_.xdx[i]+= dx_[i];
-
-          op_.ykdy=measureDynamics(op_.xdx,uk_fory_, op_.k_fory);
-          op_.ykdy-=op_.yk;
-          op_.ykdy/=dx_[i];
-
-          op_.Jy.col(i)=op_.ykdy;
-          op_.xdx[i]=op_.xk_fory[i];
-        }
-      }
-
-      //std::cout << "JACOBIAN: "<<std::endl;
-      //std::cout << op_.Jy<<std::endl;
-
-      xk_fory_ = op_.xk_fory; //last thing to do before returning to make the prediction correct
-
-      yk_ = op_.yk;
-
-      return op_.Jy;
-    }
-
-    stateObservation::Matrix IMUElasticLocalFrameDynamicalSystem::stateDynamicsJacobian()
-    {
-      op_.Jx.resize(getStateSize(),getStateSize());
-      op_.Jx.setZero();
-
-      op_.xdx = xk_;
-      op_.xk = xk_;
-      op_.xk1 = xk1_;
-
-      Index sizeAfterComBias=getStateSize()-state::comBias-2;
-      Index sizeAfterUnmodeledForces=getStateSize()-state::unmodeledForces-6;
-
-      for (Index i=0; i<state::unmodeledForces; ++i)
-      {
-        op_.xdx[i]+= dx_[i];
-
-        op_.xk1dx=stateDynamics(op_.xdx,uk_, 0);
-        op_.xk1dx-=op_.xk1;
-        op_.xk1dx/=dx_[i];
-
-        op_.Jx.col(i)=op_.xk1dx;
-        op_.xdx[i]=op_.xk[i];
-      }
-
-      if(!withUnmodeledForces_)
-      {
-        op_.Jx.block(state::unmodeledForces,state::unmodeledForces,6,6).setIdentity();
-        op_.Jx.block(0,state::unmodeledForces,state::unmodeledForces,6).setZero();
-        op_.Jx.block(state::unmodeledForces+6,state::unmodeledForces,sizeAfterUnmodeledForces,6).setZero();
-      }
-      else
-      {
-        for (Index i=state::unmodeledForces; i<state::unmodeledForces+6; ++i)
-        {
-          op_.xdx[i]+= dx_[i];
-
-          op_.xk1dx=stateDynamics(op_.xdx,uk_, 0);
-          op_.xk1dx-=op_.xk1;
-          op_.xk1dx/=dx_[i];
-
-          op_.Jx.col(i)=op_.xk1dx;
-          op_.xdx[i]=op_.xk[i];
-        }
-      }
-
-      if(!withComBias_)
-      {
-        op_.Jx.block(state::comBias,state::comBias,2,2).setIdentity();
-        op_.Jx.block(0,state::comBias,state::comBias,2).setZero();
-        op_.Jx.block(state::comBias+2,state::comBias,sizeAfterComBias,2).setZero();
-      }
-      else
-      {
-        for (Index i=state::comBias; i<state::comBias+2; ++i)
-        {
-          op_.xdx[i]+= dx_[i];
-
-          op_.xk1dx=stateDynamics(op_.xdx,uk_, 0);
-          op_.xk1dx-=op_.xk1;
-          op_.xk1dx/=dx_[i];
-
-          op_.Jx.col(i)=op_.xk1dx;
-          op_.xdx[i]=op_.xk[i];
-        }
-      }
-
-      if (!withAbsolutePos_)
-      {
-        op_.Jx.block(0,state::drift,getStateSize(),3).setZero();
-        op_.Jx.block(state::drift,state::drift,3,3).setIdentity();
-      }
-      else
-      {
-        for (Index i=state::drift; i<state::drift+3; ++i)
-        {
-          op_.xdx[i]+= dx_[i];
-
-          op_.xk1dx=stateDynamics(op_.xdx,uk_, 0);
-          op_.xk1dx-=op_.xk1;
-          op_.xk1dx/=dx_[i];
-
-          op_.Jx.col(i)=op_.xk1dx;
-          op_.xdx[i]=op_.xk[i];
-        }
-      }
-
-      //std::cout << "JACOBIAN: "<<std::endl;
-      //std::cout << op_.Jx <<std::endl;
-
-      xk_= op_.xk; //last thing to do before returning
-      xk1_ = op_.xk1;
-
-      return op_.Jx;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setProcessNoise(NoiseBase * n)
-    {
-      processNoise_=n;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::resetProcessNoise()
-    {
-      processNoise_=0x0;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setMeasurementNoise
-    ( NoiseBase * n)
-    {
-      sensor_.setNoise(n);
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::resetMeasurementNoise()
-    {
-      sensor_.resetNoise();
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setSamplingPeriod(double dt)
-    {
-      dt_=dt;
-    }
-
-    Index IMUElasticLocalFrameDynamicalSystem::getStateSize() const
-    {
-      return stateSize_;
-    }
-
-    Index IMUElasticLocalFrameDynamicalSystem::getInputSize() const
-    {
-      return inputSize_;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setInputSize(Index i)
-    {
-      inputSize_=i;
-    }
-
-    Index IMUElasticLocalFrameDynamicalSystem::getMeasurementSize() const
-    {
-      return measurementSize_;
-    }
-
-    NoiseBase * IMUElasticLocalFrameDynamicalSystem::getProcessNoise() const
-    {
-      return processNoise_;
-    }
-
-    NoiseBase * IMUElasticLocalFrameDynamicalSystem::
-    getMeasurementNoise() const
-    {
-      return sensor_.getNoise();
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setContactsNumber(unsigned i)
-    {
-      nbContacts_=i;
-      inputSize_ =input::sizeBase +12*i;
-
-      updateMeasurementSize_();
-
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::updateMeasurementSize_()
-    {
-      measurementSize_=measurementSizeBase_;
-
-      if (withForceMeasurements_)
-      {
-        measurementSize_+=nbContacts_*6;
-      }
-
-      if (withAbsolutePos_)
-      {
-        measurementSize_+=6;
-      }
-
-      sensor_.concatenateWithInput(measurementSize_-measurementSizeBase_);
-
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setWithForceMeasurements(bool b)
-    {
-      withForceMeasurements_=b;
-      updateMeasurementSize_();
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setWithComBias(bool b)
-    {
-      withComBias_=b;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setWithAbsolutePosition(bool b)
-    {
-      withAbsolutePos_=b;
-      updateMeasurementSize_();
-
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setWithUnmodeledForces(bool b)
-    {
-      withUnmodeledForces_=b;
-    }
-
-    bool IMUElasticLocalFrameDynamicalSystem::getWithForceMeasurements() const
-    {
-      return withForceMeasurements_;
-    }
-
-    bool IMUElasticLocalFrameDynamicalSystem::getWithComBias() const
-    {
-      return withComBias_;
-    }
-
-    bool IMUElasticLocalFrameDynamicalSystem::getWithAbsolutePosition() const
-    {
-      return withAbsolutePos_;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setKfe(const Matrix3 & m)
-    {
-      Kfe_=m;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setKfv(const Matrix3 & m)
-    {
-      Kfv_=m;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setKte(const Matrix3 & m)
-    {
-      Kte_=m;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setKtv(const Matrix3 & m)
-    {
-      Ktv_=m;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setKfeRopes(const Matrix3 & m)
-    {
-      KfeRopes_=m;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setKfvRopes(const Matrix3 & m)
-    {
-      KfvRopes_=m;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setKteRopes(const Matrix3 & m)
-    {
-      KteRopes_=m;
-    }
-
-    void IMUElasticLocalFrameDynamicalSystem::setKtvRopes(const Matrix3 & m)
-    {
-      KtvRopes_=m;
-    }
-
-    Matrix IMUElasticLocalFrameDynamicalSystem::getKfe() const
-    {
-      return Kfe_;
-    }
-
-    Matrix IMUElasticLocalFrameDynamicalSystem::getKfv() const
-    {
-      return Kfv_;
-    }
-
-    Matrix IMUElasticLocalFrameDynamicalSystem::getKte() const
-    {
-      return Kte_;
-    }
-
-    Matrix IMUElasticLocalFrameDynamicalSystem::getKtv() const
-    {
-      return Ktv_;
-    }
-
-    void  IMUElasticLocalFrameDynamicalSystem::setFDstep(const stateObservation::Vector & dx)
-    {
-      dx_ = dx;
-    }
+    // Positions
+    op_.contactPosV.setValue(u.segment<3>(input::contacts + 12 * i), i);
+    op_.contactOriV.setValue(u.segment<3>(input::contacts + 12 * i + 3), i);
+  }
+
+  op_.addForce = u.segment<3>(input::additionalForces);
+  op_.addMoment = u.segment<3>(input::additionalForces + 3);
+
+  computeContactWrench(op_.rFlex, op_.positionFlex, op_.contactPosV, op_.contactOriV, fc_, tc_, op_.fm, op_.tm,
+                       op_.addForce, op_.addMoment);
+
+  op_.momentaDot.segment<3>(0) = op_.f - hrp2::m * cst::gravity;
+  op_.momentaDot.segment<3>(3) =
+      op_.t - kine::skewSymmetric(op_.rFlex * op_.positionCom + op_.positionFlex) * hrp2::m * cst::gravity;
+
+  return op_.momentaDot;
+}
+
+Vector IMUElasticLocalFrameDynamicalSystem::getMomentaDotFromKinematics(const Vector & x, const Vector & u)
+{
+  assertStateVector_(x);
+  assertInputVector_(u);
+
+  op_.positionFlex = x.segment(state::pos, 3);
+  op_.orientationFlexV = x.segment(state::ori, 3);
+  op_.rFlex = computeRotation_(op_.orientationFlexV, 0);
+  op_.rFlexT = computeRotation_(op_.orientationFlexV, 0).transpose();
+  op_.velocityFlex = x.segment(state::linVel, 3);
+  op_.angularVelocityFlex = x.segment(state::angVel, 3);
+
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i)
+  {
+    op_.efforts.setValue(x.segment(state::fc + 6 * i, 6), i);
+    fc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(0, 0);
+    tc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(3, 0);
+  }
+  op_.fm = x.segment(state::unmodeledForces, 3);
+  op_.tm = x.segment(state::unmodeledForces + 3, 3);
+
+  op_.positionCom = u.segment<3>(input::posCom);
+  op_.velocityCom = u.segment<3>(input::velCom);
+  op_.accelerationCom = u.segment<3>(input::accCom);
+  if(withComBias_)
+  {
+    op_.positionComBias << x.segment(state::comBias, 2),
+        0; // the bias of the com along the z axis is assumed 0.
+    op_.positionCom -= op_.positionComBias;
+  }
+
+  buildInertiaTensor(u.segment<6>(input::inertia), op_.inertia);
+  buildInertiaTensor(u.segment<6>(input::dotInertia), op_.dotInertia);
+  op_.AngMomentum = u.segment<3>(input::angMoment);
+  op_.dotAngMomentum = u.segment<3>(input::dotAngMoment);
+
+  unsigned nbContacts(getContactsNumber());
+
+  for(unsigned i = 0; i < nbContacts; ++i)
+  {
+    // Positions
+    op_.contactPosV.setValue(u.segment<3>(input::contacts + 12 * i), i);
+    op_.contactOriV.setValue(u.segment<3>(input::contacts + 12 * i + 3), i);
+
+    // Velocities
+    op_.contactVelArray.setValue(u.segment<3>(input::contacts + 12 * i + 6), i);
+    op_.contactAngVelArray.setValue(u.segment<3>(input::contacts + 12 * i + 9), i);
+  }
+
+  op_.addForce = u.segment<3>(input::additionalForces);
+  op_.addMoment = u.segment<3>(input::additionalForces + 3);
+
+  computeAccelerations(op_.positionCom, op_.velocityCom, op_.accelerationCom, op_.AngMomentum, op_.dotAngMomentum,
+                       op_.inertia, op_.dotInertia, op_.contactPosV, op_.contactOriV, op_.positionFlex,
+                       op_.velocityFlex, op_.linearAcceleration, op_.orientationFlexV, op_.rFlex, op_.velocityFlex,
+                       op_.angularAcceleration, fc_, tc_, op_.fm, op_.tm, op_.addForce, op_.addMoment);
+
+  op_.momentaDot.segment<3>(0) = hrp2::m
+                                 * (kine::skewSymmetric(op_.angularAcceleration) * op_.rFlex * op_.positionCom
+                                    + kine::skewSymmetric2(op_.angularVelocityFlex) * op_.rFlex * op_.positionCom
+                                    + 2 * kine::skewSymmetric(op_.angularVelocityFlex) * op_.rFlex * op_.velocityCom
+                                    + op_.rFlex * op_.accelerationCom + op_.linearAcceleration);
+  op_.momentaDot.segment<3>(3) =
+      kine::skewSymmetric(op_.angularVelocityFlex) * op_.rFlex * op_.inertia * op_.rFlexT * op_.angularVelocityFlex
+      + op_.rFlex * op_.dotInertia * op_.rFlexT * op_.angularVelocityFlex
+      + op_.rFlex * op_.inertia * op_.rFlexT * op_.angularAcceleration
+      + kine::skewSymmetric(op_.angularVelocityFlex) * op_.rFlex * op_.AngMomentum + op_.rFlex * op_.dotAngMomentum
+      + kine::skewSymmetric(op_.positionFlex) * op_.momentaDot.segment<3>(0)
+      + hrp2::m * kine::skewSymmetric(op_.rFlex * op_.positionCom) * op_.linearAcceleration;
+
+  return op_.momentaDot;
+}
+
+Vector IMUElasticLocalFrameDynamicalSystem::getForcesAndMoments()
+{
+  unsigned nbContacts(getContactsNumber());
+  Vector x(6 * nbContacts);
+  x.setZero();
+
+  for(unsigned int i = 0; i < nbContacts; ++i)
+  {
+    x.segment<3>(6 * i) = fc_.segment<3>(3 * i);
+    x.segment<3>(6 * i + 3) = tc_.segment<3>(3 * i);
+  }
+
+  return x;
+}
+
+Vector IMUElasticLocalFrameDynamicalSystem::getForcesAndMoments(const Vector & x, const Vector & u)
+{
+  computeForcesAndMoments(x, u);
+  return getForcesAndMoments();
+}
+
+void IMUElasticLocalFrameDynamicalSystem::computeElastContactForcesAndMoments(
+    const IndexedVectorArray & contactPosArray,
+    const IndexedVectorArray & contactOriArray,
+    const IndexedVectorArray & contactVelArray,
+    const IndexedVectorArray & contactAngVelArray,
+    const Vector3 & position,
+    const Vector3 & linVelocity,
+    const Vector3 & oriVector,
+    const Matrix3 & orientation,
+    const Vector3 & angVel,
+    Vector & fc,
+    Vector & tc)
+{
+
+  (void)contactAngVelArray; // avoid warnings
+  unsigned nbContacts(getContactsNumber());
+  fc.setZero();
+  tc.setZero();
+
+  op_.Rt = orientation.transpose();
+
+  for(unsigned i = 0; i < nbContacts; ++i)
+  {
+    op_.contactPos = contactPosArray[i];
+    op_.contactVel = contactVelArray[i];
+
+    op_.Rci = computeRotation_(contactOriArray[i], i + 2);
+    op_.Rcit.noalias() = op_.Rci.transpose();
+
+    op_.RciContactPos.noalias() = orientation * op_.contactPos;
+
+    op_.globalContactPos = position;
+    op_.globalContactPos.noalias() += op_.RciContactPos;
+
+    op_.forcei.noalias() = -Kfe_ * op_.Rcit * op_.Rt * (op_.globalContactPos - op_.contactPos);
+
+    op_.forcei.noalias() +=
+        -Kfv_ * op_.Rcit * op_.Rt
+        * (kine::skewSymmetric(angVel) * op_.RciContactPos + linVelocity + orientation * op_.contactVel);
+
+    // std::cout << "RciContactPos " << op_.RciContactPos.transpose() <<std::endl;
+    // std::cout << "linVelocity " << linVelocity.transpose() <<std::endl;
+    // std::cout << "kine::skewSymmetric(angVel)*op_.RciContactPos +linVelocity + orientation*op_.contactVel " <<
+    // (kine::skewSymmetric(angVel)*op_.RciContactPos
+    //                          +linVelocity + orientation*op_.contactVel).transpose() <<std::endl;
+
+    // std::cout << "forcei " << op_.forcei.transpose() <<std::endl;
+
+    fc.segment<3>(3 * i) = op_.forcei;
+
+    op_.momenti.noalias() = -Kte_ * op_.Rcit * op_.Rt * oriVector;
+    op_.momenti.noalias() += -Ktv_ * op_.Rcit * op_.Rt * angVel;
+
+    tc.segment<3>(3 * i) = op_.momenti;
   }
 }
+
+void IMUElasticLocalFrameDynamicalSystem::computeElastPendulumForcesAndMoments(const IndexedVectorArray & PrArray,
+                                                                               const Vector3 & position,
+                                                                               const Vector3 & linVelocity,
+                                                                               const Vector3 & oriVector,
+                                                                               const Matrix3 & orientation,
+                                                                               const Vector3 & angVel,
+                                                                               Vector & forces,
+                                                                               Vector & moments)
+{
+  unsigned nbContacts(getContactsNumber());
+  forces.setZero();
+  moments.setZero();
+
+  Vector3 forcei;
+  Vector3 momenti;
+  Vector3 globalContactPos;
+
+  Vector3 contactOriUnitVector;
+
+  double ropeLength;
+  double modifiedRopeLength;
+
+  for(unsigned i = 0; i < nbContacts; ++i)
+  {
+    globalContactPos = position;
+    globalContactPos.noalias() += orientation * PrArray[i];
+
+    ropeLength = (PrArray[i] - pe).norm();
+    modifiedRopeLength = (globalContactPos - pe).norm();
+    contactOriUnitVector = (globalContactPos - pe) / modifiedRopeLength;
+
+    forcei = -(modifiedRopeLength - ropeLength) * KfeRopes_ * contactOriUnitVector;
+    forces.segment<3>(0) += forcei;
+
+    momenti = kine::skewSymmetric(globalContactPos) * forcei;
+
+    if(printed_ == false)
+    {
+      //            std::cout << "globalContactPos=" << globalContactPos.transpose() << std::endl;
+      //            std::cout << "ropeLength=" << ropeLength << std::endl;
+      //            std::cout << "rope deformation=" << modifiedRopeLength-ropeLength << std::endl;
+      //            std::cout << "contactOriUnitVector=" << contactOriUnitVector.transpose() << std::endl;
+      //            std::cout << "forcei=" << forcei.transpose() << std::endl;
+      //            std::cout << "momenti=" << momenti.transpose() << std::endl;
+      printed_ = true;
+    }
+  }
+
+  moments.segment<3>(0) << 0, 0, -KteRopes_(2, 2) * oriVector(2);
+  moments.segment<3>(0).noalias() += -KtvRopes_ * angVel;
+  forces.segment<3>(0).noalias() += -KfvRopes_ * linVelocity;
+}
+
+inline void IMUElasticLocalFrameDynamicalSystem::computeForcesAndMoments(const IndexedVectorArray & contactpos,
+                                                                         const IndexedVectorArray & contactori,
+                                                                         const IndexedVectorArray & contactvel,
+                                                                         const IndexedVectorArray & contactangvel,
+                                                                         const Vector3 & position,
+                                                                         const Vector3 & linVelocity,
+                                                                         const Vector3 & oriVector,
+                                                                         const Matrix3 & orientation,
+                                                                         const Vector3 & angVel,
+                                                                         Vector & fc,
+                                                                         Vector & tc)
+{
+  switch(contactModel_)
+  {
+    case contactModel::elasticContact:
+      computeElastContactForcesAndMoments(contactpos, contactori, contactvel, contactangvel, position, linVelocity,
+                                          oriVector, orientation, angVel, fc, tc);
+      break;
+
+    case contactModel::pendulum:
+      computeElastPendulumForcesAndMoments(contactpos, position, linVelocity, oriVector, orientation, angVel, fc, tc);
+      break;
+
+    default:
+      throw std::invalid_argument("IMUElasticLocalFrameDynamicalSystem: the contact model is incorrectly set.");
+  }
+}
+
+inline void IMUElasticLocalFrameDynamicalSystem::computeForcesAndMoments(const Vector & x, const Vector & u)
+{
+
+  op_.positionFlex = x.segment(state::pos, 3);
+  op_.velocityFlex = x.segment(state::linVel, 3);
+  op_.orientationFlexV = x.segment(state::ori, 3);
+  op_.angularVelocityFlex = x.segment(state::angVel, 3);
+  op_.rFlex = computeRotation_(op_.orientationFlexV, 0);
+
+  unsigned nbContacts(getContactsNumber());
+
+  for(unsigned i = 0; i < nbContacts; ++i)
+  {
+    // Positions
+    op_.contactPosV.setValue(u.segment<3>(input::contacts + 12 * i), i);
+    op_.contactOriV.setValue(u.segment<3>(input::contacts + 12 * i + 3), i);
+
+    // Velocities
+    op_.contactVelArray.setValue(u.segment<3>(input::contacts + 12 * i + 6), i);
+    op_.contactAngVelArray.setValue(u.segment<3>(input::contacts + 12 * i + 9), i);
+  }
+
+  computeForcesAndMoments(op_.contactPosV, op_.contactOriV, op_.contactVelArray, op_.contactAngVelArray,
+                          op_.positionFlex, op_.velocityFlex, op_.orientationFlexV, op_.rFlex, op_.angularVelocityFlex,
+                          fc_, tc_);
+}
+
+void IMUElasticLocalFrameDynamicalSystem::computeContactWrench(const Matrix3 & orientation,
+                                                               const Vector3 & position,
+                                                               const IndexedVectorArray & contactPosV,
+                                                               const IndexedVectorArray & contactOriV,
+                                                               const Vector & fc,
+                                                               const Vector & tc,
+                                                               const Vector3 & fm,
+                                                               const Vector3 & tm,
+                                                               const Vector3 & addForce,
+                                                               const Vector3 & addMoment)
+{
+  // from local to global frame
+  op_.f = orientation * addForce;
+  op_.t = orientation * addMoment + position.cross(op_.f);
+
+  op_.f += fm;
+  op_.t += tm;
+
+  if(contactModel_ == contactModel::elasticContact)
+  {
+    for(unsigned i = 0; i < getContactsNumber(); ++i)
+    {
+      op_.Rci = kine::rotationVectorToAngleAxis(contactOriV[i]).toRotationMatrix();
+      op_.globalContactPos.noalias() = orientation * contactPosV[i] + position;
+      op_.fi = orientation * op_.Rci * fc.segment<3>(i * 3);
+      op_.f += op_.fi;
+      op_.t += orientation * op_.Rci * tc.segment<3>(i * 3) + op_.globalContactPos.cross(op_.fi);
+    }
+  }
+  else
+  {
+    op_.f += fc.segment<3>(0);
+    op_.t += tc.segment<3>(0);
+  }
+}
+
+stateObservation::Vector IMUElasticLocalFrameDynamicalSystem::computeAccelerations(const Vector & x, const Vector & u)
+{
+  assertStateVector_(x);
+  assertInputVector_(u);
+
+  op_.positionFlex = x.segment(state::pos, 3);
+  op_.orientationFlexV = x.segment(state::ori, 3);
+  op_.rFlex = computeRotation_(op_.orientationFlexV, 0);
+  op_.velocityFlex = x.segment(state::linVel, 3);
+  op_.angularVelocityFlex = x.segment(state::angVel, 3);
+
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i)
+  {
+    op_.efforts.setValue(x.segment(state::fc + 6 * i, 6), i);
+    fc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(0, 0);
+    tc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(3, 0);
+  }
+
+  op_.positionComBias << x.segment(state::comBias, 2),
+      0; // the bias of the com along the z axis is assumed 0.
+  op_.fm = x.segment(state::unmodeledForces, 3);
+  op_.tm = x.segment(state::unmodeledForces + 3, 3);
+
+  buildInertiaTensor(u.segment<6>(input::inertia), op_.inertia);
+  buildInertiaTensor(u.segment<6>(input::dotInertia), op_.dotInertia);
+
+  unsigned nbContacts(getContactsNumber());
+
+  for(unsigned i = 0; i < nbContacts; ++i)
+  {
+    // Positions
+    op_.contactPosV.setValue(u.segment<3>(input::contacts + 12 * i), i);
+    op_.contactOriV.setValue(u.segment<3>(input::contacts + 12 * i + 3), i);
+
+    // Velocities
+    op_.contactVelArray.setValue(u.segment<3>(input::contacts + 12 * i + 6), i);
+    op_.contactAngVelArray.setValue(u.segment<3>(input::contacts + 12 * i + 9), i);
+  }
+
+  op_.positionCom = u.segment<3>(input::posCom);
+  if(withComBias_) op_.positionCom -= op_.positionComBias;
+  op_.velocityCom = u.segment<3>(input::velCom);
+  op_.accelerationCom = u.segment<3>(input::accCom);
+  op_.AngMomentum = u.segment<3>(input::angMoment);
+  op_.dotAngMomentum = u.segment<3>(input::dotAngMoment);
+
+  op_.addForce = u.segment<3>(input::additionalForces);
+  op_.addMoment = u.segment<3>(input::additionalForces + 3);
+
+  computeAccelerations(op_.positionCom, op_.velocityCom, op_.accelerationCom, op_.AngMomentum, op_.dotAngMomentum,
+                       op_.inertia, op_.dotInertia, op_.contactPosV, op_.contactOriV, op_.positionFlex,
+                       op_.velocityFlex, op_.linearAcceleration, op_.orientationFlexV, op_.rFlex,
+                       op_.angularVelocityFlex, op_.angularAcceleration, fc_, tc_, op_.fm, op_.tm, op_.addForce,
+                       op_.addMoment);
+
+  stateObservation::Vector6 acceleration;
+  acceleration << op_.linearAcceleration, op_.angularAcceleration;
+  return acceleration;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::computeAccelerations(const Vector3 & positionCom,
+                                                               const Vector3 & velocityCom,
+                                                               const Vector3 & accelerationCom,
+                                                               const Vector3 & AngMomentum,
+                                                               const Vector3 & dotAngMomentum,
+                                                               const Matrix3 & Inertia,
+                                                               const Matrix3 & dotInertia,
+                                                               const IndexedVectorArray & contactPosV,
+                                                               const IndexedVectorArray & contactOriV,
+                                                               const Vector3 & position,
+                                                               const Vector3 & linVelocity,
+                                                               Vector3 & linearAcceleration,
+                                                               const Vector3 & oriVector,
+                                                               const Matrix3 & orientation,
+                                                               const Vector3 & angularVel,
+                                                               Vector3 & angularAcceleration,
+                                                               const Vector & fc,
+                                                               const Vector & tc,
+                                                               const Vector3 & fm,
+                                                               const Vector3 & tm,
+                                                               const Vector3 & addForces,
+                                                               const Vector3 & addMoments)
+{
+
+  (void)linVelocity;
+  (void)oriVector; //
+
+  kine::skewSymmetric(angularVel, op_.skewV);
+  kine::skewSymmetric2(angularVel, op_.skewV2);
+  op_.skewVR.noalias() = op_.skewV * orientation;
+  op_.skewV2R.noalias() = op_.skewV2 * orientation;
+
+  op_.rFlexT.noalias() = orientation.transpose();
+
+  computeContactWrench(orientation, position, contactPosV, contactOriV, fc, tc, fm, tm, addForces, addMoments);
+
+  op_.wx2Rc.noalias() = op_.skewV2R * positionCom;
+  op_._2wxRv.noalias() = 2 * op_.skewVR * velocityCom;
+  op_.Ra.noalias() = orientation * accelerationCom;
+  op_.Rc.noalias() = orientation * positionCom;
+  op_.Rcp.noalias() = op_.Rc + position;
+  op_.RIRT.noalias() = orientation * Inertia * op_.rFlexT;
+
+  op_.vf.noalias() = robotMassInv_ * op_.f;
+
+  op_.vf.noalias() -= op_.Ra;
+  op_.vf.noalias() -= op_._2wxRv;
+  op_.vf.noalias() -= op_.wx2Rc;
+  op_.vf.noalias() -= cst::gravity;
+
+  op_.vt = op_.t;
+  op_.vt.noalias() -= op_.skewV * (op_.RIRT * angularVel);
+  op_.vt.noalias() -= orientation * (dotInertia * (op_.rFlexT * angularVel) + dotAngMomentum);
+  op_.vt.noalias() -= op_.skewVR * AngMomentum;
+  op_.vt.noalias() -= robotMass_ * (kine::skewSymmetric(position) * (op_.wx2Rc + op_._2wxRv + op_.Ra));
+  op_.vt.noalias() -= robotMass_ * kine::skewSymmetric(op_.Rcp) * cst::gravity;
+
+  op_.orinertia.noalias() = op_.RIRT + robotMass_ * kine::skewSymmetric2(op_.Rc);
+  op_.invinertia.compute(op_.orinertia);
+
+  angularAcceleration.noalias() = op_.vt - robotMass_ * op_.Rcp.cross(op_.vf);
+
+  op_.invinertia.matrixL().solveInPlace(angularAcceleration);
+  op_.invinertia.matrixL().transpose().solveInPlace(angularAcceleration);
+
+  // angularAcceleration = ( op_.RIRT + robotMass_*kine::skewSymmetric2(op_.Rc)).llt().solve(
+  //                        (op_.vt - robotMass_*kine::skewSymmetric(op_.Rcp)*op_.vf));
+
+  linearAcceleration = op_.vf;
+  linearAcceleration += kine::skewSymmetric(op_.Rc) * angularAcceleration;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::iterateDynamicsEuler(const Vector3 & positionCom,
+                                                               const Vector3 & velocityCom,
+                                                               const Vector3 & accelerationCom,
+                                                               const Vector3 & AngMomentum,
+                                                               const Vector3 & dotAngMomentum,
+                                                               const Matrix3 & inertia,
+                                                               const Matrix3 & dotInertia,
+                                                               const IndexedVectorArray & contactPos,
+                                                               const IndexedVectorArray & contactOri,
+                                                               Vector3 & position,
+                                                               Vector3 & linVelocity,
+                                                               Vector & fc,
+                                                               Vector3 & oriVector,
+                                                               Vector3 & angularVel,
+                                                               Vector & tc,
+                                                               const Vector3 & fm,
+                                                               const Vector3 & tm,
+                                                               const Vector3 & addiForces,
+                                                               const Vector3 & addiMoments,
+                                                               double dt)
+{
+
+  op_.rFlex = computeRotation_(oriVector, 0);
+  // compute new acceleration with the current flex position and velocity and input
+
+  //        computeForcesAndMoments (contactPos, contactOri, op_.contactVelArray, op_.contactAngVelArray,
+  //                          position, linVelocity, oriVector, op_.rFlex,
+  //                             angularVel, fc, tc);
+
+  computeAccelerations(positionCom, velocityCom, accelerationCom, AngMomentum, dotAngMomentum, inertia, dotInertia,
+                       contactPos, contactOri, position, linVelocity, op_.linearAcceleration, oriVector, op_.rFlex,
+                       angularVel, op_.angularAcceleration, fc, tc, fm, tm, addiForces, addiMoments);
+
+  /// integrate kinematics with the last acceleration
+  kine::integrateKinematics(position, linVelocity, op_.linearAcceleration, op_.rFlex, angularVel,
+                            op_.angularAcceleration, dt);
+
+  /// Adding a kinematic coupling to improve estimation of the velocities
+  //        Vector3 constrainedLinVel;
+  //        constrainedLinVel.setZero();
+  //
+  //        for(int i=0; i<getContactsNumber();++i)
+  //        {
+  //          constrainedLinVel += Vector3(op_.rFlex*contactPos[i]).cross(angularVel);
+  //        }
+  //        constrainedLinVel=constrainedLinVel/getContactsNumber();
+  //
+  //        double alphaLin=0.1; ///kinematic coupling weight
+  //        linVelocity=alphaLin*linVelocity + (1-alphaLin) * constrainedLinVel;
+  //        ///
+  //
+  //        Vector3 constrainedAngVel=angularVel;
+  //        if (getContactsNumber()==2)
+  //        {
+  //
+  //            Vector3 interlegAxis = contactPos[1]-contactPos[0];
+  //            constrainedAngVel -= (angularVel.dot(interlegAxis) * interlegAxis)/interlegAxis.squaredNorm();
+  //        }
+  //        else if (getContactsNumber()>2)
+  //        {
+  //            constrainedAngVel.setZero();
+  //        }
+  //        double alphaAng = 0.1;
+  //        angularVel = alphaAng*angularVel + (1-alphaAng)*constrainedAngVel;
+
+  op_.orientationAA = op_.rFlex;
+  oriVector.noalias() = op_.orientationAA.angle() * op_.orientationAA.axis();
+
+  computeForcesAndMoments(contactPos, contactOri, op_.contactVelArray, op_.contactAngVelArray, position, linVelocity,
+                          oriVector, op_.rFlex, angularVel, fc, tc);
+}
+
+void IMUElasticLocalFrameDynamicalSystem::iterateDynamicsRK4(const Vector3 & positionCom,
+                                                             const Vector3 & velocityCom,
+                                                             const Vector3 & accelerationCom,
+                                                             const Vector3 & AngMomentum,
+                                                             const Vector3 & dotAngMomentum,
+                                                             const Matrix3 & inertia,
+                                                             const Matrix3 & dotInertia,
+                                                             const IndexedVectorArray & contactPos,
+                                                             const IndexedVectorArray & contactOri,
+                                                             Vector3 & position,
+                                                             Vector3 & linVelocity,
+                                                             Vector & fc,
+                                                             Vector3 & oriVector,
+                                                             Vector3 & angularVel,
+                                                             Vector & tc,
+                                                             const Vector3 & fm,
+                                                             const Vector3 & tm,
+                                                             const Vector3 & addForces,
+                                                             const Vector3 & addMoments,
+                                                             double dt)
+{
+
+  Matrix3 orientationFlex(computeRotation_(oriVector, 0));
+
+  Vector3 linAcc1;
+  Vector3 angAcc1;
+
+  Vector3 pos2;
+  Vector3 oriv2;
+  AngleAxis oriaa2;
+  Matrix3 ori2;
+
+  Vector3 linVelocity2;
+  Vector3 angVelocity2;
+
+  Vector3 linAcc2;
+  Vector3 angAcc2;
+
+  Vector3 pos3;
+  Vector3 oriv3;
+  AngleAxis oriaa3;
+  Matrix3 ori3;
+
+  Vector3 linVelocity3;
+  Vector3 angVelocity3;
+
+  Vector3 linAcc3;
+  Vector3 angAcc3;
+
+  Vector3 pos4;
+  Vector3 oriv4;
+  AngleAxis oriaa4;
+  Matrix3 ori4;
+
+  Vector3 linVelocity4;
+  Vector3 angVelocity4;
+
+  Vector3 linAcc4;
+  Vector3 angAcc4;
+
+  //////////1st/////////////
+  computeAccelerations(positionCom, velocityCom, accelerationCom, AngMomentum, dotAngMomentum, inertia, dotInertia,
+                       contactPos, contactOri, position, linVelocity, linAcc1, oriVector, orientationFlex, angularVel,
+                       angAcc1, fc, tc, fm, tm, addForces, addMoments);
+
+  //////////2nd//////////////
+  pos2 = position;
+  ori2 = orientationFlex;
+
+  kine::integrateKinematics(pos2, linVelocity, ori2, angularVel, dt / 2);
+
+  oriaa2.fromRotationMatrix(ori2);
+  oriv2 = oriaa2.angle() * oriaa2.axis();
+
+  linVelocity2 = linVelocity + (dt / 2) * linAcc1;
+  angVelocity2 = angularVel + (dt / 2) * angAcc1;
+
+  computeAccelerations(positionCom, velocityCom, accelerationCom, AngMomentum, dotAngMomentum, inertia, dotInertia,
+                       contactPos, contactOri, pos2, linVelocity2, linAcc2, oriv2, ori2, angVelocity2, angAcc2, fc, tc,
+                       fm, tm, addForces, addMoments);
+
+  ////////////3rd/////////////
+
+  pos3 = position;
+  ori3 = orientationFlex;
+
+  kine::integrateKinematics(pos3, linVelocity2, ori3, angVelocity2, dt / 2);
+
+  oriaa3.fromRotationMatrix(ori3);
+  oriv3 = oriaa3.angle() * oriaa3.axis();
+
+  linVelocity3 = linVelocity + (dt / 2) * linAcc2;
+  angVelocity3 = angularVel + (dt / 2) * angAcc2;
+
+  computeAccelerations(positionCom, velocityCom, accelerationCom, AngMomentum, dotAngMomentum, inertia, dotInertia,
+                       contactPos, contactOri, pos3, linVelocity3, linAcc3, oriv3, ori3, angVelocity3, angAcc3, tc, fc,
+                       fm, tm, addForces, addMoments);
+
+  ////////////4th/////////////
+  pos4 = position;
+  ori4 = orientationFlex;
+
+  kine::integrateKinematics(pos4, linVelocity3, ori4, angVelocity3, dt);
+
+  oriaa4.fromRotationMatrix(ori4);
+  oriv4 = oriaa4.angle() * oriaa4.axis();
+
+  linVelocity4 = linVelocity + (dt)*linAcc3;
+  angVelocity4 = angularVel + (dt)*angAcc3;
+
+  computeAccelerations(positionCom, velocityCom, accelerationCom, AngMomentum, dotAngMomentum, inertia, dotInertia,
+                       contactPos, contactOri, pos4, linVelocity4, linAcc4, oriv4, ori4, angVelocity4, angAcc4, fc, tc,
+                       fm, tm, addForces, addMoments);
+
+  /////////////////////////////
+
+  kine::integrateKinematics(position, linVelocity, orientationFlex, angularVel, dt / 6);
+  kine::integrateKinematics(position, linVelocity2, orientationFlex, angVelocity2, dt / 3);
+  kine::integrateKinematics(position, linVelocity3, orientationFlex, angVelocity3, dt / 3);
+  kine::integrateKinematics(position, linVelocity4, orientationFlex, angVelocity4, dt / 6);
+
+  linVelocity += (dt / 6) * (linAcc1 + 2 * linAcc2 + 2 * linAcc3 + linAcc4);
+  angularVel += (dt / 6) * (angAcc1 + 2 * angAcc2 + 2 * angAcc3 + angAcc4);
+
+  AngleAxis orientationAA(orientationFlex);
+  oriVector = orientationAA.angle() * orientationAA.axis();
+
+  // Getting forces
+  op_.rFlex = computeRotation_(oriVector, 0);
+  computeForcesAndMoments(contactPos, contactOri, op_.contactVelArray, op_.contactAngVelArray, position, linVelocity,
+                          oriVector, op_.rFlex, angularVel, fc, tc);
+}
+
+Vector IMUElasticLocalFrameDynamicalSystem::stateDynamics(const Vector & x, const Vector & u, TimeIndex)
+{
+
+  assertStateVector_(x);
+  assertInputVector_(u);
+
+  xk_ = x;
+  uk_ = u;
+
+  op_.positionFlex = x.segment(state::pos, 3);
+  op_.orientationFlexV = x.segment(state::ori, 3);
+  op_.velocityFlex = x.segment(state::linVel, 3);
+  op_.angularVelocityFlex = x.segment(state::angVel, 3);
+
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i) op_.efforts.setValue(x.segment(state::fc + 6 * i, 6), i);
+
+  op_.positionComBias << x.segment(state::comBias, 2),
+      0; // the bias of the com along the z axis is assumed 0.
+  op_.fm = x.segment(state::unmodeledForces, 3);
+  op_.tm = x.segment(state::unmodeledForces + 3, 3);
+
+  buildInertiaTensor(u.segment<6>(input::inertia), op_.inertia);
+  buildInertiaTensor(u.segment<6>(input::dotInertia), op_.dotInertia);
+
+  unsigned nbContacts(getContactsNumber());
+
+  for(unsigned i = 0; i < nbContacts; ++i)
+  {
+    // Positions
+    op_.contactPosV.setValue(u.segment<3>(input::contacts + 12 * i), i);
+    op_.contactOriV.setValue(u.segment<3>(input::contacts + 12 * i + 3), i);
+
+    // Velocities
+    op_.contactVelArray.setValue(u.segment<3>(input::contacts + 12 * i + 6), i);
+    op_.contactAngVelArray.setValue(u.segment<3>(input::contacts + 12 * i + 9), i);
+  }
+
+  op_.positionCom = u.segment<3>(input::posCom);
+  if(withComBias_) op_.positionCom -= op_.positionComBias;
+  op_.velocityCom = u.segment<3>(input::velCom);
+  op_.accelerationCom = u.segment<3>(input::accCom);
+  op_.AngMomentum = u.segment<3>(input::angMoment);
+  op_.dotAngMomentum = u.segment<3>(input::dotAngMoment);
+
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i)
+  {
+    fc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(0, 0);
+    tc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(3, 0);
+  }
+
+  op_.addForce = u.segment<3>(input::additionalForces);
+  op_.addMoment = u.segment<3>(input::additionalForces + 3);
+
+  const int subsample = 1;
+  for(int i = 0; i < subsample; ++i)
+  {
+    iterateDynamicsEuler(op_.positionCom, op_.velocityCom, op_.accelerationCom, op_.AngMomentum, op_.dotAngMomentum,
+                         op_.inertia, op_.dotInertia, op_.contactPosV, op_.contactOriV, op_.positionFlex,
+                         op_.velocityFlex, fc_, op_.orientationFlexV, op_.angularVelocityFlex, tc_, op_.fm, op_.tm,
+                         op_.addForce, op_.addMoment, dt_ / subsample);
+  }
+  // x_{k+1}
+
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i)
+  {
+    // std::cout << "Contact " << i << std::endl
+    //          << fc_.segment<3>(3*i).transpose() << std::endl
+    //          << tc_.segment<3>(3*i).transpose()<< std::endl;
+    op_.efforts[i].block<3, 1>(0, 0) = fc_.segment<3>(3 * i);
+    op_.efforts[i].block<3, 1>(3, 0) = tc_.segment<3>(3 * i);
+  }
+
+  xk1_ = x;
+
+  xk1_.segment<3>(state::pos) = op_.positionFlex;
+  xk1_.segment<3>(state::ori) = op_.orientationFlexV;
+
+  xk1_.segment<3>(state::linVel) = op_.velocityFlex;
+  xk1_.segment<3>(state::angVel) = op_.angularVelocityFlex;
+
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i) xk1_.segment(state::fc + 6 * i, 6) = op_.efforts[i].col(0);
+
+  // xk1_.segment<2>(state::comBias) = op_.positionComBias.head<2>();
+
+  if(withUnmodeledForces_)
+  {
+    xk1_.segment<3>(state::unmodeledForces) = marginalStabilityFactor_ * op_.fm;
+    xk1_.segment<3>(state::unmodeledForces + 3) = marginalStabilityFactor_ * op_.tm;
+  }
+  else
+  {
+    xk1_.segment<6>(state::unmodeledForces).setZero();
+  }
+
+  if(processNoise_ != 0x0)
+    return processNoise_->getNoisy(op_.xk1);
+  else
+    return xk1_;
+}
+
+inline Matrix3 & IMUElasticLocalFrameDynamicalSystem::computeRotation_(const Vector3 & x, int i)
+{
+  Vector3 & oriV = op_.orientationVector(i);
+  Matrix3 & oriR = op_.curRotation(i);
+  if(oriV != x)
+  {
+    oriV = x;
+    oriR = kine::rotationVectorToAngleAxis(x).toRotationMatrix();
+  }
+
+  return oriR;
+}
+
+Vector IMUElasticLocalFrameDynamicalSystem::measureDynamics(const Vector & x, const Vector & u, TimeIndex k)
+{
+  assertStateVector_(x);
+  assertInputVector_(u);
+
+  xk_fory_ = x;
+  uk_fory_ = u;
+  op_.k_fory = k;
+
+  op_.positionFlex = x.segment(state::pos, 3);
+  op_.velocityFlex = x.segment(state::linVel, 3);
+  op_.orientationFlexV = x.segment(state::ori, 3);
+  op_.angularVelocityFlex = x.segment(state::angVel, 3);
+
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i) op_.efforts[i] = x.segment(state::fc + 6 * i, 6);
+
+  op_.fm = x.segment(state::unmodeledForces, 3);
+  op_.tm = x.segment(state::unmodeledForces + 3, 3);
+  op_.drift = x.segment<3>(state::drift);
+
+  op_.rFlex = computeRotation_(op_.orientationFlexV, 0);
+
+  buildInertiaTensor(u.segment<6>(input::inertia), op_.inertia);
+  buildInertiaTensor(u.segment<6>(input::dotInertia), op_.dotInertia);
+  unsigned nbContacts(getContactsNumber());
+  for(unsigned i = 0; i < nbContacts; ++i)
+  {
+    // Positions
+    op_.contactPosV.setValue(u.segment<3>(input::contacts + 12 * i), i);
+    op_.contactOriV.setValue(u.segment<3>(input::contacts + 12 * i + 3), i);
+  }
+  op_.positionCom = u.segment<3>(input::posCom);
+
+  if(withComBias_)
+  {
+    op_.positionComBias << x.segment(state::comBias, 2),
+        0; // the bias of the com along the z axis is assumed 0.
+    op_.positionCom -= op_.positionComBias;
+  }
+
+  op_.velocityCom = u.segment<3>(input::velCom);
+  op_.accelerationCom = u.segment<3>(input::accCom);
+  op_.AngMomentum = u.segment<3>(input::angMoment);
+  op_.dotAngMomentum = u.segment<3>(input::dotAngMoment);
+
+  op_.positionControl = u.segment(input::posIMU, 3);
+  op_.velocityControl = u.segment(input::linVelIMU, 3);
+  op_.accelerationControl = u.segment(input::linAccIMU, 3);
+  op_.orientationControlV = u.segment(input::oriIMU, 3);
+  op_.angularVelocityControl = u.segment(input::angVelIMU, 3);
+
+  op_.rControl = computeRotation_(op_.orientationControlV, 1);
+
+  op_.rimu = op_.rFlex * op_.rControl;
+
+  for(unsigned i = 0; i < hrp2::contact::nbModeledMax; ++i)
+  {
+    fc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(0, 0);
+    tc_.segment<3>(3 * i) = op_.efforts[i].block<3, 1>(3, 0);
+  }
+
+  op_.addForce = u.segment<3>(input::additionalForces);
+  op_.addMoment = u.segment<3>(input::additionalForces + 3);
+
+  // Get acceleration
+  computeAccelerations(op_.positionCom, op_.velocityCom, op_.accelerationCom, op_.AngMomentum, op_.dotAngMomentum,
+                       op_.inertia, op_.dotInertia, op_.contactPosV, op_.contactOriV, op_.positionFlex,
+                       op_.velocityFlex, op_.linearAcceleration, op_.orientationFlexV, op_.rFlex,
+                       op_.angularVelocityFlex, op_.angularAcceleration, fc_, tc_, op_.fm, op_.tm, op_.addForce,
+                       op_.addMoment);
+
+  // Translation sensor dynamic
+  op_.imuAcc = 2 * kine::skewSymmetric(op_.angularVelocityFlex) * op_.rFlex * op_.velocityControl;
+  op_.imuAcc += op_.linearAcceleration + op_.rFlex * op_.accelerationControl;
+  op_.imuAcc +=
+      (kine::skewSymmetric(op_.angularAcceleration) + tools::square(kine::skewSymmetric(op_.angularVelocityFlex)))
+      * op_.rFlex * op_.positionControl;
+
+  // Rotation sensor dynamic
+  op_.imuOmega = op_.angularVelocityFlex + op_.rFlex * op_.angularVelocityControl;
+
+  // Set sensor state before measurement
+
+  op_.sensorState.resize(sensor_.getStateSize());
+  op_.sensorState.head<9>() = Eigen::Map<Eigen::Matrix<double, 9, 1>>(&op_.rimu(0, 0));
+  op_.sensorState.segment<3>(9) = op_.imuAcc;
+  op_.sensorState.segment<3>(12) = op_.imuOmega;
+
+  index_ = 15;
+
+  if(withForceMeasurements_)
+  {
+    for(unsigned int i = 0; i < nbContacts_; ++i)
+    {
+      op_.sensorState.segment(index_, 6) = x.segment(state::fc + i * 6, 6);
+      // the last part of the measurement is force torque, it is
+      // computes by the current functor and not the sensor_.
+      // (see AlgebraicSensor::concatenateWithInput
+      // for more details
+      index_ += 6;
+    }
+  }
+
+  if(withAbsolutePos_)
+  {
+    op_.cy = cos(op_.drift(2));
+    op_.sy = sin(op_.drift(2));
+    op_.rdrift << op_.cy, -op_.sy, 0, op_.sy, op_.cy, 0, 0, 0, 1;
+    op_.rtotal.noalias() = op_.rdrift * op_.rFlex;
+
+    op_.ptotal << op_.drift(0), op_.drift(1), 0;
+    op_.ptotal.noalias() += op_.rdrift * op_.positionFlex;
+
+    op_.aatotal = op_.rtotal;
+    op_.oritotal.noalias() = op_.aatotal.angle() * op_.aatotal.axis();
+
+    op_.sensorState.segment<3>(index_) = op_.ptotal;
+    op_.sensorState.segment<3>(index_ + 3) = op_.oritotal;
+  }
+
+  sensor_.setState(op_.sensorState, k);
+
+  // measurements
+  yk_ = sensor_.getMeasurements();
+
+  return yk_;
+}
+
+stateObservation::Matrix IMUElasticLocalFrameDynamicalSystem::measureDynamicsJacobian()
+{
+  op_.Jy.resize(getMeasurementSize(), getStateSize());
+  op_.Jy.setZero();
+
+  op_.xdx = xk_fory_;
+  op_.xk_fory = xk_fory_;
+  op_.yk = yk_;
+
+  Index sizeAfterComBias = getStateSize() - state::comBias - 2;
+
+  for(Index i = 0; i < state::unmodeledForces; ++i)
+  {
+    op_.xdx[i] += dx_[i];
+
+    op_.ykdy = measureDynamics(op_.xdx, uk_fory_, op_.k_fory);
+    op_.ykdy -= op_.yk;
+    op_.ykdy /= dx_[i];
+
+    op_.Jy.col(i) = op_.ykdy;
+    op_.xdx[i] = op_.xk_fory[i];
+  }
+
+  if(!withUnmodeledForces_)
+  {
+    op_.Jy.block(0, state::unmodeledForces, getMeasurementSize(), 6).setZero();
+  }
+  else
+  {
+    for(Index i = state::unmodeledForces; i < state::unmodeledForces + 6; ++i)
+    {
+      op_.xdx[i] += dx_[i];
+
+      op_.ykdy = measureDynamics(op_.xdx, uk_fory_, op_.k_fory);
+      op_.ykdy -= op_.yk;
+      op_.ykdy /= dx_[i];
+
+      op_.Jy.col(i) = op_.ykdy;
+      op_.xdx[i] = op_.xk_fory[i];
+    }
+  }
+
+  if(!withComBias_)
+  {
+    op_.Jy.block(0, state::comBias, getMeasurementSize(), 2).setZero();
+  }
+  else
+  {
+    for(Index i = state::comBias; i < state::comBias + 2; ++i)
+    {
+      op_.xdx[i] += dx_[i];
+
+      op_.ykdy = measureDynamics(op_.xdx, uk_fory_, op_.k_fory);
+      op_.ykdy -= op_.yk;
+      op_.ykdy /= dx_[i];
+
+      op_.Jy.col(i) = op_.ykdy;
+      op_.xdx[i] = op_.xk_fory[i];
+    }
+  }
+
+  if(!withAbsolutePos_)
+  {
+    op_.Jy.block(0, state::drift, getMeasurementSize(), 3).setZero();
+  }
+  else
+  {
+    for(Index i = state::comBias + 2; i < state::comBias + 2 + sizeAfterComBias; ++i)
+    {
+      op_.xdx[i] += dx_[i];
+
+      op_.ykdy = measureDynamics(op_.xdx, uk_fory_, op_.k_fory);
+      op_.ykdy -= op_.yk;
+      op_.ykdy /= dx_[i];
+
+      op_.Jy.col(i) = op_.ykdy;
+      op_.xdx[i] = op_.xk_fory[i];
+    }
+  }
+
+  // std::cout << "JACOBIAN: "<<std::endl;
+  // std::cout << op_.Jy<<std::endl;
+
+  xk_fory_ = op_.xk_fory; // last thing to do before returning to make the prediction correct
+
+  yk_ = op_.yk;
+
+  return op_.Jy;
+}
+
+stateObservation::Matrix IMUElasticLocalFrameDynamicalSystem::stateDynamicsJacobian()
+{
+  op_.Jx.resize(getStateSize(), getStateSize());
+  op_.Jx.setZero();
+
+  op_.xdx = xk_;
+  op_.xk = xk_;
+  op_.xk1 = xk1_;
+
+  Index sizeAfterComBias = getStateSize() - state::comBias - 2;
+  Index sizeAfterUnmodeledForces = getStateSize() - state::unmodeledForces - 6;
+
+  for(Index i = 0; i < state::unmodeledForces; ++i)
+  {
+    op_.xdx[i] += dx_[i];
+
+    op_.xk1dx = stateDynamics(op_.xdx, uk_, 0);
+    op_.xk1dx -= op_.xk1;
+    op_.xk1dx /= dx_[i];
+
+    op_.Jx.col(i) = op_.xk1dx;
+    op_.xdx[i] = op_.xk[i];
+  }
+
+  if(!withUnmodeledForces_)
+  {
+    op_.Jx.block(state::unmodeledForces, state::unmodeledForces, 6, 6).setIdentity();
+    op_.Jx.block(0, state::unmodeledForces, state::unmodeledForces, 6).setZero();
+    op_.Jx.block(state::unmodeledForces + 6, state::unmodeledForces, sizeAfterUnmodeledForces, 6).setZero();
+  }
+  else
+  {
+    for(Index i = state::unmodeledForces; i < state::unmodeledForces + 6; ++i)
+    {
+      op_.xdx[i] += dx_[i];
+
+      op_.xk1dx = stateDynamics(op_.xdx, uk_, 0);
+      op_.xk1dx -= op_.xk1;
+      op_.xk1dx /= dx_[i];
+
+      op_.Jx.col(i) = op_.xk1dx;
+      op_.xdx[i] = op_.xk[i];
+    }
+  }
+
+  if(!withComBias_)
+  {
+    op_.Jx.block(state::comBias, state::comBias, 2, 2).setIdentity();
+    op_.Jx.block(0, state::comBias, state::comBias, 2).setZero();
+    op_.Jx.block(state::comBias + 2, state::comBias, sizeAfterComBias, 2).setZero();
+  }
+  else
+  {
+    for(Index i = state::comBias; i < state::comBias + 2; ++i)
+    {
+      op_.xdx[i] += dx_[i];
+
+      op_.xk1dx = stateDynamics(op_.xdx, uk_, 0);
+      op_.xk1dx -= op_.xk1;
+      op_.xk1dx /= dx_[i];
+
+      op_.Jx.col(i) = op_.xk1dx;
+      op_.xdx[i] = op_.xk[i];
+    }
+  }
+
+  if(!withAbsolutePos_)
+  {
+    op_.Jx.block(0, state::drift, getStateSize(), 3).setZero();
+    op_.Jx.block(state::drift, state::drift, 3, 3).setIdentity();
+  }
+  else
+  {
+    for(Index i = state::drift; i < state::drift + 3; ++i)
+    {
+      op_.xdx[i] += dx_[i];
+
+      op_.xk1dx = stateDynamics(op_.xdx, uk_, 0);
+      op_.xk1dx -= op_.xk1;
+      op_.xk1dx /= dx_[i];
+
+      op_.Jx.col(i) = op_.xk1dx;
+      op_.xdx[i] = op_.xk[i];
+    }
+  }
+
+  // std::cout << "JACOBIAN: "<<std::endl;
+  // std::cout << op_.Jx <<std::endl;
+
+  xk_ = op_.xk; // last thing to do before returning
+  xk1_ = op_.xk1;
+
+  return op_.Jx;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setProcessNoise(NoiseBase * n)
+{
+  processNoise_ = n;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::resetProcessNoise()
+{
+  processNoise_ = 0x0;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setMeasurementNoise(NoiseBase * n)
+{
+  sensor_.setNoise(n);
+}
+
+void IMUElasticLocalFrameDynamicalSystem::resetMeasurementNoise()
+{
+  sensor_.resetNoise();
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setSamplingPeriod(double dt)
+{
+  dt_ = dt;
+}
+
+Index IMUElasticLocalFrameDynamicalSystem::getStateSize() const
+{
+  return stateSize_;
+}
+
+Index IMUElasticLocalFrameDynamicalSystem::getInputSize() const
+{
+  return inputSize_;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setInputSize(Index i)
+{
+  inputSize_ = i;
+}
+
+Index IMUElasticLocalFrameDynamicalSystem::getMeasurementSize() const
+{
+  return measurementSize_;
+}
+
+NoiseBase * IMUElasticLocalFrameDynamicalSystem::getProcessNoise() const
+{
+  return processNoise_;
+}
+
+NoiseBase * IMUElasticLocalFrameDynamicalSystem::getMeasurementNoise() const
+{
+  return sensor_.getNoise();
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setContactsNumber(unsigned i)
+{
+  nbContacts_ = i;
+  inputSize_ = input::sizeBase + 12 * i;
+
+  updateMeasurementSize_();
+}
+
+void IMUElasticLocalFrameDynamicalSystem::updateMeasurementSize_()
+{
+  measurementSize_ = measurementSizeBase_;
+
+  if(withForceMeasurements_)
+  {
+    measurementSize_ += nbContacts_ * 6;
+  }
+
+  if(withAbsolutePos_)
+  {
+    measurementSize_ += 6;
+  }
+
+  sensor_.concatenateWithInput(measurementSize_ - measurementSizeBase_);
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setWithForceMeasurements(bool b)
+{
+  withForceMeasurements_ = b;
+  updateMeasurementSize_();
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setWithComBias(bool b)
+{
+  withComBias_ = b;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setWithAbsolutePosition(bool b)
+{
+  withAbsolutePos_ = b;
+  updateMeasurementSize_();
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setWithUnmodeledForces(bool b)
+{
+  withUnmodeledForces_ = b;
+}
+
+bool IMUElasticLocalFrameDynamicalSystem::getWithForceMeasurements() const
+{
+  return withForceMeasurements_;
+}
+
+bool IMUElasticLocalFrameDynamicalSystem::getWithComBias() const
+{
+  return withComBias_;
+}
+
+bool IMUElasticLocalFrameDynamicalSystem::getWithAbsolutePosition() const
+{
+  return withAbsolutePos_;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setKfe(const Matrix3 & m)
+{
+  Kfe_ = m;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setKfv(const Matrix3 & m)
+{
+  Kfv_ = m;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setKte(const Matrix3 & m)
+{
+  Kte_ = m;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setKtv(const Matrix3 & m)
+{
+  Ktv_ = m;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setKfeRopes(const Matrix3 & m)
+{
+  KfeRopes_ = m;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setKfvRopes(const Matrix3 & m)
+{
+  KfvRopes_ = m;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setKteRopes(const Matrix3 & m)
+{
+  KteRopes_ = m;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setKtvRopes(const Matrix3 & m)
+{
+  KtvRopes_ = m;
+}
+
+Matrix IMUElasticLocalFrameDynamicalSystem::getKfe() const
+{
+  return Kfe_;
+}
+
+Matrix IMUElasticLocalFrameDynamicalSystem::getKfv() const
+{
+  return Kfv_;
+}
+
+Matrix IMUElasticLocalFrameDynamicalSystem::getKte() const
+{
+  return Kte_;
+}
+
+Matrix IMUElasticLocalFrameDynamicalSystem::getKtv() const
+{
+  return Ktv_;
+}
+
+void IMUElasticLocalFrameDynamicalSystem::setFDstep(const stateObservation::Vector & dx)
+{
+  dx_ = dx;
+}
+} // namespace flexibilityEstimation
+} // namespace stateObservation

--- a/src/imu-fixed-contact-dynamical-system.cpp
+++ b/src/imu-fixed-contact-dynamical-system.cpp
@@ -5,202 +5,186 @@ namespace stateObservation
 {
 namespace flexibilityEstimation
 {
-    using namespace stateObservation;
+using namespace stateObservation;
 
-    IMUFixedContactDynamicalSystem::
-                    IMUFixedContactDynamicalSystem(double dt):
-        processNoise_(0x0), dt_(dt),orientationVector_(Vector3::Zero()),
-        quaternion_(Quaternion::Identity()),
-        measurementSize_(measurementSizeBase_)
-    {
+IMUFixedContactDynamicalSystem::IMUFixedContactDynamicalSystem(double dt)
+: processNoise_(0x0), dt_(dt), orientationVector_(Vector3::Zero()), quaternion_(Quaternion::Identity()),
+  measurementSize_(measurementSizeBase_)
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-     std::cout<<std::endl<<"IMUFixedContactDynamicalSystem Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
-    }
-
-    IMUFixedContactDynamicalSystem::
-                    ~IMUFixedContactDynamicalSystem()
-    {
-        //dtor
-    }
-
-
-    Vector IMUFixedContactDynamicalSystem::stateDynamics
-        (const Vector& x, const Vector& , TimeIndex )
-    {
-        assertStateVector_(x);
-
-        Vector3 positionFlex(x.segment(indexes::pos,3));
-        Vector3 velocityFlex(x.segment(indexes::linVel,3));
-        Vector3 accelerationFlex(x.segment(indexes::linAcc,3));
-
-        Vector3 orientationFlexV(x.segment(indexes::ori,3));
-        Vector3 angularVelocityFlex(x.segment(indexes::angVel,3));
-        Vector3 angularAccelerationFlex(x.segment(indexes::angAcc,3));
-
-        Quaternion orientationFlex(computeQuaternion_(orientationFlexV));
-
-        kine::integrateKinematics
-                (positionFlex, velocityFlex, accelerationFlex, orientationFlex,
-                 angularVelocityFlex, angularAccelerationFlex, dt_);
-
-        //x_{k+1}
-        Vector xk1(x);
-
-        xk1.segment(indexes::pos,3) = positionFlex;
-        xk1.segment(indexes::linVel,3) = velocityFlex;
-
-        AngleAxis orientationAA(orientationFlex);
-        orientationFlexV=orientationAA.angle()*orientationAA.axis();
-
-        xk1.segment(indexes::ori,3) =  orientationFlexV;
-        xk1.segment(indexes::angVel,3) = angularVelocityFlex;
-
-        if (processNoise_!=0x0)
-            return processNoise_->getNoisy(xk1);
-        else
-            return xk1;
-    }
-
-    Quaternion IMUFixedContactDynamicalSystem::computeQuaternion_
-                (const Vector3 & x)
-    {
-        if (orientationVector_!=x)
-        {
-            orientationVector_ = x;
-            quaternion_ = kine::rotationVectorToAngleAxis(x);
-        }
-
-        return quaternion_;
-    }
-
-    Vector IMUFixedContactDynamicalSystem::measureDynamics
-                (const Vector& x, const Vector& u, TimeIndex k)
-    {
-        assertStateVector_(x);
-
-        Vector3 positionFlex(x.segment(indexes::pos,3));
-        Vector3 velocityFlex(x.segment(indexes::linVel,3));
-        Vector3 accelerationFlex(x.segment(indexes::linAcc,3));
-
-        Vector3 orientationFlexV(x.segment(indexes::ori,3));
-        Vector3 angularVelocityFlex(x.segment(indexes::angVel,3));
-        Vector3 angularAccelerationFlex(x.segment(indexes::angAcc,3));
-
-        Quaternion qFlex (computeQuaternion_(orientationFlexV));
-        Matrix3 rFlex (qFlex.toRotationMatrix());
-
-
-        assertInputVector_(u);
-
-        Vector3 positionControl(u.segment(indexes::pos,3));
-        Vector3 velocityControl(u.segment(indexes::linVel,3));
-        Vector3 accelerationControl(u.segment(indexes::linAcc,3));
-
-        Vector3 orientationControlV(u.segment(indexes::ori,3));
-        Vector3 angularVelocityControl(u.segment(indexes::angVel,3));
-
-        Quaternion qControl(computeQuaternion_(orientationControlV));
-
-        Quaternion q = qFlex * qControl;
-
-        Vector3 acceleration
-        (
-            (kine::skewSymmetric(angularAccelerationFlex) + tools::square(kine::skewSymmetric(angularVelocityFlex)))*
-                rFlex * positionControl
-            + 2*kine::skewSymmetric(angularVelocityFlex) * rFlex * velocityControl
-            + accelerationFlex
-            + rFlex * accelerationControl
-        );
-
-        Vector3 angularVelocity( angularVelocityFlex + rFlex * angularVelocityControl);
-        Vector v(Vector::Zero(10,1));
-
-
-        v.head<4>() = q.coeffs();
-
-        v.segment(4,3)=acceleration;
-        v.tail(3)=angularVelocity;
-
-        sensor_.setState(v,k);
-
-        Vector y (Matrix::Zero(measurementSize_,1));
-
-        y.head(sensor_.getMeasurementSize()) = sensor_.getMeasurements();
-
-        for (unsigned i=0; i<contactPositions_.size();++i)
-        {
-            y.segment(sensor_.getMeasurementSize()+i*3,3)=
-                rFlex * contactPositions_[i] + positionFlex - contactPositions_[i];
-        }
-
-        return y;
-    }
-
-    void IMUFixedContactDynamicalSystem::setProcessNoise(NoiseBase * n)
-    {
-        processNoise_=n;
-    }
-
-    void IMUFixedContactDynamicalSystem::resetProcessNoise()
-    {
-        processNoise_=0x0;
-    }
-
-    void IMUFixedContactDynamicalSystem::setMeasurementNoise
-                ( NoiseBase * n)
-    {
-        sensor_.setNoise(n);
-    }
-
-    void IMUFixedContactDynamicalSystem::resetMeasurementNoise()
-    {
-        sensor_.resetNoise();
-    }
-
-    void IMUFixedContactDynamicalSystem::setSamplingPeriod(double dt)
-    {
-        dt_=dt;
-    }
-
-    Index IMUFixedContactDynamicalSystem::getStateSize() const
-    {
-        return stateSize_;
-    }
-
-    Index IMUFixedContactDynamicalSystem::getInputSize() const
-    {
-        return inputSize_;
-    }
-
-    Index IMUFixedContactDynamicalSystem::getMeasurementSize() const
-    {
-        return measurementSize_;
-    }
-
-    NoiseBase * IMUFixedContactDynamicalSystem::getProcessNoise() const
-    {
-        return processNoise_;
-    }
-
-    NoiseBase * IMUFixedContactDynamicalSystem::getMeasurementNoise() const
-    {
-        return sensor_.getNoise();
-    }
-
-    void IMUFixedContactDynamicalSystem::setContactsNumber(unsigned i)
-    {
-        measurementSize_ = measurementSizeBase_ + 3 * i;
-        contactPositions_.resize(i, Vector3::Zero());
-    }
-
-    void IMUFixedContactDynamicalSystem::setContactPosition
-                                        (unsigned i, const Vector3 & position)
-    {
-        BOOST_ASSERT( i< contactPositions_.size() &&
-                    "ERROR: The index of contact is out of range.");
-
-        contactPositions_[i] = position;
-    }
+  std::cout << std::endl << "IMUFixedContactDynamicalSystem Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
 }
+
+IMUFixedContactDynamicalSystem::~IMUFixedContactDynamicalSystem()
+{
+  // dtor
 }
+
+Vector IMUFixedContactDynamicalSystem::stateDynamics(const Vector & x, const Vector &, TimeIndex)
+{
+  assertStateVector_(x);
+
+  Vector3 positionFlex(x.segment(indexes::pos, 3));
+  Vector3 velocityFlex(x.segment(indexes::linVel, 3));
+  Vector3 accelerationFlex(x.segment(indexes::linAcc, 3));
+
+  Vector3 orientationFlexV(x.segment(indexes::ori, 3));
+  Vector3 angularVelocityFlex(x.segment(indexes::angVel, 3));
+  Vector3 angularAccelerationFlex(x.segment(indexes::angAcc, 3));
+
+  Quaternion orientationFlex(computeQuaternion_(orientationFlexV));
+
+  kine::integrateKinematics(positionFlex, velocityFlex, accelerationFlex, orientationFlex, angularVelocityFlex,
+                            angularAccelerationFlex, dt_);
+
+  // x_{k+1}
+  Vector xk1(x);
+
+  xk1.segment(indexes::pos, 3) = positionFlex;
+  xk1.segment(indexes::linVel, 3) = velocityFlex;
+
+  AngleAxis orientationAA(orientationFlex);
+  orientationFlexV = orientationAA.angle() * orientationAA.axis();
+
+  xk1.segment(indexes::ori, 3) = orientationFlexV;
+  xk1.segment(indexes::angVel, 3) = angularVelocityFlex;
+
+  if(processNoise_ != 0x0)
+    return processNoise_->getNoisy(xk1);
+  else
+    return xk1;
+}
+
+Quaternion IMUFixedContactDynamicalSystem::computeQuaternion_(const Vector3 & x)
+{
+  if(orientationVector_ != x)
+  {
+    orientationVector_ = x;
+    quaternion_ = kine::rotationVectorToAngleAxis(x);
+  }
+
+  return quaternion_;
+}
+
+Vector IMUFixedContactDynamicalSystem::measureDynamics(const Vector & x, const Vector & u, TimeIndex k)
+{
+  assertStateVector_(x);
+
+  Vector3 positionFlex(x.segment(indexes::pos, 3));
+  Vector3 velocityFlex(x.segment(indexes::linVel, 3));
+  Vector3 accelerationFlex(x.segment(indexes::linAcc, 3));
+
+  Vector3 orientationFlexV(x.segment(indexes::ori, 3));
+  Vector3 angularVelocityFlex(x.segment(indexes::angVel, 3));
+  Vector3 angularAccelerationFlex(x.segment(indexes::angAcc, 3));
+
+  Quaternion qFlex(computeQuaternion_(orientationFlexV));
+  Matrix3 rFlex(qFlex.toRotationMatrix());
+
+  assertInputVector_(u);
+
+  Vector3 positionControl(u.segment(indexes::pos, 3));
+  Vector3 velocityControl(u.segment(indexes::linVel, 3));
+  Vector3 accelerationControl(u.segment(indexes::linAcc, 3));
+
+  Vector3 orientationControlV(u.segment(indexes::ori, 3));
+  Vector3 angularVelocityControl(u.segment(indexes::angVel, 3));
+
+  Quaternion qControl(computeQuaternion_(orientationControlV));
+
+  Quaternion q = qFlex * qControl;
+
+  Vector3 acceleration(
+      (kine::skewSymmetric(angularAccelerationFlex) + tools::square(kine::skewSymmetric(angularVelocityFlex))) * rFlex
+          * positionControl
+      + 2 * kine::skewSymmetric(angularVelocityFlex) * rFlex * velocityControl + accelerationFlex
+      + rFlex * accelerationControl);
+
+  Vector3 angularVelocity(angularVelocityFlex + rFlex * angularVelocityControl);
+  Vector v(Vector::Zero(10, 1));
+
+  v.head<4>() = q.coeffs();
+
+  v.segment(4, 3) = acceleration;
+  v.tail(3) = angularVelocity;
+
+  sensor_.setState(v, k);
+
+  Vector y(Matrix::Zero(measurementSize_, 1));
+
+  y.head(sensor_.getMeasurementSize()) = sensor_.getMeasurements();
+
+  for(unsigned i = 0; i < contactPositions_.size(); ++i)
+  {
+    y.segment(sensor_.getMeasurementSize() + i * 3, 3) =
+        rFlex * contactPositions_[i] + positionFlex - contactPositions_[i];
+  }
+
+  return y;
+}
+
+void IMUFixedContactDynamicalSystem::setProcessNoise(NoiseBase * n)
+{
+  processNoise_ = n;
+}
+
+void IMUFixedContactDynamicalSystem::resetProcessNoise()
+{
+  processNoise_ = 0x0;
+}
+
+void IMUFixedContactDynamicalSystem::setMeasurementNoise(NoiseBase * n)
+{
+  sensor_.setNoise(n);
+}
+
+void IMUFixedContactDynamicalSystem::resetMeasurementNoise()
+{
+  sensor_.resetNoise();
+}
+
+void IMUFixedContactDynamicalSystem::setSamplingPeriod(double dt)
+{
+  dt_ = dt;
+}
+
+Index IMUFixedContactDynamicalSystem::getStateSize() const
+{
+  return stateSize_;
+}
+
+Index IMUFixedContactDynamicalSystem::getInputSize() const
+{
+  return inputSize_;
+}
+
+Index IMUFixedContactDynamicalSystem::getMeasurementSize() const
+{
+  return measurementSize_;
+}
+
+NoiseBase * IMUFixedContactDynamicalSystem::getProcessNoise() const
+{
+  return processNoise_;
+}
+
+NoiseBase * IMUFixedContactDynamicalSystem::getMeasurementNoise() const
+{
+  return sensor_.getNoise();
+}
+
+void IMUFixedContactDynamicalSystem::setContactsNumber(unsigned i)
+{
+  measurementSize_ = measurementSizeBase_ + 3 * i;
+  contactPositions_.resize(i, Vector3::Zero());
+}
+
+void IMUFixedContactDynamicalSystem::setContactPosition(unsigned i, const Vector3 & position)
+{
+  BOOST_ASSERT(i < contactPositions_.size() && "ERROR: The index of contact is out of range.");
+
+  contactPositions_[i] = position;
+}
+} // namespace flexibilityEstimation
+} // namespace stateObservation

--- a/src/imu-magnetometer-dynamical-system.cpp
+++ b/src/imu-magnetometer-dynamical-system.cpp
@@ -1,148 +1,142 @@
 #include <state-observation/dynamical-system/imu-magnetometer-dynamical-system.hpp>
 
-
 #include <state-observation/tools/miscellaneous-algorithms.hpp>
 
 namespace stateObservation
 {
 
-    IMUMagnetometerDynamicalSystem::IMUMagnetometerDynamicalSystem()
-    :processNoise_(0x0),dt_(1),orientationVector_(Vector3::Zero()),
-        quaternion_(Quaternion::Identity())
-    {
+IMUMagnetometerDynamicalSystem::IMUMagnetometerDynamicalSystem()
+: processNoise_(0x0), dt_(1), orientationVector_(Vector3::Zero()), quaternion_(Quaternion::Identity())
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-       std::cout<<std::endl<<"IMUFixedContactDynamicalSystem Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
-        //ctor
-    }
-
-    IMUMagnetometerDynamicalSystem::~IMUMagnetometerDynamicalSystem()
-    {
-        //dtor
-    }
-
-    Vector IMUMagnetometerDynamicalSystem::stateDynamics
-        (const Vector& x, const Vector& , TimeIndex)
-    {
-        assertStateVector_(x);
-
-        Vector3 position=x.segment(indexes::pos,3);
-        Vector3 velocity=x.segment(indexes::linVel,3);
-        Vector3 acceleration=x.segment(indexes::linAcc,3);
-
-        Vector3 orientationV=x.segment(indexes::ori,3);
-        Vector3 angularVelocity=x.segment(indexes::angVel,3);
-        Vector3 angularAcceleration=x.segment(indexes::angAcc,3);
-
-        Quaternion orientation=computeQuaternion_(orientationV);
-
-        kine::integrateKinematics
-                (position, velocity, acceleration, orientation, angularVelocity,
-                        angularAcceleration, dt_);
-
-        //x_{k+1}
-        Vector xk1=Vector::Zero(18,1);
-
-        xk1.segment(indexes::pos,3) = position;
-        xk1.segment(indexes::linVel,3) = velocity;
-
-        AngleAxis orientationAA(orientation);
-
-        orientationV=orientationAA.angle()*orientationAA.axis();
-
-        xk1.segment(indexes::ori,3) =  orientationV;
-        xk1.segment(indexes::angVel,3) = angularVelocity;
-
-        xk1.segment(indexes::linAcc,3).setZero();
-        xk1.segment(indexes::angAcc,3).setZero();
-
-        if (processNoise_!=0x0)
-            return processNoise_->getNoisy(xk1);
-        else
-            return xk1;
-
-    }
-
-    Quaternion IMUMagnetometerDynamicalSystem::computeQuaternion_(const Vector3 & x)
-    {
-        if (orientationVector_!=x)
-        {
-            quaternion_ = kine::rotationVectorToAngleAxis(x);
-            orientationVector_=x;
-        }
-
-        return quaternion_;
-    }
-
-    Vector IMUMagnetometerDynamicalSystem::measureDynamics (const Vector& x, const Vector& , TimeIndex k)
-    {
-        assertStateVector_(x);
-
-        Vector3 acceleration=x.segment(indexes::linAcc,3);
-
-        Vector3 orientationV=x.segment(indexes::ori,3);
-        Vector3 angularVelocity=x.segment(indexes::angVel,3);
-
-        Quaternion q=computeQuaternion_(orientationV);
-
-        Vector v=Vector::Zero(10,1);
-
-        v.head<4>() = q.coeffs();
-
-        v.segment(4,3)=acceleration;
-        v.tail(3)=angularVelocity;
-
-        sensor_.setState(v,k);
-
-        return sensor_.getMeasurements();
-    }
-
-    void IMUMagnetometerDynamicalSystem::setProcessNoise( NoiseBase * n)
-    {
-        processNoise_=n;
-    }
-
-    void IMUMagnetometerDynamicalSystem::resetProcessNoise()
-    {
-        processNoise_=0x0;
-    }
-
-    void IMUMagnetometerDynamicalSystem::setMeasurementNoise( NoiseBase * n)
-    {
-        sensor_.setNoise(n);
-    }
-    void IMUMagnetometerDynamicalSystem::resetMeasurementNoise()
-    {
-        sensor_.resetNoise();
-    }
-
-    void IMUMagnetometerDynamicalSystem::setSamplingPeriod(double dt)
-    {
-        dt_=dt;
-    }
-
-    Index IMUMagnetometerDynamicalSystem::getStateSize() const
-    {
-        return stateSize_;
-    }
-
-    Index IMUMagnetometerDynamicalSystem::getInputSize() const
-    {
-        return inputSize_;
-    }
-
-    Index IMUMagnetometerDynamicalSystem::getMeasurementSize() const
-    {
-        return measurementSize_;
-    }
-
-    NoiseBase * IMUMagnetometerDynamicalSystem::getProcessNoise() const
-    {
-        return processNoise_;
-    }
-
-    NoiseBase * IMUMagnetometerDynamicalSystem::getMeasurementNoise() const
-    {
-        return sensor_.getNoise();
-    }
+  std::cout << std::endl << "IMUFixedContactDynamicalSystem Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+       // ctor
 }
+
+IMUMagnetometerDynamicalSystem::~IMUMagnetometerDynamicalSystem()
+{
+  // dtor
+}
+
+Vector IMUMagnetometerDynamicalSystem::stateDynamics(const Vector & x, const Vector &, TimeIndex)
+{
+  assertStateVector_(x);
+
+  Vector3 position = x.segment(indexes::pos, 3);
+  Vector3 velocity = x.segment(indexes::linVel, 3);
+  Vector3 acceleration = x.segment(indexes::linAcc, 3);
+
+  Vector3 orientationV = x.segment(indexes::ori, 3);
+  Vector3 angularVelocity = x.segment(indexes::angVel, 3);
+  Vector3 angularAcceleration = x.segment(indexes::angAcc, 3);
+
+  Quaternion orientation = computeQuaternion_(orientationV);
+
+  kine::integrateKinematics(position, velocity, acceleration, orientation, angularVelocity, angularAcceleration, dt_);
+
+  // x_{k+1}
+  Vector xk1 = Vector::Zero(18, 1);
+
+  xk1.segment(indexes::pos, 3) = position;
+  xk1.segment(indexes::linVel, 3) = velocity;
+
+  AngleAxis orientationAA(orientation);
+
+  orientationV = orientationAA.angle() * orientationAA.axis();
+
+  xk1.segment(indexes::ori, 3) = orientationV;
+  xk1.segment(indexes::angVel, 3) = angularVelocity;
+
+  xk1.segment(indexes::linAcc, 3).setZero();
+  xk1.segment(indexes::angAcc, 3).setZero();
+
+  if(processNoise_ != 0x0)
+    return processNoise_->getNoisy(xk1);
+  else
+    return xk1;
+}
+
+Quaternion IMUMagnetometerDynamicalSystem::computeQuaternion_(const Vector3 & x)
+{
+  if(orientationVector_ != x)
+  {
+    quaternion_ = kine::rotationVectorToAngleAxis(x);
+    orientationVector_ = x;
+  }
+
+  return quaternion_;
+}
+
+Vector IMUMagnetometerDynamicalSystem::measureDynamics(const Vector & x, const Vector &, TimeIndex k)
+{
+  assertStateVector_(x);
+
+  Vector3 acceleration = x.segment(indexes::linAcc, 3);
+
+  Vector3 orientationV = x.segment(indexes::ori, 3);
+  Vector3 angularVelocity = x.segment(indexes::angVel, 3);
+
+  Quaternion q = computeQuaternion_(orientationV);
+
+  Vector v = Vector::Zero(10, 1);
+
+  v.head<4>() = q.coeffs();
+
+  v.segment(4, 3) = acceleration;
+  v.tail(3) = angularVelocity;
+
+  sensor_.setState(v, k);
+
+  return sensor_.getMeasurements();
+}
+
+void IMUMagnetometerDynamicalSystem::setProcessNoise(NoiseBase * n)
+{
+  processNoise_ = n;
+}
+
+void IMUMagnetometerDynamicalSystem::resetProcessNoise()
+{
+  processNoise_ = 0x0;
+}
+
+void IMUMagnetometerDynamicalSystem::setMeasurementNoise(NoiseBase * n)
+{
+  sensor_.setNoise(n);
+}
+void IMUMagnetometerDynamicalSystem::resetMeasurementNoise()
+{
+  sensor_.resetNoise();
+}
+
+void IMUMagnetometerDynamicalSystem::setSamplingPeriod(double dt)
+{
+  dt_ = dt;
+}
+
+Index IMUMagnetometerDynamicalSystem::getStateSize() const
+{
+  return stateSize_;
+}
+
+Index IMUMagnetometerDynamicalSystem::getInputSize() const
+{
+  return inputSize_;
+}
+
+Index IMUMagnetometerDynamicalSystem::getMeasurementSize() const
+{
+  return measurementSize_;
+}
+
+NoiseBase * IMUMagnetometerDynamicalSystem::getProcessNoise() const
+{
+  return processNoise_;
+}
+
+NoiseBase * IMUMagnetometerDynamicalSystem::getMeasurementNoise() const
+{
+  return sensor_.getNoise();
+}
+} // namespace stateObservation

--- a/src/imu-mltpctive-dynamical-system.cpp
+++ b/src/imu-mltpctive-dynamical-system.cpp
@@ -1,217 +1,213 @@
 #include <state-observation/dynamical-system/imu-mltpctive-dynamical-system.hpp>
 
-
 #include <state-observation/tools/miscellaneous-algorithms.hpp>
 
 namespace stateObservation
 {
 
-  IMUMltpctiveDynamicalSystem::IMUMltpctiveDynamicalSystem()
-    :opt_(stateTangentSize_,measurementSize_),processNoise_(0x0),dt_(1)
-  {
+IMUMltpctiveDynamicalSystem::IMUMltpctiveDynamicalSystem()
+: opt_(stateTangentSize_, measurementSize_), processNoise_(0x0), dt_(1)
+{
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
-    std::cout<<std::endl<<"IMUFixedContactDynamicalSystem Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
-    //ctor
-  }
-
-  IMUMltpctiveDynamicalSystem::~IMUMltpctiveDynamicalSystem()
-  {
-    //dtor
-  }
-
-  Vector IMUMltpctiveDynamicalSystem::stateDynamics
-  (const Vector& x, const Vector& u, TimeIndex)
-  {
-    assertStateVector_(x);
-    assertInputVector_(u);
-
-    Vector3 position=x.segment(indexes::pos,3);
-    Vector3 velocity=x.segment(indexes::linVel,3);
-    Vector3 acceleration=x.segment(indexes::linAcc,3);
-
-    Quaternion orientation(x.segment<4>(indexes::ori));
-    Vector3 angularVelocity=x.segment(indexes::angVel,3);
-    Vector3 angularAcceleration=x.segment(indexes::angAcc,3);
-
-
-    kine::integrateKinematics
-    (position, velocity, acceleration, orientation, angularVelocity,
-     angularAcceleration, dt_);
-
-    double norm2 = orientation.squaredNorm();
-
-    if (norm2>1+kine::quatNormTol || norm2<1-kine::quatNormTol)
-    {
-      orientation.normalize();
-    }
-
-    //x_{k+1}
-    Vector xk1=Vector::Zero(indexes::size,1);
-
-    xk1.segment(indexes::pos,3) = position;
-    xk1.segment(indexes::linVel,3) = velocity;
-
-    xk1.segment<4>(indexes::ori) = orientation.coeffs();
-
-    xk1.segment(indexes::angVel,3) = angularVelocity;
-
-
-    //inputs
-    Vector3 accelerationInput =u.head(3);
-    Vector3 angularAccelerationInput =u.tail(3);
-
-    xk1.segment<3>(indexes::linAcc)=accelerationInput;
-    xk1.segment<3>(indexes::angAcc)=angularAccelerationInput;
-
-    if (processNoise_!=0x0)
-      return processNoise_->getNoisy(xk1);
-    else
-      return xk1;
-
-  }
-
-  Vector IMUMltpctiveDynamicalSystem::measureDynamics (const Vector& x, const Vector&, TimeIndex k)
-  {
-    assertStateVector_(x);
-
-    Vector3 acceleration=x.segment(indexes::linAcc,3);
-
-    Quaternion q(x.segment<4>(indexes::ori));
-
-    Vector3 angularVelocity=x.segment(indexes::angVel,3);
-
-
-
-    Vector v=Vector::Zero(10,1);
-
-
-    v.head<4>() = q.coeffs();
-
-    v.segment(4,3)=acceleration;
-    v.tail(3)=angularVelocity;
-
-    sensor_.setState(v,k);
-
-    return sensor_.getMeasurements();
-  }
-
-
-  Matrix IMUMltpctiveDynamicalSystem::getAMatrix (const Vector& xh)
-  {
-
-
-    opt_.deltaR=xh.segment<3>(indexes::angVel)*dt_+xh.segment<3>(indexes::angAcc)*dt_*dt_/2;
-
-    kine::derivateRotationMultiplicative(opt_.deltaR, opt_.jRR, opt_.jRv);
-
-
-    opt_.AJacobian.block<3,3>(indexesTangent::ori,indexesTangent::ori)=opt_.jRR;
-
-
-
-    opt_.AJacobian.block<3,3>(indexesTangent::pos,indexesTangent::linVel).diagonal().setConstant(dt_);
-    opt_.AJacobian.block<3,3>(indexesTangent::ori,indexesTangent::angVel)=opt_.jRv*dt_;
-    opt_.AJacobian.block<6,6>(indexesTangent::linVel,indexesTangent::linAcc).diagonal().setConstant(dt_);
-
-
-    opt_.AJacobian.block< 3, 3>(indexesTangent::pos,indexesTangent::linAcc).diagonal().setConstant(dt_*dt_*0.5);
-    opt_.AJacobian.block< 3, 3>(indexesTangent::ori,indexesTangent::angAcc)=opt_.jRv*dt_*dt_/2;
-
-    return opt_.AJacobian;
-  }
-
-  Matrix IMUMltpctiveDynamicalSystem::getCMatrix (const Vector& xp)
-  {
-    opt_.Rt = Quaternion(xp.segment<4>(indexes::ori)).toRotationMatrix().transpose();
-
-    opt_.CJacobian.block<3,3>(0,indexesTangent::ori).noalias()=
-              opt_.Rt*kine::skewSymmetric(xp.segment<3>(indexes::linAcc)+cst::gravity);
-
-    opt_.CJacobian.block<3,3>(0,indexesTangent::linAcc).noalias()= opt_.Rt;
-
-    opt_.CJacobian.block<3,3>(3,indexesTangent::ori).noalias()=
-              opt_.Rt*kine::skewSymmetric(xp.segment<3>(indexes::angVel));
-
-
-    opt_.CJacobian.block<3,3>(3,indexesTangent::angVel).noalias()= opt_.Rt;
-
-    return opt_.CJacobian;
-  }
-
-
-
-  void IMUMltpctiveDynamicalSystem::setProcessNoise( NoiseBase * n)
-  {
-    processNoise_=n;
-  }
-
-  void IMUMltpctiveDynamicalSystem::resetProcessNoise()
-  {
-    processNoise_=0x0;
-  }
-
-  void IMUMltpctiveDynamicalSystem::setMeasurementNoise( NoiseBase * n)
-  {
-    sensor_.setNoise(n);
-  }
-  void IMUMltpctiveDynamicalSystem::resetMeasurementNoise()
-  {
-    sensor_.resetNoise();
-  }
-
-  void IMUMltpctiveDynamicalSystem::setSamplingPeriod(double dt)
-  {
-    dt_=dt;
-  }
-
-  Index IMUMltpctiveDynamicalSystem::getStateSize() const
-  {
-    return stateSize_;
-  }
-
-  Index IMUMltpctiveDynamicalSystem::getInputSize() const
-  {
-    return inputSize_;
-  }
-
-  Index IMUMltpctiveDynamicalSystem::getMeasurementSize() const
-  {
-    return measurementSize_;
-  }
-
-  NoiseBase * IMUMltpctiveDynamicalSystem::getProcessNoise() const
-  {
-    return processNoise_;
-  }
-
-  NoiseBase * IMUMltpctiveDynamicalSystem::getMeasurementNoise() const
-  {
-    return sensor_.getNoise();
-  }
-
-  void IMUMltpctiveDynamicalSystem::stateSum(const  Vector& stateVector, const Vector& tangentVector, Vector& sum)
-  {
-    sum.resize(indexes::size);
-    sum.segment<3>(indexes::pos) = stateVector.segment<3>(indexes::pos) + tangentVector.segment<3>(indexesTangent::pos);
-    sum.segment<3>(indexes::linVel) = stateVector.segment<3>(indexes::linVel) + tangentVector.segment<3>(indexesTangent::linVel);
-    sum.segment<3>(indexes::linAcc) = stateVector.segment<3>(indexes::linAcc) + tangentVector.segment<3>(indexesTangent::linAcc);
-
-    sum.segment<4>(indexes::ori) = ( kine::rotationVectorToQuaternion(tangentVector.segment<3>(indexesTangent::ori)) * Quaternion(stateVector.segment<4>(indexes::ori))).coeffs();
-    sum.segment<3>(indexes::angVel) = stateVector.segment<3>(indexes::angVel) + tangentVector.segment<3>(indexesTangent::angVel);
-    sum.segment<3>(indexes::angAcc) = stateVector.segment<3>(indexes::angAcc) + tangentVector.segment<3>(indexesTangent::angAcc);
-  }
-
-  void IMUMltpctiveDynamicalSystem::stateDifference(const  Vector& stateVector1, const Vector& stateVector2, Vector& difference)
-  {
-    difference.resize(indexesTangent::size);
-    difference.segment<3>(indexesTangent::pos) = stateVector1.segment<3>(indexes::pos) - stateVector2.segment<3>(indexes::pos);
-    difference.segment<3>(indexesTangent::linVel) = stateVector1.segment<3>(indexes::linVel) - stateVector2.segment<3>(indexes::linVel);
-    difference.segment<3>(indexesTangent::linAcc) = stateVector1.segment<3>(indexes::linAcc) - stateVector2.segment<3>(indexes::linAcc);
-
-    difference.segment<3>(indexesTangent::ori) =  kine::quaternionToRotationVector( Quaternion(stateVector1.segment<4>(indexes::ori))*Quaternion(stateVector2.segment<4>(indexes::ori)).conjugate());
-    difference.segment<3>(indexesTangent::angVel) = stateVector1.segment<3>(indexes::angVel) - stateVector2.segment<3>(indexes::angVel);
-    difference.segment<3>(indexesTangent::angAcc) = stateVector1.segment<3>(indexes::angAcc) - stateVector2.segment<3>(indexes::angAcc);
-  }
-
+  std::cout << std::endl << "IMUFixedContactDynamicalSystem Constructor" << std::endl;
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+  // ctor
 }
+
+IMUMltpctiveDynamicalSystem::~IMUMltpctiveDynamicalSystem()
+{
+  // dtor
+}
+
+Vector IMUMltpctiveDynamicalSystem::stateDynamics(const Vector & x, const Vector & u, TimeIndex)
+{
+  assertStateVector_(x);
+  assertInputVector_(u);
+
+  Vector3 position = x.segment(indexes::pos, 3);
+  Vector3 velocity = x.segment(indexes::linVel, 3);
+  Vector3 acceleration = x.segment(indexes::linAcc, 3);
+
+  Quaternion orientation(x.segment<4>(indexes::ori));
+  Vector3 angularVelocity = x.segment(indexes::angVel, 3);
+  Vector3 angularAcceleration = x.segment(indexes::angAcc, 3);
+
+  kine::integrateKinematics(position, velocity, acceleration, orientation, angularVelocity, angularAcceleration, dt_);
+
+  double norm2 = orientation.squaredNorm();
+
+  if(norm2 > 1 + kine::quatNormTol || norm2 < 1 - kine::quatNormTol)
+  {
+    orientation.normalize();
+  }
+
+  // x_{k+1}
+  Vector xk1 = Vector::Zero(indexes::size, 1);
+
+  xk1.segment(indexes::pos, 3) = position;
+  xk1.segment(indexes::linVel, 3) = velocity;
+
+  xk1.segment<4>(indexes::ori) = orientation.coeffs();
+
+  xk1.segment(indexes::angVel, 3) = angularVelocity;
+
+  // inputs
+  Vector3 accelerationInput = u.head(3);
+  Vector3 angularAccelerationInput = u.tail(3);
+
+  xk1.segment<3>(indexes::linAcc) = accelerationInput;
+  xk1.segment<3>(indexes::angAcc) = angularAccelerationInput;
+
+  if(processNoise_ != 0x0)
+    return processNoise_->getNoisy(xk1);
+  else
+    return xk1;
+}
+
+Vector IMUMltpctiveDynamicalSystem::measureDynamics(const Vector & x, const Vector &, TimeIndex k)
+{
+  assertStateVector_(x);
+
+  Vector3 acceleration = x.segment(indexes::linAcc, 3);
+
+  Quaternion q(x.segment<4>(indexes::ori));
+
+  Vector3 angularVelocity = x.segment(indexes::angVel, 3);
+
+  Vector v = Vector::Zero(10, 1);
+
+  v.head<4>() = q.coeffs();
+
+  v.segment(4, 3) = acceleration;
+  v.tail(3) = angularVelocity;
+
+  sensor_.setState(v, k);
+
+  return sensor_.getMeasurements();
+}
+
+Matrix IMUMltpctiveDynamicalSystem::getAMatrix(const Vector & xh)
+{
+
+  opt_.deltaR = xh.segment<3>(indexes::angVel) * dt_ + xh.segment<3>(indexes::angAcc) * dt_ * dt_ / 2;
+
+  kine::derivateRotationMultiplicative(opt_.deltaR, opt_.jRR, opt_.jRv);
+
+  opt_.AJacobian.block<3, 3>(indexesTangent::ori, indexesTangent::ori) = opt_.jRR;
+
+  opt_.AJacobian.block<3, 3>(indexesTangent::pos, indexesTangent::linVel).diagonal().setConstant(dt_);
+  opt_.AJacobian.block<3, 3>(indexesTangent::ori, indexesTangent::angVel) = opt_.jRv * dt_;
+  opt_.AJacobian.block<6, 6>(indexesTangent::linVel, indexesTangent::linAcc).diagonal().setConstant(dt_);
+
+  opt_.AJacobian.block<3, 3>(indexesTangent::pos, indexesTangent::linAcc).diagonal().setConstant(dt_ * dt_ * 0.5);
+  opt_.AJacobian.block<3, 3>(indexesTangent::ori, indexesTangent::angAcc) = opt_.jRv * dt_ * dt_ / 2;
+
+  return opt_.AJacobian;
+}
+
+Matrix IMUMltpctiveDynamicalSystem::getCMatrix(const Vector & xp)
+{
+  opt_.Rt = Quaternion(xp.segment<4>(indexes::ori)).toRotationMatrix().transpose();
+
+  opt_.CJacobian.block<3, 3>(0, indexesTangent::ori).noalias() =
+      opt_.Rt * kine::skewSymmetric(xp.segment<3>(indexes::linAcc) + cst::gravity);
+
+  opt_.CJacobian.block<3, 3>(0, indexesTangent::linAcc).noalias() = opt_.Rt;
+
+  opt_.CJacobian.block<3, 3>(3, indexesTangent::ori).noalias() =
+      opt_.Rt * kine::skewSymmetric(xp.segment<3>(indexes::angVel));
+
+  opt_.CJacobian.block<3, 3>(3, indexesTangent::angVel).noalias() = opt_.Rt;
+
+  return opt_.CJacobian;
+}
+
+void IMUMltpctiveDynamicalSystem::setProcessNoise(NoiseBase * n)
+{
+  processNoise_ = n;
+}
+
+void IMUMltpctiveDynamicalSystem::resetProcessNoise()
+{
+  processNoise_ = 0x0;
+}
+
+void IMUMltpctiveDynamicalSystem::setMeasurementNoise(NoiseBase * n)
+{
+  sensor_.setNoise(n);
+}
+void IMUMltpctiveDynamicalSystem::resetMeasurementNoise()
+{
+  sensor_.resetNoise();
+}
+
+void IMUMltpctiveDynamicalSystem::setSamplingPeriod(double dt)
+{
+  dt_ = dt;
+}
+
+Index IMUMltpctiveDynamicalSystem::getStateSize() const
+{
+  return stateSize_;
+}
+
+Index IMUMltpctiveDynamicalSystem::getInputSize() const
+{
+  return inputSize_;
+}
+
+Index IMUMltpctiveDynamicalSystem::getMeasurementSize() const
+{
+  return measurementSize_;
+}
+
+NoiseBase * IMUMltpctiveDynamicalSystem::getProcessNoise() const
+{
+  return processNoise_;
+}
+
+NoiseBase * IMUMltpctiveDynamicalSystem::getMeasurementNoise() const
+{
+  return sensor_.getNoise();
+}
+
+void IMUMltpctiveDynamicalSystem::stateSum(const Vector & stateVector, const Vector & tangentVector, Vector & sum)
+{
+  sum.resize(indexes::size);
+  sum.segment<3>(indexes::pos) = stateVector.segment<3>(indexes::pos) + tangentVector.segment<3>(indexesTangent::pos);
+  sum.segment<3>(indexes::linVel) =
+      stateVector.segment<3>(indexes::linVel) + tangentVector.segment<3>(indexesTangent::linVel);
+  sum.segment<3>(indexes::linAcc) =
+      stateVector.segment<3>(indexes::linAcc) + tangentVector.segment<3>(indexesTangent::linAcc);
+
+  sum.segment<4>(indexes::ori) = (kine::rotationVectorToQuaternion(tangentVector.segment<3>(indexesTangent::ori))
+                                  * Quaternion(stateVector.segment<4>(indexes::ori)))
+                                     .coeffs();
+  sum.segment<3>(indexes::angVel) =
+      stateVector.segment<3>(indexes::angVel) + tangentVector.segment<3>(indexesTangent::angVel);
+  sum.segment<3>(indexes::angAcc) =
+      stateVector.segment<3>(indexes::angAcc) + tangentVector.segment<3>(indexesTangent::angAcc);
+}
+
+void IMUMltpctiveDynamicalSystem::stateDifference(const Vector & stateVector1,
+                                                  const Vector & stateVector2,
+                                                  Vector & difference)
+{
+  difference.resize(indexesTangent::size);
+  difference.segment<3>(indexesTangent::pos) =
+      stateVector1.segment<3>(indexes::pos) - stateVector2.segment<3>(indexes::pos);
+  difference.segment<3>(indexesTangent::linVel) =
+      stateVector1.segment<3>(indexes::linVel) - stateVector2.segment<3>(indexes::linVel);
+  difference.segment<3>(indexesTangent::linAcc) =
+      stateVector1.segment<3>(indexes::linAcc) - stateVector2.segment<3>(indexes::linAcc);
+
+  difference.segment<3>(indexesTangent::ori) =
+      kine::quaternionToRotationVector(Quaternion(stateVector1.segment<4>(indexes::ori))
+                                       * Quaternion(stateVector2.segment<4>(indexes::ori)).conjugate());
+  difference.segment<3>(indexesTangent::angVel) =
+      stateVector1.segment<3>(indexes::angVel) - stateVector2.segment<3>(indexes::angVel);
+  difference.segment<3>(indexesTangent::angAcc) =
+      stateVector1.segment<3>(indexes::angAcc) - stateVector2.segment<3>(indexes::angAcc);
+}
+
+} // namespace stateObservation

--- a/src/kalman-filter-base.cpp
+++ b/src/kalman-filter-base.cpp
@@ -5,427 +5,410 @@
 #endif
 
 #ifdef VERBOUS_KALMANFILTER
-#include <iostream>
-#include <iomanip>      // std::setprecision
+#  include <iomanip> // std::setprecision
+#  include <iostream>
 #endif // VERBOUS_KALMANFILTER
 
 namespace stateObservation
 {
 
-    KalmanFilterBase::KalmanFilterBase():
-      nt_(0),
-      arithm_(this)
-    {
-    }
+KalmanFilterBase::KalmanFilterBase() : nt_(0), arithm_(this) {}
 
-    KalmanFilterBase::KalmanFilterBase(Index n,Index m,Index p)
-            :ZeroDelayObserver(n,m,p),
-            nt_(n),
-            mt_(m),
-            arithm_(this)
-    {
-    }
+KalmanFilterBase::KalmanFilterBase(Index n, Index m, Index p)
+: ZeroDelayObserver(n, m, p), nt_(n), mt_(m), arithm_(this)
+{
+}
 
-    KalmanFilterBase::KalmanFilterBase(Index n, Index nt, Index m, Index mt, Index p)
-            :ZeroDelayObserver(n,m,p),
-            nt_(nt),
-            mt_(mt),
-            arithm_(this)
-    {
-    }
+KalmanFilterBase::KalmanFilterBase(Index n, Index nt, Index m, Index mt, Index p)
+: ZeroDelayObserver(n, m, p), nt_(nt), mt_(mt), arithm_(this)
+{
+}
 
+void KalmanFilterBase::setA(const Amatrix & A)
+{
+  BOOST_ASSERT(checkAmatrix(A) && "ERROR: The A matrix dimensions are wrong");
+  a_ = A;
+}
 
-    void KalmanFilterBase::setA(const Amatrix& A)
-    {
-        BOOST_ASSERT(checkAmatrix(A)&& "ERROR: The A matrix dimensions are wrong");
-        a_=A;
-    }
+Matrix KalmanFilterBase::getA() const
+{
+  return a_;
+}
 
-    Matrix KalmanFilterBase::getA() const
-    {
-        return a_;
-    }
+void KalmanFilterBase::clearA()
+{
+  a_.resize(0, 0);
+}
 
-    void KalmanFilterBase::clearA()
-    {
-        a_.resize(0,0);
-    }
+void KalmanFilterBase::setC(const Cmatrix & C)
+{
+  BOOST_ASSERT(checkCmatrix(C) && "ERROR: The C matrix dimensions are wrong");
+  c_ = C;
+}
 
-    void KalmanFilterBase::setC( const Cmatrix& C)
-    {
-        BOOST_ASSERT(checkCmatrix(C)&& "ERROR: The C matrix dimensions are wrong");
-        c_=C;
-    }
+void KalmanFilterBase::clearC()
+{
+  c_.resize(0, 0);
+}
 
-    void KalmanFilterBase::clearC()
-    {
-        c_.resize(0,0);
-    }
+Matrix KalmanFilterBase::getC() const
+{
+  return c_;
+}
 
-    Matrix KalmanFilterBase::getC() const
-    {
-        return c_;
-    }
+void KalmanFilterBase::setR(const Rmatrix & R)
+{
+  BOOST_ASSERT(checkRmatrix(R) && "ERROR: The dimensions of the measurement noise covariance matrix R are wrong");
+  r_ = R;
+}
 
-    void KalmanFilterBase::setR( const Rmatrix& R)
-    {
-        BOOST_ASSERT(checkRmatrix(R)&& "ERROR: The dimensions of the measurement noise covariance matrix R are wrong");
-        r_=R;
-    }
+Matrix KalmanFilterBase::getR() const
+{
+  return r_;
+}
 
-    Matrix KalmanFilterBase::getR() const
-    {
-        return r_;
-    }
+void KalmanFilterBase::clearR()
+{
+  r_.resize(0, 0);
+}
 
-    void KalmanFilterBase::clearR()
-    {
-        r_.resize(0,0);
-    }
+void KalmanFilterBase::setQ(const Qmatrix & Q)
+{
+  BOOST_ASSERT(checkQmatrix(Q) && "ERROR: The dimensions of the process noise covariance matrix Q are wrong");
+  q_ = Q;
+}
 
-    void KalmanFilterBase::setQ( const Qmatrix& Q)
-    {
-        BOOST_ASSERT(checkQmatrix(Q)&& "ERROR: The dimensions of the process noise covariance matrix Q are wrong");
-        q_=Q;
-    }
+Matrix KalmanFilterBase::getQ() const
+{
+  return q_;
+}
 
-    Matrix KalmanFilterBase::getQ() const
-    {
-        return q_;
-    }
+void KalmanFilterBase::clearQ()
+{
+  q_.resize(0, 0);
+}
 
-    void KalmanFilterBase::clearQ()
-    {
-        q_.resize(0,0);
-    }
+void KalmanFilterBase::setStateCovariance(const Pmatrix & P)
+{
+  BOOST_ASSERT(checkPmatrix(P) && "ERROR: The P matrix dimensions are wrong");
+  pr_ = P;
+}
 
-    void KalmanFilterBase::setStateCovariance(const Pmatrix& P)
-    {
-        BOOST_ASSERT(checkPmatrix(P)&& "ERROR: The P matrix dimensions are wrong");
-        pr_=P;
-    }
+void KalmanFilterBase::clearStateCovariance()
+{
+  pr_.resize(0, 0);
+}
 
-    void KalmanFilterBase::clearStateCovariance()
-    {
-        pr_.resize(0,0);
-    }
+ObserverBase::StateVector KalmanFilterBase::oneStepEstimation_()
+{
+  TimeIndex k = this->x_.getTime();
 
-    ObserverBase::StateVector KalmanFilterBase::oneStepEstimation_()
-    {
-        TimeIndex k=this->x_.getTime();
+  BOOST_ASSERT(this->y_.size() > 0 && this->y_.checkIndex(k + 1) && "ERROR: The measurement vector is not set");
 
-        BOOST_ASSERT(this->y_.size()> 0 && this->y_.checkIndex(k+1) && "ERROR: The measurement vector is not set");
+  BOOST_ASSERT(checkAmatrix(a_) && "ERROR: The Matrix A is not initialized");
+  BOOST_ASSERT(checkCmatrix(c_) && "ERROR: The Matrix C is not initialized");
+  BOOST_ASSERT(checkQmatrix(q_) && "ERROR: The Matrix Q is not initialized");
+  BOOST_ASSERT(checkRmatrix(r_) && "ERROR: The Matrix R is not initialized");
+  BOOST_ASSERT(checkPmatrix(pr_) && "ERROR: The Matrix P is not initialized");
 
-        BOOST_ASSERT(checkAmatrix(a_) && "ERROR: The Matrix A is not initialized" );
-        BOOST_ASSERT(checkCmatrix(c_) && "ERROR: The Matrix C is not initialized");
-        BOOST_ASSERT(checkQmatrix(q_) && "ERROR: The Matrix Q is not initialized");
-        BOOST_ASSERT(checkRmatrix(r_) && "ERROR: The Matrix R is not initialized");
-        BOOST_ASSERT(checkPmatrix(pr_) && "ERROR: The Matrix P is not initialized");
+  // prediction
+  updateStateAndMeasurementPrediction(); // runs also updatePrediction_();
+  oc_.pbar.noalias() = q_ + a_ * (pr_ * a_.transpose());
 
-        //prediction
-        updateStateAndMeasurementPrediction();// runs also updatePrediction_();
-        oc_.pbar.noalias()=q_ +a_*(pr_*a_.transpose());
+  // innovation Measurements
+  arithm_->measurementDifference(this->y_[k + 1], ybar_(), oc_.inoMeas);
+  oc_.inoMeasCov.noalias() = r_ + c_ * (oc_.pbar * c_.transpose());
 
+  Index & measurementTangentSize = mt_;
+  // inversing innovation measurement covariance matrix
+  oc_.inoMeasCovLLT.compute(oc_.inoMeasCov);
+  oc_.inoMeasCovInverse.resize(measurementTangentSize, measurementTangentSize);
+  oc_.inoMeasCovInverse.setIdentity();
+  oc_.inoMeasCovLLT.matrixL().solveInPlace(oc_.inoMeasCovInverse);
+  oc_.inoMeasCovLLT.matrixL().transpose().solveInPlace(oc_.inoMeasCovInverse);
 
-        //innovation Measurements
-        arithm_->measurementDifference(this->y_[k+1], ybar_(),oc_.inoMeas);
-        oc_.inoMeasCov.noalias() = r_ +  c_ * (oc_.pbar * c_.transpose());
+  // innovation
+  oc_.kGain.noalias() = oc_.pbar * (c_.transpose() * oc_.inoMeasCovInverse);
+  innovation_.noalias() = oc_.kGain * oc_.inoMeas;
 
-        Index &  measurementTangentSize =mt_;
-        //inversing innovation measurement covariance matrix
-        oc_.inoMeasCovLLT.compute(oc_.inoMeasCov);
-        oc_.inoMeasCovInverse.resize(measurementTangentSize,measurementTangentSize);
-        oc_.inoMeasCovInverse.setIdentity();
-        oc_.inoMeasCovLLT.matrixL().solveInPlace(oc_.inoMeasCovInverse);
-        oc_.inoMeasCovLLT.matrixL().transpose().solveInPlace(oc_.inoMeasCovInverse);
+  // update
 
-        //innovation
-        oc_.kGain.noalias() = oc_.pbar * (c_.transpose() * oc_.inoMeasCovInverse);
-        innovation_.noalias() = oc_.kGain*oc_.inoMeas;
-
-        //update
-
-        arithm_->stateSum(xbar_(),innovation_,oc_.xhat);
+  arithm_->stateSum(xbar_(), innovation_, oc_.xhat);
 
 #ifdef VERBOUS_KALMANFILTER
-        Eigen::IOFormat CleanFmt(2, 0, " ", "\n", "", "");
-        std::cout <<"A" <<std::endl<< a_.format(CleanFmt)<<std::endl;
-        std::cout <<"C" <<std::endl<< c_.format(CleanFmt)<<std::endl;
-        std::cout <<"P" <<std::endl<< pr_.format(CleanFmt)<<std::endl;
-        std::cout <<"K" <<std::endl<< oc_.kGain.format(CleanFmt)<<std::endl;
-        std::cout <<"Xbar" <<std::endl<< xbar().transpose().format(CleanFmt)<<std::endl;
-        std::cout <<"inoMeasCov" <<std::endl<< oc_.inoMeasCov.format(CleanFmt)<<std::endl;
-        std::cout <<"oc_.pbar" <<std::endl<< (oc_.pbar).format(CleanFmt)<<std::endl;
-        std::cout <<"c_ * (oc_.pbar * c_.transpose())" <<std::endl<< ( c_ * (oc_.pbar * c_.transpose())).format(CleanFmt)<<std::endl;
-        std::cout <<"inoMeasCovInverse" <<std::endl<< oc_.inoMeasCovInverse.format(CleanFmt)<<std::endl;
-        std::cout <<"predictedMeasurement " <<std::endl<<  ybar_().transpose().format(CleanFmt)<<std::endl;
-        std::cout <<"inoMeas" <<std::endl<< oc_.inoMeas.transpose().format(CleanFmt)<<std::endl;
-        std::cout <<"inovation_" <<std::endl<< inovation_.transpose().format(CleanFmt)<<std::endl;
-        std::cout <<"Xhat" <<std::endl<< oc_.xhat.transpose().format(CleanFmt)<<std::endl;
+  Eigen::IOFormat CleanFmt(2, 0, " ", "\n", "", "");
+  std::cout << "A" << std::endl << a_.format(CleanFmt) << std::endl;
+  std::cout << "C" << std::endl << c_.format(CleanFmt) << std::endl;
+  std::cout << "P" << std::endl << pr_.format(CleanFmt) << std::endl;
+  std::cout << "K" << std::endl << oc_.kGain.format(CleanFmt) << std::endl;
+  std::cout << "Xbar" << std::endl << xbar().transpose().format(CleanFmt) << std::endl;
+  std::cout << "inoMeasCov" << std::endl << oc_.inoMeasCov.format(CleanFmt) << std::endl;
+  std::cout << "oc_.pbar" << std::endl << (oc_.pbar).format(CleanFmt) << std::endl;
+  std::cout << "c_ * (oc_.pbar * c_.transpose())" << std::endl
+            << (c_ * (oc_.pbar * c_.transpose())).format(CleanFmt) << std::endl;
+  std::cout << "inoMeasCovInverse" << std::endl << oc_.inoMeasCovInverse.format(CleanFmt) << std::endl;
+  std::cout << "predictedMeasurement " << std::endl << ybar_().transpose().format(CleanFmt) << std::endl;
+  std::cout << "inoMeas" << std::endl << oc_.inoMeas.transpose().format(CleanFmt) << std::endl;
+  std::cout << "inovation_" << std::endl << inovation_.transpose().format(CleanFmt) << std::endl;
+  std::cout << "Xhat" << std::endl << oc_.xhat.transpose().format(CleanFmt) << std::endl;
 #endif // VERBOUS_KALMANFILTER
 
-        this->x_.set(oc_.xhat,k+1);
-        pr_.noalias() = -oc_.kGain*c_;
-        pr_.diagonal().array()+=1;
-        pr_ *= oc_.pbar;
+  this->x_.set(oc_.xhat, k + 1);
+  pr_.noalias() = -oc_.kGain * c_;
+  pr_.diagonal().array() += 1;
+  pr_ *= oc_.pbar;
 
-        // simmetrize the pr_ matrix
-        pr_=(pr_+pr_.transpose())*0.5;
+  // simmetrize the pr_ matrix
+  pr_ = (pr_ + pr_.transpose()) * 0.5;
 
-        return oc_.xhat;
-    }
-
-    KalmanFilterBase::Pmatrix KalmanFilterBase::getStateCovariance() const
-    {
-        return pr_;
-    }
-
-    void KalmanFilterBase::reset()
-    {
-        ZeroDelayObserver::reset();
-
-        clearA();
-        clearC();
-        clearQ();
-        clearR();
-        clearStateCovariance();
-    }
-
-    KalmanFilterBase::Amatrix KalmanFilterBase::getAmatrixConstant(double c) const
-    {
-        return Amatrix::Constant(nt_,nt_,c);
-    }
-
-    KalmanFilterBase::Amatrix KalmanFilterBase::getAmatrixRandom() const
-    {
-        return Amatrix::Random(nt_,nt_);
-    }
-
-    KalmanFilterBase::Amatrix KalmanFilterBase::getAmatrixZero() const
-    {
-        return Amatrix::Zero(nt_,nt_);
-    }
-
-    KalmanFilterBase::Amatrix KalmanFilterBase::getAmatrixIdentity() const
-    {
-        return Amatrix::Identity(nt_,nt_);
-    }
-
-    bool KalmanFilterBase::checkAmatrix(const Amatrix & a) const
-    {
-        return (a.rows()==nt_ && a.cols()==nt_);
-    }
-
-    KalmanFilterBase::Cmatrix KalmanFilterBase::getCmatrixConstant(double c) const
-    {
-        return Cmatrix::Constant(mt_,nt_,c);
-    }
-
-    KalmanFilterBase::Cmatrix KalmanFilterBase::getCmatrixRandom() const
-    {
-        return Cmatrix::Random(mt_,nt_);
-    }
-
-    KalmanFilterBase::Cmatrix KalmanFilterBase::getCmatrixZero() const
-    {
-        return Cmatrix::Zero(mt_,nt_);
-    }
-
-    bool KalmanFilterBase::checkCmatrix(const Cmatrix & a) const
-    {
-        return (a.rows()==mt_ && a.cols()==nt_);
-    }
-
-    KalmanFilterBase::Qmatrix KalmanFilterBase::getQmatrixConstant(double c) const
-    {
-        return Qmatrix::Constant(nt_,nt_,c);
-    }
-
-    KalmanFilterBase::Qmatrix KalmanFilterBase::getQmatrixRandom() const
-    {
-        return Qmatrix::Random(nt_,nt_);
-    }
-
-    KalmanFilterBase::Qmatrix KalmanFilterBase::getQmatrixZero() const
-    {
-        return Qmatrix::Zero(nt_,nt_);
-    }
-
-    KalmanFilterBase::Qmatrix KalmanFilterBase::getQmatrixIdentity() const
-    {
-        return Qmatrix::Identity(nt_,nt_);
-    }
-
-    bool KalmanFilterBase::checkQmatrix(const Qmatrix & a) const
-    {
-        return (a.rows()==nt_ && a.cols()==nt_);
-    }
-
-    KalmanFilterBase::Rmatrix KalmanFilterBase::getRmatrixConstant(double c) const
-    {
-        return Cmatrix::Constant(mt_,mt_,c);
-    }
-
-    KalmanFilterBase::Rmatrix KalmanFilterBase::getRmatrixRandom() const
-    {
-        return Cmatrix::Random(mt_,mt_);
-    }
-
-    KalmanFilterBase::Rmatrix KalmanFilterBase::getRmatrixZero() const
-    {
-        return Rmatrix::Zero(mt_,mt_);
-    }
-
-    KalmanFilterBase::Rmatrix KalmanFilterBase::getRmatrixIdentity() const
-    {
-        return Rmatrix::Identity(mt_,mt_);
-    }
-
-    bool KalmanFilterBase::checkRmatrix(const Rmatrix & a) const
-    {
-        return (a.rows()==mt_ && a.cols()==mt_);
-    }
-
-    KalmanFilterBase::Pmatrix KalmanFilterBase::getPmatrixConstant(double c) const
-    {
-        return Pmatrix::Constant(nt_,nt_,c);
-    }
-
-    KalmanFilterBase::Pmatrix KalmanFilterBase::getPmatrixRandom() const
-    {
-        return Pmatrix::Random(nt_,nt_);
-    }
-
-    KalmanFilterBase::Pmatrix KalmanFilterBase::getPmatrixZero() const
-    {
-        return Pmatrix::Zero(nt_,nt_);
-    }
-
-    KalmanFilterBase::Pmatrix KalmanFilterBase::getPmatrixIdentity() const
-    {
-        return Pmatrix::Identity(nt_,nt_);
-    }
-
-    bool KalmanFilterBase::checkPmatrix(const Pmatrix & a) const
-    {
-        return (a.rows()==nt_ && a.cols()==nt_);
-    }
-
-
-
-    KalmanFilterBase::StateVectorTan KalmanFilterBase::stateTangentVectorConstant( double c ) const
-    {
-        return StateVectorTan::Constant(nt_,1,c);
-    }
-
-    KalmanFilterBase::StateVectorTan KalmanFilterBase::stateTangentVectorRandom() const
-    {
-        return StateVectorTan::Random(nt_,1);
-    }
-
-    KalmanFilterBase::StateVectorTan KalmanFilterBase::stateTangentVectorZero() const
-    {
-        return StateVectorTan::Zero(nt_,1);
-    }
-
-    bool KalmanFilterBase::checkStateTangentVector(const KalmanFilterBase::StateVectorTan & v) const
-    {
-        return (v.rows()==nt_ && v.cols()==1);
-    }
-
-
-    KalmanFilterBase::MeasureVectorTan KalmanFilterBase::measureTangentVectorConstant( double c ) const
-    {
-        return MeasureVectorTan::Constant(mt_,1,c);
-    }
-
-    KalmanFilterBase::MeasureVectorTan KalmanFilterBase::measureTangentVectorRandom() const
-    {
-        return MeasureVectorTan::Random(mt_,1);
-    }
-
-    KalmanFilterBase::MeasureVectorTan KalmanFilterBase::measureTangentVectorZero() const
-    {
-        return MeasureVectorTan::Zero(mt_,1);
-    }
-
-    bool KalmanFilterBase::checkMeasureTangentVector(const KalmanFilterBase::MeasureVectorTan & v) const
-    {
-        return (v.rows()==mt_ && v.cols()==1);
-    }
-
-
-    void KalmanFilterBase::setStateSize(Index n)
-    {
-        setStateSize(n,n);
-    }
-
-    void KalmanFilterBase::setStateSize(Index n, Index nt)
-    {
-        if ((n!=n_) || (nt_ !=nt))
-        {
-            ZeroDelayObserver::setStateSize(n);
-
-            nt_=nt;
-
-            clearA();
-            clearC();
-            clearQ();
-            clearStateCovariance();
-
-        }
-    }
-
-    void KalmanFilterBase::setMeasureSize(Index m)
-    {
-        setMeasureSize(m,m);
-    }
-
-    void KalmanFilterBase::setMeasureSize(Index m, Index mt)
-    {
-        if ((m!=m_) || mt!=mt_)
-        {
-            mt_=mt;
-            ZeroDelayObserver::setMeasureSize(m);
-            clearC();
-            clearR();
-        }
-    }
-
-    Vector KalmanFilterBase::getSimulatedMeasurement(TimeIndex k)
-    {
-        return simulateSensor_(getEstimatedState(k),k);
-    }
-
-    Vector KalmanFilterBase::getInnovation()
-    {
-        return innovation_;
-    }
-
-    Vector KalmanFilterBase::getLastPrediction() const
-    {
-        return xbar_();
-    }
-
-    Vector KalmanFilterBase::getLastPredictedMeasurement() const
-    {
-        return ybar_();
-    }
-
-    Matrix KalmanFilterBase::getLastGain() const
-    {
-        return oc_.kGain;
-    }
-
-    Vector KalmanFilterBase::predictSensor_(TimeIndex k)
-    {
-        return ybar_.set(simulateSensor_(xbar_(),k),k);
-    }
-
-
-    void KalmanFilterBase::setStateArithmetics(StateVectorArithmetics * a)
-    {
-        arithm_ = a;
-    }
-
+  return oc_.xhat;
 }
+
+KalmanFilterBase::Pmatrix KalmanFilterBase::getStateCovariance() const
+{
+  return pr_;
+}
+
+void KalmanFilterBase::reset()
+{
+  ZeroDelayObserver::reset();
+
+  clearA();
+  clearC();
+  clearQ();
+  clearR();
+  clearStateCovariance();
+}
+
+KalmanFilterBase::Amatrix KalmanFilterBase::getAmatrixConstant(double c) const
+{
+  return Amatrix::Constant(nt_, nt_, c);
+}
+
+KalmanFilterBase::Amatrix KalmanFilterBase::getAmatrixRandom() const
+{
+  return Amatrix::Random(nt_, nt_);
+}
+
+KalmanFilterBase::Amatrix KalmanFilterBase::getAmatrixZero() const
+{
+  return Amatrix::Zero(nt_, nt_);
+}
+
+KalmanFilterBase::Amatrix KalmanFilterBase::getAmatrixIdentity() const
+{
+  return Amatrix::Identity(nt_, nt_);
+}
+
+bool KalmanFilterBase::checkAmatrix(const Amatrix & a) const
+{
+  return (a.rows() == nt_ && a.cols() == nt_);
+}
+
+KalmanFilterBase::Cmatrix KalmanFilterBase::getCmatrixConstant(double c) const
+{
+  return Cmatrix::Constant(mt_, nt_, c);
+}
+
+KalmanFilterBase::Cmatrix KalmanFilterBase::getCmatrixRandom() const
+{
+  return Cmatrix::Random(mt_, nt_);
+}
+
+KalmanFilterBase::Cmatrix KalmanFilterBase::getCmatrixZero() const
+{
+  return Cmatrix::Zero(mt_, nt_);
+}
+
+bool KalmanFilterBase::checkCmatrix(const Cmatrix & a) const
+{
+  return (a.rows() == mt_ && a.cols() == nt_);
+}
+
+KalmanFilterBase::Qmatrix KalmanFilterBase::getQmatrixConstant(double c) const
+{
+  return Qmatrix::Constant(nt_, nt_, c);
+}
+
+KalmanFilterBase::Qmatrix KalmanFilterBase::getQmatrixRandom() const
+{
+  return Qmatrix::Random(nt_, nt_);
+}
+
+KalmanFilterBase::Qmatrix KalmanFilterBase::getQmatrixZero() const
+{
+  return Qmatrix::Zero(nt_, nt_);
+}
+
+KalmanFilterBase::Qmatrix KalmanFilterBase::getQmatrixIdentity() const
+{
+  return Qmatrix::Identity(nt_, nt_);
+}
+
+bool KalmanFilterBase::checkQmatrix(const Qmatrix & a) const
+{
+  return (a.rows() == nt_ && a.cols() == nt_);
+}
+
+KalmanFilterBase::Rmatrix KalmanFilterBase::getRmatrixConstant(double c) const
+{
+  return Cmatrix::Constant(mt_, mt_, c);
+}
+
+KalmanFilterBase::Rmatrix KalmanFilterBase::getRmatrixRandom() const
+{
+  return Cmatrix::Random(mt_, mt_);
+}
+
+KalmanFilterBase::Rmatrix KalmanFilterBase::getRmatrixZero() const
+{
+  return Rmatrix::Zero(mt_, mt_);
+}
+
+KalmanFilterBase::Rmatrix KalmanFilterBase::getRmatrixIdentity() const
+{
+  return Rmatrix::Identity(mt_, mt_);
+}
+
+bool KalmanFilterBase::checkRmatrix(const Rmatrix & a) const
+{
+  return (a.rows() == mt_ && a.cols() == mt_);
+}
+
+KalmanFilterBase::Pmatrix KalmanFilterBase::getPmatrixConstant(double c) const
+{
+  return Pmatrix::Constant(nt_, nt_, c);
+}
+
+KalmanFilterBase::Pmatrix KalmanFilterBase::getPmatrixRandom() const
+{
+  return Pmatrix::Random(nt_, nt_);
+}
+
+KalmanFilterBase::Pmatrix KalmanFilterBase::getPmatrixZero() const
+{
+  return Pmatrix::Zero(nt_, nt_);
+}
+
+KalmanFilterBase::Pmatrix KalmanFilterBase::getPmatrixIdentity() const
+{
+  return Pmatrix::Identity(nt_, nt_);
+}
+
+bool KalmanFilterBase::checkPmatrix(const Pmatrix & a) const
+{
+  return (a.rows() == nt_ && a.cols() == nt_);
+}
+
+KalmanFilterBase::StateVectorTan KalmanFilterBase::stateTangentVectorConstant(double c) const
+{
+  return StateVectorTan::Constant(nt_, 1, c);
+}
+
+KalmanFilterBase::StateVectorTan KalmanFilterBase::stateTangentVectorRandom() const
+{
+  return StateVectorTan::Random(nt_, 1);
+}
+
+KalmanFilterBase::StateVectorTan KalmanFilterBase::stateTangentVectorZero() const
+{
+  return StateVectorTan::Zero(nt_, 1);
+}
+
+bool KalmanFilterBase::checkStateTangentVector(const KalmanFilterBase::StateVectorTan & v) const
+{
+  return (v.rows() == nt_ && v.cols() == 1);
+}
+
+KalmanFilterBase::MeasureVectorTan KalmanFilterBase::measureTangentVectorConstant(double c) const
+{
+  return MeasureVectorTan::Constant(mt_, 1, c);
+}
+
+KalmanFilterBase::MeasureVectorTan KalmanFilterBase::measureTangentVectorRandom() const
+{
+  return MeasureVectorTan::Random(mt_, 1);
+}
+
+KalmanFilterBase::MeasureVectorTan KalmanFilterBase::measureTangentVectorZero() const
+{
+  return MeasureVectorTan::Zero(mt_, 1);
+}
+
+bool KalmanFilterBase::checkMeasureTangentVector(const KalmanFilterBase::MeasureVectorTan & v) const
+{
+  return (v.rows() == mt_ && v.cols() == 1);
+}
+
+void KalmanFilterBase::setStateSize(Index n)
+{
+  setStateSize(n, n);
+}
+
+void KalmanFilterBase::setStateSize(Index n, Index nt)
+{
+  if((n != n_) || (nt_ != nt))
+  {
+    ZeroDelayObserver::setStateSize(n);
+
+    nt_ = nt;
+
+    clearA();
+    clearC();
+    clearQ();
+    clearStateCovariance();
+  }
+}
+
+void KalmanFilterBase::setMeasureSize(Index m)
+{
+  setMeasureSize(m, m);
+}
+
+void KalmanFilterBase::setMeasureSize(Index m, Index mt)
+{
+  if((m != m_) || mt != mt_)
+  {
+    mt_ = mt;
+    ZeroDelayObserver::setMeasureSize(m);
+    clearC();
+    clearR();
+  }
+}
+
+Vector KalmanFilterBase::getSimulatedMeasurement(TimeIndex k)
+{
+  return simulateSensor_(getEstimatedState(k), k);
+}
+
+Vector KalmanFilterBase::getInnovation()
+{
+  return innovation_;
+}
+
+Vector KalmanFilterBase::getLastPrediction() const
+{
+  return xbar_();
+}
+
+Vector KalmanFilterBase::getLastPredictedMeasurement() const
+{
+  return ybar_();
+}
+
+Matrix KalmanFilterBase::getLastGain() const
+{
+  return oc_.kGain;
+}
+
+Vector KalmanFilterBase::predictSensor_(TimeIndex k)
+{
+  return ybar_.set(simulateSensor_(xbar_(), k), k);
+}
+
+void KalmanFilterBase::setStateArithmetics(StateVectorArithmetics * a)
+{
+  arithm_ = a;
+}
+
+} // namespace stateObservation

--- a/src/kinetics-observer.cpp
+++ b/src/kinetics-observer.cpp
@@ -1,1655 +1,1634 @@
 /*
-* Copyright (c) 2019-2020
-* @author Mehdi BENALLEGUE
-*
-* National Institute of Advanced Industrial Science and Technology (AIST)
-*/
-
+ * Copyright (c) 2019-2020
+ * @author Mehdi BENALLEGUE
+ *
+ * National Institute of Advanced Industrial Science and Technology (AIST)
+ */
 
 #include <state-observation/dynamics-estimators/kinetics-observer.hpp>
 
-
-
-
-
 namespace stateObservation
 {
-  inline Matrix6 STATE_OBSERVATION_DLLAPI blockMat6(const Matrix3 & m1, const Matrix3 & m2, const Matrix3 & m3, const Matrix3 & m4)
+inline Matrix6 STATE_OBSERVATION_DLLAPI blockMat6(const Matrix3 & m1,
+                                                  const Matrix3 & m2,
+                                                  const Matrix3 & m3,
+                                                  const Matrix3 & m4)
+{
+  Matrix6 m;
+  m << m1, m2, m3, m4;
+
+  return m;
+}
+
+/// resets one block on the diagonal of the state Covariance Matrix
+/// i.e. sets value of a square block on the diagonal of the covMat
+/// and sets to zero all the values related to their lines and columns
+template<int blockSize>
+void STATE_OBSERVATION_DLLAPI setBlockStateCovariance(Matrix & covMat, const Matrix & covBlock, int blockIndex)
+{
+  long int matrixSize = covMat.rows();
+  covMat.block<blockSize, blockSize>(blockIndex, blockIndex) = covBlock;
+  covMat.block(blockIndex, 0, blockSize, blockIndex).setZero();
+  covMat.block(0, blockIndex, blockIndex, blockSize).setZero();
+  covMat.block(blockIndex + blockSize, blockIndex, matrixSize - blockIndex - blockSize, blockSize).setZero();
+  covMat.block(blockIndex, blockIndex + blockSize, blockSize, matrixSize - blockIndex - blockSize).setZero();
+}
+
+inline void STATE_OBSERVATION_DLLAPI
+    fillSymmetricMatrix(Matrix3 & m, const Vector3 & vdiag, double e1, double e2, double e3)
+{
+  m.diagonal() = vdiag;
+  m(1, 0) = m(0, 1) = e1;
+  m(2, 0) = m(0, 2) = e2;
+  m(2, 1) = m(1, 2) = e3;
+}
+
+const double KineticsObserver::defaultMass = 50;
+
+const double KineticsObserver::statePoseInitVarianceDefault = 1e-4;
+const double KineticsObserver::stateOriInitVarianceDefault = 1e-4;
+const double KineticsObserver::stateLinVelInitVarianceDefault = 1e-6;
+const double KineticsObserver::stateAngVelInitVarianceDefault = 1e-6;
+const double KineticsObserver::gyroBiasInitVarianceDefault = 1e-10;
+const double KineticsObserver::unmodeledWrenchInitVarianceDefault = 1e100;
+const double KineticsObserver::contactForceInitVarianceDefault = 1e100;
+const double KineticsObserver::contactTorqueInitVarianceDefault = 1e100;
+
+const double KineticsObserver::statePoseProcessVarianceDefault = 1e-8;
+const double KineticsObserver::stateOriProcessVarianceDefault = 1e-8;
+const double KineticsObserver::stateLinVelProcessVarianceDefault = 1e-8;
+const double KineticsObserver::stateAngVelProcessVarianceDefault = 1e-8;
+const double KineticsObserver::gyroBiasProcessVarianceDefault = 1e-12;
+const double KineticsObserver::unmodeledWrenchProcessVarianceDefault = 1e-8;
+const double KineticsObserver::contactPositionProcessVarianceDefault = 1e-8;
+const double KineticsObserver::contactOrientationProcessVarianceDefault = 1e-8;
+const double KineticsObserver::contactForceProcessVarianceDefault = 1e-8;
+const double KineticsObserver::contactTorqueProcessVarianceDefault = 1e-8;
+
+const double KineticsObserver::acceleroVarianceDefault = 1e-4;
+const double KineticsObserver::gyroVarianceDefault = 1e-8;
+const double KineticsObserver::forceSensorVarianceDefault = 1e-8;
+const double KineticsObserver::torqueSensorVarianceDefault = 1e-10;
+const double KineticsObserver::positionSensorVarianceDefault = 1e-4;
+const double KineticsObserver::orientationSensorVarianceDefault = 1e-3;
+
+const double KineticsObserver::linearStiffnessDefault = 40000;
+const double KineticsObserver::angularStiffnessDefault = 400;
+const double KineticsObserver::linearDampingDefault = 120;
+const double KineticsObserver::angularDampingDefault = 12;
+
+const double KineticsObserver::defaultdx = 1e-6;
+
+const int measurementSizeBase = 0;
+const int inputSize = 0;
+
+int KineticsObserver::Contact::numberOfRealSensors = 0;
+int KineticsObserver::IMU::currentNumber = 0;
+
+KineticsObserver::KineticsObserver(unsigned maxContacts, unsigned maxNumberOfIMU)
+: maxContacts_(maxContacts), maxImuNumber_(maxNumberOfIMU), contacts_(maxContacts_), imuSensors_(maxImuNumber_),
+  stateSize_(sizeStateBase + maxImuNumber_ * sizeGyroBias + maxContacts * sizeContact),
+  stateTangentSize_(sizeStateTangentBase + maxImuNumber_ * sizeGyroBias + sizeContactTangent * maxContacts),
+  measurementSize_(0), measurementTangentSize_(0), stateVector_(stateSize_), stateVectorDx_(stateTangentSize_),
+  oldStateVector_(stateSize_), additionalForce_(Vector3::Zero()), additionalTorque_(Vector3::Zero()),
+  ekf_(stateSize_, stateTangentSize_, measurementSizeBase, measurementSizeBase, inputSize, false, false),
+  finiteDifferencesJacobians_(true), withGyroBias_(true), withUnmodeledWrench_(false),
+  withAccelerationEstimation_(false), k_est_(0), k_data_(0), mass_(defaultMass), dt_(defaultdx), processNoise_(0x0),
+  measurementNoise_(0x0), linearStiffnessMatDefault_(Matrix3::Identity() * linearStiffnessDefault),
+  angularStiffnessMatDefault_(Matrix3::Identity() * angularStiffnessDefault),
+  linearDampingMatDefault_(Matrix3::Identity() * linearDampingDefault),
+  angularDampingMatDefault_(Matrix3::Identity() * angularDampingDefault),
+  acceleroCovMatDefault_(Matrix3::Identity() * acceleroVarianceDefault),
+  gyroCovMatDefault_(Matrix3::Identity() * gyroVarianceDefault),
+  contactWrenchSensorCovMatDefault_(blockMat6(Matrix3::Identity() * forceSensorVarianceDefault,
+                                              Matrix3::Zero(),
+                                              Matrix3::Zero(),
+                                              Matrix3::Identity() * torqueSensorVarianceDefault)),
+  absPoseSensorCovMatDefault_(blockMat6(Matrix3::Identity() * positionSensorVarianceDefault,
+                                        Matrix3::Zero(),
+                                        Matrix3::Zero(),
+                                        Matrix3::Identity() * orientationSensorVarianceDefault)),
+  statePosInitCovMat_(Matrix3::Identity() * statePoseInitVarianceDefault),
+  stateOriInitCovMat_(Matrix3::Identity() * stateOriInitVarianceDefault),
+  stateLinVelInitCovMat_(Matrix3::Identity() * stateLinVelInitVarianceDefault),
+  stateAngVelInitCovMat_(Matrix3::Identity() * stateAngVelInitVarianceDefault),
+  gyroBiasInitCovMat_(Matrix3::Identity() * gyroBiasInitVarianceDefault),
+  unmodeledWrenchInitCovMat_(Matrix6::Identity() * unmodeledWrenchInitVarianceDefault),
+  statePosProcessCovMat_(Matrix3::Identity() * statePoseProcessVarianceDefault),
+  stateOriProcessCovMat_(Matrix3::Identity() * stateOriProcessVarianceDefault),
+  stateLinVelProcessCovMat_(Matrix3::Identity() * stateLinVelProcessVarianceDefault),
+  stateAngVelProcessCovMat_(Matrix3::Identity() * stateAngVelProcessVarianceDefault),
+  gyroBiasProcessCovMat_(Matrix3::Identity() * gyroBiasProcessVarianceDefault),
+  unmodeledWrenchProcessCovMat_(Matrix6::Identity() * unmodeledWrenchProcessVarianceDefault),
+  contactPositionProcessCovMat_(Matrix3::Identity() * contactPositionProcessVarianceDefault),
+  contactOrientationProcessCovMat_(Matrix3::Identity() * contactOrientationProcessVarianceDefault),
+  contactForceProcessCovMat_(Matrix3::Identity() * contactForceInitVarianceDefault),
+  contactTorqueProcessCovMat_(Matrix3::Identity() * contactTorqueInitVarianceDefault)
+{
+  ekf_.setFunctor(this);
+  ekf_.setStateArithmetics(this);
+
+  stateVector_.setZero();
+  oldStateVector_ = stateVector_;
+
+  ekf_.setState(stateVector_, k_est_);
+
+  stateKinematicsInitCovMat_.setZero();
+  stateKinematicsInitCovMat_.block<sizePos, sizePos>(posIndexTangent(), posIndexTangent()) = statePosInitCovMat_;
+  stateKinematicsInitCovMat_.block<sizeOriTangent, sizeOriTangent>(oriIndexTangent(), oriIndexTangent()) =
+      stateOriInitCovMat_;
+  stateKinematicsInitCovMat_.block<sizeLinVel, sizeLinVel>(linVelIndexTangent(), linVelIndexTangent()) =
+      stateLinVelInitCovMat_;
+  stateKinematicsInitCovMat_.block<sizeAngVel, sizeAngVel>(angVelIndexTangent(), angVelIndexTangent()) =
+      stateAngVelInitCovMat_;
+
+  stateKinematicsProcessCovMat_.setZero();
+  stateKinematicsProcessCovMat_.block<sizePos, sizePos>(posIndexTangent(), posIndexTangent()) = statePosProcessCovMat_;
+  stateKinematicsProcessCovMat_.block<sizeOriTangent, sizeOriTangent>(oriIndexTangent(), oriIndexTangent()) =
+      stateOriProcessCovMat_;
+  stateKinematicsProcessCovMat_.block<sizeLinVel, sizeLinVel>(linVelIndexTangent(), linVelIndexTangent()) =
+      stateLinVelProcessCovMat_;
+  stateKinematicsProcessCovMat_.block<sizeAngVel, sizeAngVel>(angVelIndexTangent(), angVelIndexTangent()) =
+      stateAngVelProcessCovMat_;
+
+  contactProcessCovMat_.setZero();
+  contactProcessCovMat_.block<sizePos, sizePos>(0, 0) = contactPositionProcessCovMat_;
+  contactProcessCovMat_.block<sizeOriTangent, sizeOriTangent>(3, 3) = contactOrientationProcessCovMat_;
+  contactProcessCovMat_.block<sizeForce, sizeForce>(6, 6) = contactForceProcessCovMat_;
+  contactProcessCovMat_.block<sizeTorque, sizeTorque>(9, 9) = contactTorqueProcessCovMat_;
+
+  I_.set(Matrix3::Identity(), k_data_);
+  Id_.set(Matrix3::Zero(), k_data_);
+  comd_.set(Vector3::Zero(), k_data_);
+  comdd_.set(Vector3::Zero(), k_data_);
+  sigma_.set(Vector3::Zero(), k_data_);
+  sigmad_.set(Vector3::Zero(), k_data_);
+
+  ekf_.setStateCovariance(ekf_.getPmatrixZero());
+  ekf_.setQ(ekf_.getQmatrixZero());
+  ekf_.setR(ekf_.getRmatrixZero());
+
+  resetStateCovarianceMat();
+  resetProcessCovarianceMat();
+
+  updateKine_();
+
+  Contact::numberOfRealSensors = 0;
+
+  stateVectorDx_.setConstant(1e-6);
+}
+
+KineticsObserver::~KineticsObserver() {}
+
+Index KineticsObserver::getStateSize() const
+{
+  return stateSize_;
+}
+
+Index KineticsObserver::getMeasurementSize() const
+{
+  Index size = 0;
+  if(k_est_ != k_data_) // test if there are new measurements
   {
-    Matrix6 m;
-    m<< m1,m2,
-        m3,m4;
-
-    return m;
-  }
-
-  /// resets one block on the diagonal of the state Covariance Matrix
-        /// i.e. sets value of a square block on the diagonal of the covMat
-        /// and sets to zero all the values related to their lines and columns
-  template <int blockSize>
-  void STATE_OBSERVATION_DLLAPI setBlockStateCovariance(Matrix & covMat, const Matrix & covBlock, int blockIndex)
-  {
-    long int matrixSize = covMat.rows();
-    covMat.block<blockSize,blockSize>(blockIndex,blockIndex)=covBlock;
-    covMat.block(blockIndex,0,blockSize,blockIndex).setZero();
-    covMat.block(0,blockIndex,blockIndex,blockSize).setZero();
-    covMat.block(blockIndex+blockSize,blockIndex,matrixSize-blockIndex-blockSize,blockSize).setZero();
-    covMat.block(blockIndex,blockIndex+blockSize,blockSize,matrixSize-blockIndex-blockSize).setZero();
-  }
-
-  inline void STATE_OBSERVATION_DLLAPI fillSymmetricMatrix(Matrix3 & m,const Vector3 &vdiag, double e1, double e2, double e3)
-  {
-    m.diagonal() = vdiag;
-    m(1,0)=m(0,1)=e1;
-    m(2,0)=m(0,2)=e2;
-    m(2,1)=m(1,2)=e3;
-  }
-
-  const double KineticsObserver::defaultMass = 50;
-
-  const double KineticsObserver::statePoseInitVarianceDefault = 1e-4;
-  const double KineticsObserver::stateOriInitVarianceDefault = 1e-4;
-  const double KineticsObserver::stateLinVelInitVarianceDefault = 1e-6;
-  const double KineticsObserver::stateAngVelInitVarianceDefault = 1e-6;
-  const double KineticsObserver::gyroBiasInitVarianceDefault = 1e-10;
-  const double KineticsObserver::unmodeledWrenchInitVarianceDefault = 1e100;
-  const double KineticsObserver::contactForceInitVarianceDefault = 1e100;
-  const double KineticsObserver::contactTorqueInitVarianceDefault = 1e100;
-
-  const double KineticsObserver::statePoseProcessVarianceDefault = 1e-8;
-  const double KineticsObserver::stateOriProcessVarianceDefault = 1e-8;
-  const double KineticsObserver::stateLinVelProcessVarianceDefault = 1e-8;
-  const double KineticsObserver::stateAngVelProcessVarianceDefault = 1e-8;
-  const double KineticsObserver::gyroBiasProcessVarianceDefault = 1e-12;
-  const double KineticsObserver::unmodeledWrenchProcessVarianceDefault = 1e-8;
-  const double KineticsObserver::contactPositionProcessVarianceDefault = 1e-8;
-  const double KineticsObserver::contactOrientationProcessVarianceDefault = 1e-8;
-  const double KineticsObserver::contactForceProcessVarianceDefault = 1e-8;
-  const double KineticsObserver::contactTorqueProcessVarianceDefault = 1e-8;
-
-  const double KineticsObserver::acceleroVarianceDefault = 1e-4;
-  const double KineticsObserver::gyroVarianceDefault = 1e-8;
-  const double KineticsObserver::forceSensorVarianceDefault = 1e-8;
-  const double KineticsObserver::torqueSensorVarianceDefault = 1e-10;
-  const double KineticsObserver::positionSensorVarianceDefault = 1e-4;
-  const double KineticsObserver::orientationSensorVarianceDefault = 1e-3;
-
-  const double KineticsObserver::linearStiffnessDefault = 40000;
-  const double KineticsObserver::angularStiffnessDefault = 400;
-  const double KineticsObserver::linearDampingDefault = 120;
-  const double KineticsObserver::angularDampingDefault = 12;
-
-  const double KineticsObserver::defaultdx = 1e-6;
-
-  const int measurementSizeBase = 0;
-  const int inputSize = 0;
-
-  int KineticsObserver::Contact::numberOfRealSensors = 0;
-  int KineticsObserver::IMU::currentNumber = 0;
-
-  KineticsObserver::KineticsObserver(unsigned maxContacts, unsigned maxNumberOfIMU):
-    maxContacts_(maxContacts),
-    maxImuNumber_(maxNumberOfIMU),
-    contacts_(maxContacts_),
-    imuSensors_(maxImuNumber_),
-    stateSize_(sizeStateBase + maxImuNumber_*sizeGyroBias + maxContacts*sizeContact),
-    stateTangentSize_(sizeStateTangentBase + maxImuNumber_*sizeGyroBias + sizeContactTangent * maxContacts),
-    measurementSize_(0),
-    measurementTangentSize_(0),
-    stateVector_(stateSize_),
-    stateVectorDx_(stateTangentSize_),
-    oldStateVector_(stateSize_),
-    additionalForce_(Vector3::Zero()),
-    additionalTorque_(Vector3::Zero()),
-    ekf_(stateSize_, stateTangentSize_, measurementSizeBase, measurementSizeBase,  inputSize,false,false),
-    finiteDifferencesJacobians_(true),
-    withGyroBias_(true), withUnmodeledWrench_(false), withAccelerationEstimation_(false),
-    k_est_(0),k_data_(0), mass_(defaultMass), dt_(defaultdx),
-    processNoise_(0x0), measurementNoise_(0x0),
-    linearStiffnessMatDefault_(Matrix3::Identity()*linearStiffnessDefault),
-    angularStiffnessMatDefault_(Matrix3::Identity()*angularStiffnessDefault),
-    linearDampingMatDefault_(Matrix3::Identity()*linearDampingDefault),
-    angularDampingMatDefault_(Matrix3::Identity()*angularDampingDefault),
-    acceleroCovMatDefault_(Matrix3::Identity()*acceleroVarianceDefault),
-    gyroCovMatDefault_( Matrix3::Identity()*gyroVarianceDefault),
-    contactWrenchSensorCovMatDefault_(blockMat6( Matrix3::Identity()*forceSensorVarianceDefault, Matrix3::Zero(),
-                                Matrix3::Zero(), Matrix3::Identity()*torqueSensorVarianceDefault )),
-    absPoseSensorCovMatDefault_(blockMat6( Matrix3::Identity()*positionSensorVarianceDefault, Matrix3::Zero(),
-                                Matrix3::Zero(), Matrix3::Identity()*orientationSensorVarianceDefault )),
-    statePosInitCovMat_(Matrix3::Identity()*statePoseInitVarianceDefault),
-    stateOriInitCovMat_(Matrix3::Identity()*stateOriInitVarianceDefault),
-    stateLinVelInitCovMat_(Matrix3::Identity()*stateLinVelInitVarianceDefault),
-    stateAngVelInitCovMat_(Matrix3::Identity()*stateAngVelInitVarianceDefault),
-    gyroBiasInitCovMat_(Matrix3::Identity()*gyroBiasInitVarianceDefault),
-    unmodeledWrenchInitCovMat_(Matrix6::Identity()*unmodeledWrenchInitVarianceDefault),
-    statePosProcessCovMat_(Matrix3::Identity()*statePoseProcessVarianceDefault),
-    stateOriProcessCovMat_(Matrix3::Identity()*stateOriProcessVarianceDefault),
-    stateLinVelProcessCovMat_(Matrix3::Identity()*stateLinVelProcessVarianceDefault),
-    stateAngVelProcessCovMat_(Matrix3::Identity()*stateAngVelProcessVarianceDefault),
-    gyroBiasProcessCovMat_(Matrix3::Identity()*gyroBiasProcessVarianceDefault),
-    unmodeledWrenchProcessCovMat_(Matrix6::Identity()*unmodeledWrenchProcessVarianceDefault),
-    contactPositionProcessCovMat_(Matrix3::Identity()*contactPositionProcessVarianceDefault),
-    contactOrientationProcessCovMat_(Matrix3::Identity()*contactOrientationProcessVarianceDefault),
-    contactForceProcessCovMat_(Matrix3::Identity()*contactForceInitVarianceDefault),
-    contactTorqueProcessCovMat_(Matrix3::Identity()*contactTorqueInitVarianceDefault)
-  {
-    ekf_.setFunctor(this);
-    ekf_.setStateArithmetics(this);
-
-    stateVector_.setZero();
-    oldStateVector_ = stateVector_;
-
-    ekf_.setState(stateVector_,k_est_);
-
-    stateKinematicsInitCovMat_.setZero();
-    stateKinematicsInitCovMat_.block<sizePos,sizePos>               (posIndexTangent(),posIndexTangent())       = statePosInitCovMat_;
-    stateKinematicsInitCovMat_.block<sizeOriTangent,sizeOriTangent> (oriIndexTangent(),oriIndexTangent())       = stateOriInitCovMat_;
-    stateKinematicsInitCovMat_.block<sizeLinVel,sizeLinVel>         (linVelIndexTangent(),linVelIndexTangent()) = stateLinVelInitCovMat_;
-    stateKinematicsInitCovMat_.block<sizeAngVel,sizeAngVel>         (angVelIndexTangent(),angVelIndexTangent()) = stateAngVelInitCovMat_;
-
-
-    stateKinematicsProcessCovMat_.setZero();
-    stateKinematicsProcessCovMat_.block<sizePos,sizePos>               (posIndexTangent(),posIndexTangent())       = statePosProcessCovMat_;
-    stateKinematicsProcessCovMat_.block<sizeOriTangent,sizeOriTangent> (oriIndexTangent(),oriIndexTangent())       = stateOriProcessCovMat_;
-    stateKinematicsProcessCovMat_.block<sizeLinVel,sizeLinVel>         (linVelIndexTangent(),linVelIndexTangent()) = stateLinVelProcessCovMat_;
-    stateKinematicsProcessCovMat_.block<sizeAngVel,sizeAngVel>         (angVelIndexTangent(),angVelIndexTangent()) = stateAngVelProcessCovMat_;
-
-
-    contactProcessCovMat_.setZero();
-    contactProcessCovMat_.block<sizePos,sizePos>               (0,0) = contactPositionProcessCovMat_;
-    contactProcessCovMat_.block<sizeOriTangent,sizeOriTangent> (3,3) = contactOrientationProcessCovMat_;
-    contactProcessCovMat_.block<sizeForce,sizeForce>           (6,6) = contactForceProcessCovMat_;
-    contactProcessCovMat_.block<sizeTorque,sizeTorque>         (9,9) = contactTorqueProcessCovMat_;
-
-
-    I_.set(Matrix3::Identity(),k_data_);
-    Id_.set(Matrix3::Zero(),k_data_);
-    comd_.set(Vector3::Zero(),k_data_);
-    comdd_.set(Vector3::Zero(),k_data_);
-    sigma_.set(Vector3::Zero(),k_data_);
-    sigmad_.set(Vector3::Zero(),k_data_);
-
-    ekf_.setStateCovariance(ekf_.getPmatrixZero());
-    ekf_.setQ(ekf_.getQmatrixZero());
-    ekf_.setR(ekf_.getRmatrixZero());
-
-    resetStateCovarianceMat();
-    resetProcessCovarianceMat();
-
-    updateKine_();
-
-    Contact::numberOfRealSensors = 0;
-
-    stateVectorDx_.setConstant(1e-6);
-  }
-
-  KineticsObserver::~KineticsObserver()
-  {
-  }
-
-
-  Index KineticsObserver::getStateSize() const
-  {
-    return stateSize_;
-  }
-
-  Index KineticsObserver::getMeasurementSize() const
-  {
-    Index size = 0;
-    if (k_est_!=k_data_) //test if there are new measurements
+    for(VectorIMUConstIterator i = imuSensors_.begin(); i != imuSensors_.end(); ++i)
     {
-      for (VectorIMUConstIterator i = imuSensors_.begin(); i != imuSensors_.end(); ++i)
+      if(i->time == k_data_)
       {
-        if (i->time==k_data_)
-        {
-          size+=sizeIMUSignal;
-        }
+        size += sizeIMUSignal;
       }
-
-      size += Contact::numberOfRealSensors * sizeWrench;
-
-      if (absPoseSensor_.time == k_data_)
-      {
-        size+=sizePose;
-      }
-
     }
 
-    return size;
-  }
+    size += Contact::numberOfRealSensors * sizeWrench;
 
-
-  double KineticsObserver::getSamplingTime() const
-  {
-    return dt_;
-  }
-
-  void KineticsObserver::setSamplingTime( double dt)
-  {
-    dt_ = dt;
-  }
-
-  void KineticsObserver::setMass(double m)
-  {
-    mass_=m;
-  }
-
-  Vector KineticsObserver::update()
-  {
-    if (k_est_!=k_data_)
+    if(absPoseSensor_.time == k_data_)
     {
-      for (VectorContactIterator i= contacts_.begin(), ie = contacts_.end(); i!=ie ; ++i)
+      size += sizePose;
+    }
+  }
+
+  return size;
+}
+
+double KineticsObserver::getSamplingTime() const
+{
+  return dt_;
+}
+
+void KineticsObserver::setSamplingTime(double dt)
+{
+  dt_ = dt;
+}
+
+void KineticsObserver::setMass(double m)
+{
+  mass_ = m;
+}
+
+Vector KineticsObserver::update()
+{
+  if(k_est_ != k_data_)
+  {
+    for(VectorContactIterator i = contacts_.begin(), ie = contacts_.end(); i != ie; ++i)
+    {
+      if(i->isSet)
       {
-        if (i->isSet)
-        {
-          BOOST_ASSERT((i->time == k_data_) && "The contacts have not all been updated. \
+        BOOST_ASSERT((i->time == k_data_) && "The contacts have not all been updated. \
               Either remove lost contacts using removeContact \
               or Run setContactFTSensor or setContactWithNoSensor on every existing contact");
 
-          /// the following code is only an attempt to maintain a coherent state of the state observer
-          /// therefore we unset the observer
-          if (i->time != k_data_)
+        /// the following code is only an attempt to maintain a coherent state of the state observer
+        /// therefore we unset the observer
+        if(i->time != k_data_)
+        {
+          if(i->withRealSensor)
           {
-            if (i->withRealSensor)
-            {
-              Contact::numberOfRealSensors--;
-            }
-            i->isSet =false;
+            Contact::numberOfRealSensors--;
           }
+          i->isSet = false;
         }
       }
-
-      ///////////// initialize the measurement Vector and matrix //////////////
-
-      measurementSize_ = sizeIMUSignal * IMU::currentNumber + sizeWrench*Contact::numberOfRealSensors;
-      measurementTangentSize_ = measurementSize_;
-      if (absPoseSensor_.time == k_data_)
-      {
-        measurementSize_ += sizePose;
-        measurementTangentSize_ += sizePoseTangent;
-      }
-
-      measurementVector_.resize(measurementSize_);
-      measurementCovMatrix_.resize(measurementTangentSize_,measurementTangentSize_);
-      measurementCovMatrix_.setZero();
-
-      int curMeasIndex = 0;
-
-      for (VectorIMUIterator i= imuSensors_.begin(), ie = imuSensors_.end(); i!=ie ; ++i)
-      {
-        if (i->time == k_data_)
-        {
-          i->measIndex = curMeasIndex;
-          measurementVector_.segment<sizeIMUSignal>(curMeasIndex) = i->acceleroGyro;
-          measurementCovMatrix_.block<sizeAcceleroSignal, sizeAcceleroSignal>(curMeasIndex, curMeasIndex) = i->covMatrixAccelero;
-          curMeasIndex += sizeAcceleroSignal;
-          measurementCovMatrix_.block<sizeGyroSignal, sizeGyroSignal>(curMeasIndex, curMeasIndex) = i->covMatrixGyro;
-          curMeasIndex += sizeGyroSignal;
-        }
-      }
-
-      for (VectorContactIterator i=contacts_.begin(), ie = contacts_.end();i!=ie;++i)
-      {
-        if (i->withRealSensor)
-        {
-          i->measIndex = curMeasIndex;
-          measurementVector_.segment<sizeWrench>(curMeasIndex) = i->wrench;
-          measurementCovMatrix_.block<sizeWrench,sizeWrench>(curMeasIndex,curMeasIndex)=i->sensorCovMatrix();
-          curMeasIndex+=sizeWrench;
-        }
-      }
-
-      if (absPoseSensor_.time == k_data_)
-      {
-        absPoseSensor_.measIndex= curMeasIndex;
-        BOOST_ASSERT(absPoseSensor_.pose.position.isSet() && absPoseSensor_.pose.orientation.isSet() \
-                    && "The absolute pose needs to contain the position and the orientation");
-        measurementVector_.segment<sizePose>(curMeasIndex) = absPoseSensor_.pose.toVector(flagsPoseKine);
-        measurementCovMatrix_.block<sizePoseTangent,sizePoseTangent>(curMeasIndex,curMeasIndex)=absPoseSensor_.covMatrix();
-      }
-
-      ekf_.setMeasureSize(measurementSize_,measurementTangentSize_);
-      ekf_.setMeasurement(measurementVector_,k_data_);
-      ekf_.setR(measurementCovMatrix_);
-      if (finiteDifferencesJacobians_)
-      {
-        ekf_.setA(ekf_.getAMatrixFD(stateVectorDx_));
-        ekf_.setC(ekf_.getCMatrixFD(stateVectorDx_));
-      }
-      else
-      {
-        ekf_.setA(computeAMatrix_());
-        ekf_.setC(computeCMatrix_());
-      }
-
-
-      stateVector_ = ekf_.getEstimatedState(k_data_);
-
-      if (stateVector_.hasNaN())
-      {
-  #ifndef NDEBUG
-        std::cout << "Kinetics observer: NaN value detected" << std::endl;
-  #endif
-        stateVector_ = stateNaNCorrection_();
-      }
-      else
-      {
-        oldStateVector_ = stateVector_;
-      }
-
-      ++k_est_; //the timestamp of the state we estimated
-
-      stateKinematics_.reset();
-
-      updateKine_();
-
-      if (withAccelerationEstimation_)
-      {
-        estimateAccelerations();
-      }
-
     }
 
-    return stateVector_;
-  }
+    ///////////// initialize the measurement Vector and matrix //////////////
 
-  Vector KineticsObserver::getStateVector() const
-  {
-    return stateVector_;
-  }
-
-  stateObservation::TimeIndex KineticsObserver::getStateVectorSampleTime() const
-  {
-    return ekf_.getCurrentTime() ;
-  }
-
-  kine::Kinematics KineticsObserver::getKinematics() const
-  {
-    return stateKinematics_;
-  }
-
-  kine::Kinematics KineticsObserver::getKinematicsOf( const Kinematics & local) const
-  {
-    return Kinematics(stateKinematics_,local);///product of the kinematics
-  }
-
-  kine::Kinematics KineticsObserver::getKinematicsOf( const Kinematics & local)
-  {
-    return Kinematics(stateKinematics_,local);///product of the kinematics
-  }
-
-  kine::Kinematics KineticsObserver::getKinematicsOf( Kinematics & local) const
-  {
-    return Kinematics(stateKinematics_,local);///product of the kinematics
-  }
-
-  kine::Kinematics KineticsObserver::getKinematicsOf( Kinematics & local)
-  {
-    return Kinematics(stateKinematics_,local);///product of the kinematics
-  }
-
-  Vector6 KineticsObserver::getContactWrench(int contactNbr) const
-  {
-    return stateVector_.segment<sizeWrench>(contactWrenchIndex(contactNbr));
-  }
-
-  kine::Kinematics KineticsObserver::getContactPosition(int contactNbr) const
-  {
-    return Kinematics(stateVector_.segment<sizeStateKine>(contactKineIndex(contactNbr)),
-                                                          flagsContactKine);
-  }
-
-  Vector6 KineticsObserver::getUnmodeledWrench() const
-  {
-    return stateVector_.segment<sizeWrench>(unmodeledWrenchIndex());
-  }
-
-  kine::Kinematics KineticsObserver::estimateAccelerations()
-  {
-    Vector3 forceLocal = additionalForce_;
-    Vector3 torqueLocal = additionalTorque_;
-
-    addUnmodeledAndContactWrench_(stateVector_,forceLocal,torqueLocal);
-
-    /// The accelerations are about to be computed so we set them to "initialized"
-    stateKinematics_.linAcc.set(true);
-    stateKinematics_.angAcc.set(true);
-
-    computeAccelerations_(stateKinematics_,forceLocal,torqueLocal,
-                          stateKinematics_.linAcc(), stateKinematics_.angAcc());
-
-
-    return stateKinematics_;
-  }
-
-  void KineticsObserver::setStateKinematics(const Kinematics & kine, bool resetForces,
-                                            bool resetCovariance)
-  {
-    BOOST_ASSERT( kine.position.isSet() && kine.orientation.isSet() &&
-                  kine.linVel.isSet()   && kine.angVel.isSet() &&
-                  "The Kinematics is not correctly initialized");
-    stateKinematics_ = kine;
-    stateVector_.segment<sizeStateKine>(kineIndex()) = stateKinematics_.toVector(flagsStateKine);
-
-    if (resetForces)
+    measurementSize_ = sizeIMUSignal * IMU::currentNumber + sizeWrench * Contact::numberOfRealSensors;
+    measurementTangentSize_ = measurementSize_;
+    if(absPoseSensor_.time == k_data_)
     {
-      for (VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+      measurementSize_ += sizePose;
+      measurementTangentSize_ += sizePoseTangent;
+    }
+
+    measurementVector_.resize(measurementSize_);
+    measurementCovMatrix_.resize(measurementTangentSize_, measurementTangentSize_);
+    measurementCovMatrix_.setZero();
+
+    int curMeasIndex = 0;
+
+    for(VectorIMUIterator i = imuSensors_.begin(), ie = imuSensors_.end(); i != ie; ++i)
+    {
+      if(i->time == k_data_)
       {
-        if (i->isSet)
-        {
-          stateVector_.segment<sizeWrench>(contactWrenchIndex(i)).setZero();
-        }
+        i->measIndex = curMeasIndex;
+        measurementVector_.segment<sizeIMUSignal>(curMeasIndex) = i->acceleroGyro;
+        measurementCovMatrix_.block<sizeAcceleroSignal, sizeAcceleroSignal>(curMeasIndex, curMeasIndex) =
+            i->covMatrixAccelero;
+        curMeasIndex += sizeAcceleroSignal;
+        measurementCovMatrix_.block<sizeGyroSignal, sizeGyroSignal>(curMeasIndex, curMeasIndex) = i->covMatrixGyro;
+        curMeasIndex += sizeGyroSignal;
       }
     }
 
-    ekf_.setState(stateVector_,k_est_);
-
-    if (resetCovariance)
+    for(VectorContactIterator i = contacts_.begin(), ie = contacts_.end(); i != ie; ++i)
     {
-      Matrix stateCovariance = ekf_.getStateCovariance();
-      setBlockStateCovariance<sizeStateKineTangent>(stateCovariance,stateKinematicsInitCovMat_,kineIndex());
-
-      if (resetForces)
+      if(i->withRealSensor)
       {
-        for (VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
-        {
-          if (i->isSet)
-          {
-            setBlockStateCovariance<sizeContact>(stateCovariance,contactInitCovMat_,contactIndex(i));
-          }
-        }
+        i->measIndex = curMeasIndex;
+        measurementVector_.segment<sizeWrench>(curMeasIndex) = i->wrench;
+        measurementCovMatrix_.block<sizeWrench, sizeWrench>(curMeasIndex, curMeasIndex) = i->sensorCovMatrix();
+        curMeasIndex += sizeWrench;
       }
-      ekf_.setStateCovariance(stateCovariance);
     }
 
-  }
-
-  void KineticsObserver::setGyroBias(const Vector3 & bias, unsigned numberOfIMU,  bool resetCovariance)
-  {
-    stateVector_.segment<sizeGyroBias>(gyroBiasIndex(numberOfIMU))=bias;
-    ekf_.setState(stateVector_,k_est_);
-
-    if (resetCovariance)
+    if(absPoseSensor_.time == k_data_)
     {
-      Matrix stateCovariance = ekf_.getStateCovariance();
-      setBlockStateCovariance<sizeGyroBias>(stateCovariance,gyroBiasInitCovMat_,gyroBiasIndex(numberOfIMU));
-
-      ekf_.setStateCovariance(stateCovariance);
+      absPoseSensor_.measIndex = curMeasIndex;
+      BOOST_ASSERT(absPoseSensor_.pose.position.isSet() && absPoseSensor_.pose.orientation.isSet()
+                   && "The absolute pose needs to contain the position and the orientation");
+      measurementVector_.segment<sizePose>(curMeasIndex) = absPoseSensor_.pose.toVector(flagsPoseKine);
+      measurementCovMatrix_.block<sizePoseTangent, sizePoseTangent>(curMeasIndex, curMeasIndex) =
+          absPoseSensor_.covMatrix();
     }
-  }
 
-  void KineticsObserver::setStateUnmodeledWrench(const Vector6 & wrench, bool resetCovariance)
-  {
-    stateVector_.segment<sizeWrench>(unmodeledWrenchIndex())=wrench;
-    ekf_.setState(stateVector_,k_est_);
-
-    if (resetCovariance)
+    ekf_.setMeasureSize(measurementSize_, measurementTangentSize_);
+    ekf_.setMeasurement(measurementVector_, k_data_);
+    ekf_.setR(measurementCovMatrix_);
+    if(finiteDifferencesJacobians_)
     {
-      Matrix stateCovariance = ekf_.getStateCovariance();
-      setBlockStateCovariance<sizeWrench>(stateCovariance,unmodeledWrenchInitCovMat_,unmodeledWrenchIndex());
-
-      ekf_.setStateCovariance(stateCovariance);
+      ekf_.setA(ekf_.getAMatrixFD(stateVectorDx_));
+      ekf_.setC(ekf_.getCMatrixFD(stateVectorDx_));
     }
-  }
+    else
+    {
+      ekf_.setA(computeAMatrix_());
+      ekf_.setC(computeCMatrix_());
+    }
 
+    stateVector_ = ekf_.getEstimatedState(k_data_);
 
-  void KineticsObserver::setStateVector(const Vector & v, bool resetCovariance)
-  {
-    stateVector_ = v;
-    ekf_.setState(v,k_est_);
+    if(stateVector_.hasNaN())
+    {
+#ifndef NDEBUG
+      std::cout << "Kinetics observer: NaN value detected" << std::endl;
+#endif
+      stateVector_ = stateNaNCorrection_();
+    }
+    else
+    {
+      oldStateVector_ = stateVector_;
+    }
+
+    ++k_est_; // the timestamp of the state we estimated
+
+    stateKinematics_.reset();
+
     updateKine_();
 
-    if (resetCovariance)
+    if(withAccelerationEstimation_)
     {
-      resetStateCovarianceMat();
+      estimateAccelerations();
     }
-
   }
 
-  void KineticsObserver::setAdditionalWrench(const Vector3& force,const Vector3& moment)
+  return stateVector_;
+}
+
+Vector KineticsObserver::getStateVector() const
+{
+  return stateVector_;
+}
+
+stateObservation::TimeIndex KineticsObserver::getStateVectorSampleTime() const
+{
+  return ekf_.getCurrentTime();
+}
+
+kine::Kinematics KineticsObserver::getKinematics() const
+{
+  return stateKinematics_;
+}
+
+kine::Kinematics KineticsObserver::getKinematicsOf(const Kinematics & local) const
+{
+  return Kinematics(stateKinematics_, local); /// product of the kinematics
+}
+
+kine::Kinematics KineticsObserver::getKinematicsOf(const Kinematics & local)
+{
+  return Kinematics(stateKinematics_, local); /// product of the kinematics
+}
+
+kine::Kinematics KineticsObserver::getKinematicsOf(Kinematics & local) const
+{
+  return Kinematics(stateKinematics_, local); /// product of the kinematics
+}
+
+kine::Kinematics KineticsObserver::getKinematicsOf(Kinematics & local)
+{
+  return Kinematics(stateKinematics_, local); /// product of the kinematics
+}
+
+Vector6 KineticsObserver::getContactWrench(int contactNbr) const
+{
+  return stateVector_.segment<sizeWrench>(contactWrenchIndex(contactNbr));
+}
+
+kine::Kinematics KineticsObserver::getContactPosition(int contactNbr) const
+{
+  return Kinematics(stateVector_.segment<sizeStateKine>(contactKineIndex(contactNbr)), flagsContactKine);
+}
+
+Vector6 KineticsObserver::getUnmodeledWrench() const
+{
+  return stateVector_.segment<sizeWrench>(unmodeledWrenchIndex());
+}
+
+kine::Kinematics KineticsObserver::estimateAccelerations()
+{
+  Vector3 forceLocal = additionalForce_;
+  Vector3 torqueLocal = additionalTorque_;
+
+  addUnmodeledAndContactWrench_(stateVector_, forceLocal, torqueLocal);
+
+  /// The accelerations are about to be computed so we set them to "initialized"
+  stateKinematics_.linAcc.set(true);
+  stateKinematics_.angAcc.set(true);
+
+  computeAccelerations_(stateKinematics_, forceLocal, torqueLocal, stateKinematics_.linAcc(),
+                        stateKinematics_.angAcc());
+
+  return stateKinematics_;
+}
+
+void KineticsObserver::setStateKinematics(const Kinematics & kine, bool resetForces, bool resetCovariance)
+{
+  BOOST_ASSERT(kine.position.isSet() && kine.orientation.isSet() && kine.linVel.isSet() && kine.angVel.isSet()
+               && "The Kinematics is not correctly initialized");
+  stateKinematics_ = kine;
+  stateVector_.segment<sizeStateKine>(kineIndex()) = stateKinematics_.toVector(flagsStateKine);
+
+  if(resetForces)
   {
-
-    additionalForce_=force;
-    additionalTorque_=moment;
-  }
-
-  void KineticsObserver::setWithUnmodeledWrench(bool b)
-  {
-    withUnmodeledWrench_ = b;
-  }
-
-  void KineticsObserver::setWithAccelerationEstimation(bool b)
-  {
-    withAccelerationEstimation_=b;
-  }
-
-  void KineticsObserver::setWithGyroBias(bool b)
-  {
-    withAccelerationEstimation_=b;
-  }
-
-  int KineticsObserver::setIMU(const Vector3 & accelero, const  Vector3 & gyrometer, const Kinematics &localKine, int num)
-  {
-    ///ensure the measuements are labeled with the good time stamp
-    startNewIteration_();
-
-    if (num<0)
+    for(VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
     {
-      num=0;
-      while (imuSensors_[num].time!=k_data_ && unsigned(num) < imuSensors_.size())
+      if(i->isSet)
       {
-        ++num;
-      }
-    }
-
-    BOOST_ASSERT (unsigned (num) < maxImuNumber_ && "The inserted IMU number exceeds the maximum number");
-
-    IMU & imu = imuSensors_[num]; /// reference
-
-    BOOST_ASSERT (imu.time<k_data_ && "The IMU has been already set, use another number");
-
-    imu.acceleroGyro.head<3>()=accelero;
-    imu.acceleroGyro.tail<3>()=gyrometer;
-    if (imuSensors_[num].time == 0) /// this is the first value for the IMU
-    {
-      imu.covMatrixAccelero = acceleroCovMatDefault_;
-      imu.covMatrixGyro = gyroCovMatDefault_;
-      imu.kinematics=localKine;
-      BOOST_ASSERT(imu.kinematics.position.isSet()
-                && imu.kinematics.orientation.isSet() &&
-                "The kinematics of the IMU is incorrectly initialized");
-      if (!imu.kinematics.linVel.isSet())
-      {
-        imu.kinematics.linVel.set().setZero();
-      }
-      if (!imu.kinematics.angVel.isSet())
-      {
-        imu.kinematics.angVel.set().setZero();
-      }
-      if (!imu.kinematics.linAcc.isSet())
-      {
-        imu.kinematics.linAcc.set().setZero();
-      }
-    }
-    else
-    {
-      imu.kinematics.update(localKine, dt_*(k_data_-k_data_),flagsIMUKine);
-    }
-
-    imu.time = k_data_;
-    ++IMU::currentNumber;
-
-    return num;
-  }
-
-  int KineticsObserver::setIMU(const Vector3 & accelero, const  Vector3 & gyrometer, const Matrix3& acceleroCov,
-                                                        const Matrix3 gyroCov, const Kinematics &localKine, int num)
-  {
-    ///ensure the measuements are labeled with the good time stamp
-    startNewIteration_();
-
-    if (num<0)
-    {
-      num=0;
-      while (imuSensors_[num].time!=k_data_ && unsigned(num)< imuSensors_.size())
-      {
-        ++num;
+        stateVector_.segment<sizeWrench>(contactWrenchIndex(i)).setZero();
       }
     }
-
-    BOOST_ASSERT (unsigned(num)<maxImuNumber_ && "The inserted IMU number exceeds the maximum number");
-
-    IMU & imu = imuSensors_[num]; /// reference
-
-    BOOST_ASSERT (imu.time<k_data_ && "The IMU has been already set, use another number");
-
-    imu.acceleroGyro.head<3>()=accelero;
-    imu.acceleroGyro.tail<3>()=gyrometer;
-    imu.covMatrixAccelero  = acceleroCov;
-    imu.covMatrixGyro = gyroCov;
-
-    if (imuSensors_[num].time == 0) /// this is the first value for the IMU
-    {
-      imu.kinematics=localKine;
-      BOOST_ASSERT(imu.kinematics.position.isSet()
-                && imu.kinematics.orientation.isSet() &&
-                "The kinematics of the IMU is incorrectly initialized");
-      if (!imu.kinematics.linVel.isSet())
-      {
-        imu.kinematics.linVel.set().setZero();
-      }
-      if (!imu.kinematics.angVel.isSet())
-      {
-        imu.kinematics.angVel.set().setZero();
-      }
-      if (!imu.kinematics.linAcc.isSet())
-      {
-        imu.kinematics.linAcc.set().setZero();
-      }
-    }
-    else
-    {
-      imu.kinematics.update(localKine, dt_*(k_data_-k_data_),flagsIMUKine);
-    }
-
-    imu.time = k_data_;
-
-    ++IMU::currentNumber;
-
-    return num;
   }
 
-  void KineticsObserver::setIMUDefaultCovarianceMatrix(const Matrix3& acceleroCov, const Matrix3 &gyroCov)
+  ekf_.setState(stateVector_, k_est_);
+
+  if(resetCovariance)
   {
-    acceleroCovMatDefault_=acceleroCov;
-    gyroCovMatDefault_=gyroCov;
+    Matrix stateCovariance = ekf_.getStateCovariance();
+    setBlockStateCovariance<sizeStateKineTangent>(stateCovariance, stateKinematicsInitCovMat_, kineIndex());
+
+    if(resetForces)
+    {
+      for(VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+      {
+        if(i->isSet)
+        {
+          setBlockStateCovariance<sizeContact>(stateCovariance, contactInitCovMat_, contactIndex(i));
+        }
+      }
+    }
+    ekf_.setStateCovariance(stateCovariance);
+  }
+}
+
+void KineticsObserver::setGyroBias(const Vector3 & bias, unsigned numberOfIMU, bool resetCovariance)
+{
+  stateVector_.segment<sizeGyroBias>(gyroBiasIndex(numberOfIMU)) = bias;
+  ekf_.setState(stateVector_, k_est_);
+
+  if(resetCovariance)
+  {
+    Matrix stateCovariance = ekf_.getStateCovariance();
+    setBlockStateCovariance<sizeGyroBias>(stateCovariance, gyroBiasInitCovMat_, gyroBiasIndex(numberOfIMU));
+
+    ekf_.setStateCovariance(stateCovariance);
+  }
+}
+
+void KineticsObserver::setStateUnmodeledWrench(const Vector6 & wrench, bool resetCovariance)
+{
+  stateVector_.segment<sizeWrench>(unmodeledWrenchIndex()) = wrench;
+  ekf_.setState(stateVector_, k_est_);
+
+  if(resetCovariance)
+  {
+    Matrix stateCovariance = ekf_.getStateCovariance();
+    setBlockStateCovariance<sizeWrench>(stateCovariance, unmodeledWrenchInitCovMat_, unmodeledWrenchIndex());
+
+    ekf_.setStateCovariance(stateCovariance);
+  }
+}
+
+void KineticsObserver::setStateVector(const Vector & v, bool resetCovariance)
+{
+  stateVector_ = v;
+  ekf_.setState(v, k_est_);
+  updateKine_();
+
+  if(resetCovariance)
+  {
+    resetStateCovarianceMat();
+  }
+}
+
+void KineticsObserver::setAdditionalWrench(const Vector3 & force, const Vector3 & moment)
+{
+
+  additionalForce_ = force;
+  additionalTorque_ = moment;
+}
+
+void KineticsObserver::setWithUnmodeledWrench(bool b)
+{
+  withUnmodeledWrench_ = b;
+}
+
+void KineticsObserver::setWithAccelerationEstimation(bool b)
+{
+  withAccelerationEstimation_ = b;
+}
+
+void KineticsObserver::setWithGyroBias(bool b)
+{
+  withAccelerationEstimation_ = b;
+}
+
+int KineticsObserver::setIMU(const Vector3 & accelero, const Vector3 & gyrometer, const Kinematics & localKine, int num)
+{
+  /// ensure the measuements are labeled with the good time stamp
+  startNewIteration_();
+
+  if(num < 0)
+  {
+    num = 0;
+    while(imuSensors_[num].time != k_data_ && unsigned(num) < imuSensors_.size())
+    {
+      ++num;
+    }
   }
 
-  void KineticsObserver::setContactWrenchSensor(const Vector6 & wrench, const Kinematics &localKine, unsigned contactNumber)
+  BOOST_ASSERT(unsigned(num) < maxImuNumber_ && "The inserted IMU number exceeds the maximum number");
+
+  IMU & imu = imuSensors_[num]; /// reference
+
+  BOOST_ASSERT(imu.time < k_data_ && "The IMU has been already set, use another number");
+
+  imu.acceleroGyro.head<3>() = accelero;
+  imu.acceleroGyro.tail<3>() = gyrometer;
+  if(imuSensors_[num].time == 0) /// this is the first value for the IMU
   {
-    ///ensure the measuements are labeled with the good time stamp
-    startNewIteration_();
+    imu.covMatrixAccelero = acceleroCovMatDefault_;
+    imu.covMatrixGyro = gyroCovMatDefault_;
+    imu.kinematics = localKine;
+    BOOST_ASSERT(imu.kinematics.position.isSet() && imu.kinematics.orientation.isSet()
+                 && "The kinematics of the IMU is incorrectly initialized");
+    if(!imu.kinematics.linVel.isSet())
+    {
+      imu.kinematics.linVel.set().setZero();
+    }
+    if(!imu.kinematics.angVel.isSet())
+    {
+      imu.kinematics.angVel.set().setZero();
+    }
+    if(!imu.kinematics.linAcc.isSet())
+    {
+      imu.kinematics.linAcc.set().setZero();
+    }
+  }
+  else
+  {
+    imu.kinematics.update(localKine, dt_ * (k_data_ - k_data_), flagsIMUKine);
+  }
 
-    BOOST_ASSERT(contactNumber < maxContacts_ && "Tried to set the wrench of a contact number higher than the maximum.");
+  imu.time = k_data_;
+  ++IMU::currentNumber;
 
-    BOOST_ASSERT((contacts_[contactNumber].isSet) && "Tried to set the wrench of non-existing contact. \
+  return num;
+}
+
+int KineticsObserver::setIMU(const Vector3 & accelero,
+                             const Vector3 & gyrometer,
+                             const Matrix3 & acceleroCov,
+                             const Matrix3 gyroCov,
+                             const Kinematics & localKine,
+                             int num)
+{
+  /// ensure the measuements are labeled with the good time stamp
+  startNewIteration_();
+
+  if(num < 0)
+  {
+    num = 0;
+    while(imuSensors_[num].time != k_data_ && unsigned(num) < imuSensors_.size())
+    {
+      ++num;
+    }
+  }
+
+  BOOST_ASSERT(unsigned(num) < maxImuNumber_ && "The inserted IMU number exceeds the maximum number");
+
+  IMU & imu = imuSensors_[num]; /// reference
+
+  BOOST_ASSERT(imu.time < k_data_ && "The IMU has been already set, use another number");
+
+  imu.acceleroGyro.head<3>() = accelero;
+  imu.acceleroGyro.tail<3>() = gyrometer;
+  imu.covMatrixAccelero = acceleroCov;
+  imu.covMatrixGyro = gyroCov;
+
+  if(imuSensors_[num].time == 0) /// this is the first value for the IMU
+  {
+    imu.kinematics = localKine;
+    BOOST_ASSERT(imu.kinematics.position.isSet() && imu.kinematics.orientation.isSet()
+                 && "The kinematics of the IMU is incorrectly initialized");
+    if(!imu.kinematics.linVel.isSet())
+    {
+      imu.kinematics.linVel.set().setZero();
+    }
+    if(!imu.kinematics.angVel.isSet())
+    {
+      imu.kinematics.angVel.set().setZero();
+    }
+    if(!imu.kinematics.linAcc.isSet())
+    {
+      imu.kinematics.linAcc.set().setZero();
+    }
+  }
+  else
+  {
+    imu.kinematics.update(localKine, dt_ * (k_data_ - k_data_), flagsIMUKine);
+  }
+
+  imu.time = k_data_;
+
+  ++IMU::currentNumber;
+
+  return num;
+}
+
+void KineticsObserver::setIMUDefaultCovarianceMatrix(const Matrix3 & acceleroCov, const Matrix3 & gyroCov)
+{
+  acceleroCovMatDefault_ = acceleroCov;
+  gyroCovMatDefault_ = gyroCov;
+}
+
+void KineticsObserver::setContactWrenchSensor(const Vector6 & wrench,
+                                              const Kinematics & localKine,
+                                              unsigned contactNumber)
+{
+  /// ensure the measuements are labeled with the good time stamp
+  startNewIteration_();
+
+  BOOST_ASSERT(contactNumber < maxContacts_ && "Tried to set the wrench of a contact number higher than the maximum.");
+
+  BOOST_ASSERT((contacts_[contactNumber].isSet) && "Tried to set the wrench of non-existing contact. \
                                             The contact must be added BEFORE setting a contact wrench Sensor");
 
-    if (contacts_[contactNumber].time == k_data_-1) ///the contact is not newly set
-    {
-      contacts_[contactNumber].localKine.update(localKine,dt_,Contact::localKineFlags);
-    }
-    else ///the contact is newlyset
-    {
-      contacts_[contactNumber].localKine = localKine;
-    }
-    contacts_[contactNumber].wrench=wrench;
-    contacts_[contactNumber].time = k_data_;
+  if(contacts_[contactNumber].time == k_data_ - 1) /// the contact is not newly set
+  {
+    contacts_[contactNumber].localKine.update(localKine, dt_, Contact::localKineFlags);
+  }
+  else /// the contact is newlyset
+  {
+    contacts_[contactNumber].localKine = localKine;
+  }
+  contacts_[contactNumber].wrench = wrench;
+  contacts_[contactNumber].time = k_data_;
 
-    if (!contacts_[contactNumber].sensorCovMatrix.isSet())
-    {
-      contacts_[contactNumber].sensorCovMatrix = contactWrenchSensorCovMatDefault_;
-    }
-
-    if (!(contacts_[contactNumber].withRealSensor))
-    {
-      contacts_[contactNumber].withRealSensor=true;
-      Contact::numberOfRealSensors++;
-    }
+  if(!contacts_[contactNumber].sensorCovMatrix.isSet())
+  {
+    contacts_[contactNumber].sensorCovMatrix = contactWrenchSensorCovMatDefault_;
   }
 
-   void KineticsObserver::setContactWrenchSensor(const Vector6 & wrench, const Matrix6 & wrenchCovMatrix,
-                                                                                    const Kinematics &localKine, unsigned contactNumber)
+  if(!(contacts_[contactNumber].withRealSensor))
   {
-    ///ensure the measuements are labeled with the good time stamp
-    startNewIteration_();
+    contacts_[contactNumber].withRealSensor = true;
+    Contact::numberOfRealSensors++;
+  }
+}
 
-    BOOST_ASSERT(contactNumber < maxContacts_ && "Tried to set the wrench of a contact number higher than the maximum.");
+void KineticsObserver::setContactWrenchSensor(const Vector6 & wrench,
+                                              const Matrix6 & wrenchCovMatrix,
+                                              const Kinematics & localKine,
+                                              unsigned contactNumber)
+{
+  /// ensure the measuements are labeled with the good time stamp
+  startNewIteration_();
 
-    BOOST_ASSERT((contacts_[contactNumber].isSet) && "Tried to set the wrench of non-existing contact. \
+  BOOST_ASSERT(contactNumber < maxContacts_ && "Tried to set the wrench of a contact number higher than the maximum.");
+
+  BOOST_ASSERT((contacts_[contactNumber].isSet) && "Tried to set the wrench of non-existing contact. \
                                             The contact must be added BEFORE setting a contact wrench Sensor");
 
-    if (contacts_[contactNumber].time == k_data_-1) ///the contact is not newly set
-    {
-      contacts_[contactNumber].localKine.update(localKine,dt_,Contact::localKineFlags);
-    }
-    else ///the contact is newlyset
-    {
-      contacts_[contactNumber].localKine = localKine;
-    }
-    contacts_[contactNumber].wrench=wrench;
-    contacts_[contactNumber].time = k_data_;
-    contacts_[contactNumber].sensorCovMatrix = wrenchCovMatrix;
-
-    if (!(contacts_[contactNumber].withRealSensor))
-    {
-      contacts_[contactNumber].withRealSensor=true;
-      Contact::numberOfRealSensors++;
-    }
-  }
-
-  void KineticsObserver::setContactWrenchSensorDefaultCovarianceMatrix(const Matrix6 & wrenchSensorCovMat)
+  if(contacts_[contactNumber].time == k_data_ - 1) /// the contact is not newly set
   {
-    contactWrenchSensorCovMatDefault_=wrenchSensorCovMat;
+    contacts_[contactNumber].localKine.update(localKine, dt_, Contact::localKineFlags);
   }
-
-  void KineticsObserver::setContactWithNoSensor(const Kinematics &localKine, unsigned contactNumber)
+  else /// the contact is newlyset
   {
-     ///ensure the measuements are labeled with the good time stamp
-    startNewIteration_();
+    contacts_[contactNumber].localKine = localKine;
+  }
+  contacts_[contactNumber].wrench = wrench;
+  contacts_[contactNumber].time = k_data_;
+  contacts_[contactNumber].sensorCovMatrix = wrenchCovMatrix;
 
-    BOOST_ASSERT(contactNumber < maxContacts_ && "Tried to set the wrench of a contact number higher than the maximum.");
+  if(!(contacts_[contactNumber].withRealSensor))
+  {
+    contacts_[contactNumber].withRealSensor = true;
+    Contact::numberOfRealSensors++;
+  }
+}
 
-    BOOST_ASSERT((contacts_[contactNumber].isSet) && "Tried to set the wrench of non-existing contact. \
+void KineticsObserver::setContactWrenchSensorDefaultCovarianceMatrix(const Matrix6 & wrenchSensorCovMat)
+{
+  contactWrenchSensorCovMatDefault_ = wrenchSensorCovMat;
+}
+
+void KineticsObserver::setContactWithNoSensor(const Kinematics & localKine, unsigned contactNumber)
+{
+  /// ensure the measuements are labeled with the good time stamp
+  startNewIteration_();
+
+  BOOST_ASSERT(contactNumber < maxContacts_ && "Tried to set the wrench of a contact number higher than the maximum.");
+
+  BOOST_ASSERT((contacts_[contactNumber].isSet) && "Tried to set the wrench of non-existing contact. \
                                             The contact must be added BEFORE setting a contact wrench Sensor");
 
-    if (contacts_[contactNumber].time == k_data_-1) ///the contact is not newly set
-    {
-      contacts_[contactNumber].localKine.update(localKine,dt_,Contact::localKineFlags);
-    }
-    else ///the contact is newlyset
-    {
-      contacts_[contactNumber].localKine = localKine;
-    }
-
-    contacts_[contactNumber].time = k_data_;
-
-    if (contacts_[contactNumber].withRealSensor)
-    {
-      contacts_[contactNumber].withRealSensor=false;
-      Contact::numberOfRealSensors--;
-    }
-
+  if(contacts_[contactNumber].time == k_data_ - 1) /// the contact is not newly set
+  {
+    contacts_[contactNumber].localKine.update(localKine, dt_, Contact::localKineFlags);
+  }
+  else /// the contact is newlyset
+  {
+    contacts_[contactNumber].localKine = localKine;
   }
 
-  void KineticsObserver::setAbsolutePoseSensor(const Kinematics & pose)
+  contacts_[contactNumber].time = k_data_;
+
+  if(contacts_[contactNumber].withRealSensor)
   {
-    ///ensure the measuements are labeled with the good time stamp
-    startNewIteration_();
-
-    absPoseSensor_.time = k_data_;
-    absPoseSensor_.pose = pose;
-
-    if (!(absPoseSensor_.covMatrix.isSet()))
-    {
-      absPoseSensor_.covMatrix = absPoseSensorCovMatDefault_;
-    }
+    contacts_[contactNumber].withRealSensor = false;
+    Contact::numberOfRealSensors--;
   }
+}
 
-  void KineticsObserver::setAbsolutePoseSensor(const Kinematics & pose, const Matrix6 & CovarianceMatrix)
+void KineticsObserver::setAbsolutePoseSensor(const Kinematics & pose)
+{
+  /// ensure the measuements are labeled with the good time stamp
+  startNewIteration_();
+
+  absPoseSensor_.time = k_data_;
+  absPoseSensor_.pose = pose;
+
+  if(!(absPoseSensor_.covMatrix.isSet()))
   {
-    ///ensure the measuements are labeled with the good time stamp
-    startNewIteration_();
-
-    absPoseSensor_.time = k_data_;
-    absPoseSensor_.pose = pose;
-
-    absPoseSensor_.covMatrix = CovarianceMatrix;
+    absPoseSensor_.covMatrix = absPoseSensorCovMatDefault_;
   }
+}
 
-  void KineticsObserver::setAbsolutePoseSensorDefaultCovarianceMatrix(const Matrix6& newdefault)
+void KineticsObserver::setAbsolutePoseSensor(const Kinematics & pose, const Matrix6 & CovarianceMatrix)
+{
+  /// ensure the measuements are labeled with the good time stamp
+  startNewIteration_();
+
+  absPoseSensor_.time = k_data_;
+  absPoseSensor_.pose = pose;
+
+  absPoseSensor_.covMatrix = CovarianceMatrix;
+}
+
+void KineticsObserver::setAbsolutePoseSensorDefaultCovarianceMatrix(const Matrix6 & newdefault)
+{
+  absPoseSensorCovMatDefault_ = newdefault;
+}
+
+void KineticsObserver::setInertiaMatrix(const Matrix3 & I, const Matrix3 & I_dot)
+{
+  startNewIteration_();
+  I_.set(I, k_data_);
+  Id_.set(I_dot, k_data_);
+}
+
+void KineticsObserver::setInertiaMatrix(const Matrix3 & I)
+{
+  startNewIteration_();
+
+  if(I_.getTime() < k_data_)
   {
-    absPoseSensorCovMatDefault_ = newdefault;
+    Id_.set(tools::derivate(I_(), I, dt_ * double(k_data_ - I_.getTime())), k_data_);
   }
+  I_.set(I, k_data_);
+}
 
-  void KineticsObserver::setInertiaMatrix(const Matrix3& I, const Matrix3& I_dot)
+void KineticsObserver::setInertiaMatrix(const Vector6 & Iv, const Vector6 & Iv_dot)
+{
+  startNewIteration_();
+
+  I_.set();
+  I_.setIndex(k_data_);
+  fillSymmetricMatrix(I_(), Iv.head<3>(), Iv(3), Iv(4), Iv(5));
+
+  Id_.set();
+  Id_.setIndex(k_data_);
+  fillSymmetricMatrix(Id_(), Iv_dot.head<3>(), Iv_dot(3), Iv_dot(4), Iv_dot(5));
+}
+
+void KineticsObserver::setInertiaMatrix(const Vector6 & Iv)
+{
+  startNewIteration_();
+  namespace t = tools;
+
+  if(I_.getTime() < k_data_)
   {
-    startNewIteration_();
-    I_.set(I,k_data_);
-    Id_.set(I_dot,k_data_);
-
-  }
-
-  void KineticsObserver::setInertiaMatrix(const Matrix3& I)
-  {
-    startNewIteration_();
-
-    if (I_.getTime()<k_data_)
-    {
-      Id_.set(tools::derivate(I_(),I,dt_*double(k_data_-I_.getTime())),k_data_);
-    }
-    I_.set(I,k_data_);
-  }
-
-  void KineticsObserver::setInertiaMatrix(const Vector6& Iv, const Vector6& Iv_dot)
-  {
-    startNewIteration_();
-
-    I_.set();
-    I_.setIndex(k_data_);
-    fillSymmetricMatrix(I_(),Iv.head<3>(),Iv(3),Iv(4),Iv(5));
-
     Id_.set();
     Id_.setIndex(k_data_);
-    fillSymmetricMatrix(Id_(),Iv_dot.head<3>(),Iv_dot(3),Iv_dot(4),Iv_dot(5));
-  }
-
-  void KineticsObserver::setInertiaMatrix(const Vector6& Iv)
-  {
-    startNewIteration_();
-    namespace t = tools;
-
-    if (I_.getTime()<k_data_)
-    {
-      Id_.set();
-      Id_.setIndex(k_data_);
-      double dt = dt_*double(k_data_-I_.getTime());
-      fillSymmetricMatrix(Id_(),t::derivate<Vector3>(I_().diagonal(),Iv.head<3>(),dt),
-                                t::derivate(I_()(1,0), Iv(3), dt),
-                                t::derivate(I_()(2,0), Iv(4), dt),
-                                t::derivate(I_()(2,1), Iv(5), dt));
-    }
-
-    I_.set();
-    I_.setIndex(k_data_);
-    fillSymmetricMatrix(I_(),Iv.head<3>(),Iv(3),Iv(4),Iv(5));
-  }
-
-  void KineticsObserver::setCenterOfMass(const Vector3& com, const Vector3& com_dot, const Vector3& com_dot_dot)
-  {
-    startNewIteration_();
-    com_.set(com,k_data_);
-    comd_.set(com_dot,k_data_);
-    comdd_.set(com_dot_dot,k_data_);
-  }
-
-  void KineticsObserver::setCenterOfMass(const Vector3& com, const Vector3& com_dot)
-  {
-    startNewIteration_();
-    com_.set(com,k_data_);
-
-
-    if (comd_.getTime()<k_data_)
-    {
-      comdd_.set( tools::derivate(comd_(),com_dot,dt_ * double(k_data_- comd_.getTime())),k_data_);
-    }
-    comd_.set(com_dot,k_data_);
-
-
-  }
-
-  void KineticsObserver::setCenterOfMass(const Vector3& com)
-  {
-    startNewIteration_();
-
-    if (com_.getTime()<k_data_ )
-    {
-      double dt = dt_ * double(k_data_- com_.getTime());
-      Vector3 com_dot = tools::derivate(com_(),com,dt);
-
-      comdd_.set( tools::derivate(comd_(),com_dot,dt),k_data_);
-
-      comd_.set(com_dot,k_data_);
-    }
-
-    com_.set(com,k_data_);
-  }
-
-  void KineticsObserver::setAngularMomentum (const Vector3& sigma, const Vector3& sigma_dot)
-  {
-    startNewIteration_();
-    sigma_.set(sigma, k_data_);
-    sigmad_.set(sigma_dot, k_data_);
-  }
-
-  void KineticsObserver::setAngularMomentum (const Vector3& sigma)
-  {
-    startNewIteration_();
-    if (sigma_.getTime()<k_data_)
-    {
-      sigmad_.set(tools::derivate(sigma_(),sigma,dt_*double(k_data_-sigma_.getTime())),
-                  k_data_);
-    }
-    sigma_.set(sigma,k_data_);
-  }
-
-
-  int KineticsObserver::addContact(const Kinematics & pose,
-                            const Matrix12 & initialCovarianceMatrix, const Matrix12 & processCovarianceMatrix,
-                            const Matrix3 & linearStiffness,  const Matrix3 & linearDamping,
-                            const Matrix3 & angularStiffness, const Matrix3 & angularDamping,
-                            int contactNumber)
-  {
-
-    BOOST_ASSERT (pose.position.isSet() &&  pose.orientation.isSet() &&
-     "The added contact pose is not initialized correctly (position and orientation)");
-
-
-    if (contactNumber <0)
-    {
-      contactNumber=0;
-
-      while (unsigned(contactNumber) < maxContacts_  && contacts_[contactNumber].isSet)
-      {
-        ++contactNumber;
-      }
-    }
-
-    BOOST_ASSERT (unsigned(contactNumber)<maxContacts_ &&
-        "Trying to add contact: The contact number exceeds the maximum allowed, please give a number of contact between 0 and maxContact-1");
-
-
-    if (unsigned(contactNumber)>=maxContacts_) ///this is a bug-prone protection code that is here only to guarantee the consistence of the state
-    {
-      contactNumber = maxContacts_-1;
-    }
-
-    BOOST_ASSERT ( !contacts_[contactNumber].isSet && "The contact already exists, please remove it before adding it again");
-
-    Contact & contact = contacts_[contactNumber];  ///reference
-
-    contact.isSet=true; ///set the contacts
-    contact.stateIndex = contactsIndex()+contactNumber*sizeContact;
-    contact.stateIndexTangent = contactsIndexTangent()+contactNumber*sizeContactTangent;
-
-    contact.absPose = pose;
-
-    contact.linearStiffness = linearStiffness;
-    contact.linearDamping = linearDamping;
-    contact.angularStiffness = angularStiffness;
-    contact.angularDamping = angularDamping;
-
-    ///update the state vector
-    stateVector_.segment<sizeContact> (contact.stateIndex) << pose.toVector(flagsContactKine) , Vector6::Zero();
-
-    /// sets the initial covariance matrix
-    Matrix stateCovMat= ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeContactTangent>(stateCovMat,initialCovarianceMatrix,contact.stateIndexTangent);
-    ekf_.setStateCovariance(stateCovMat);
-
-    ///Sets the process cov mat
-    Matrix processCovMat= ekf_.getQ();
-    setBlockStateCovariance<sizeContactTangent>(processCovMat,processCovarianceMatrix,contact.stateIndexTangent);
-    ekf_.setQ(processCovMat);
-
-    return contactNumber;
-  }
-
-  /// version with default stiffness and damping
-  /// use when the contact parameters are known
-  int KineticsObserver::addContact(const Kinematics & pose,
-                            const Matrix12 & initialCovarianceMatrix, const Matrix12 & processCovarianceMatrix,
-                            int contactNumber)
-  {
-    return addContact(pose,initialCovarianceMatrix,processCovarianceMatrix,
-                      linearStiffnessMatDefault_,linearDampingMatDefault_,
-                      angularDampingMatDefault_,angularDampingMatDefault_,contactNumber);
-
-  }
-
-  /// version when the contact position is perfectly known
-  int KineticsObserver::addContact(const Kinematics & pose,
-                            const Matrix3 & linearStiffness,  const Matrix3 & linearDamping,
-                            const Matrix3 & angularStiffness, const Matrix3 & angularDamping,
-                            int contactNumber)
-  {
-    return addContact(pose,contactInitCovMat_,contactProcessCovMat_,linearStiffness,linearDamping,
-                      angularStiffness,angularDamping,contactNumber);
-
-
-  }
-
-  /// version when the position is perfectly known but not the stiffness and damping
-  int KineticsObserver::addContact(const Kinematics & pose, int contactNumber)
-  {
-    return addContact(pose,contactInitCovMat_,contactProcessCovMat_,
-                      linearStiffnessMatDefault_,linearDampingMatDefault_,
-                      angularDampingMatDefault_,angularDampingMatDefault_,contactNumber);
-  }
-
-  void KineticsObserver::removeContact(int contactNbr)
-  {
-    BOOST_ASSERT(!contacts_[contactNbr].isSet && "Tried to remove a non-existing contact.");
-    if (contacts_[contactNbr].isSet)
-    {
-      contacts_[contactNbr].isSet = false;
-      if (contacts_[contactNbr].withRealSensor)
-      {
-        contacts_[contactNbr].withRealSensor = false;
-        --Contact::numberOfRealSensors;
-      }
-    }
-  }
-
-  void KineticsObserver::clearContacts()
-  {
-    contacts_.clear();
-    Contact::numberOfRealSensors=0;
-  }
-
-  Index KineticsObserver::getNumberOfContacts() const
-  {
-    return contacts_.size();
-  }
-
-  std::vector<int> KineticsObserver::getListOfContacts() const
-  {
-    std::vector<int> v;
-
-    for (unsigned i = 0; i < contacts_.size(); ++i)
-    {
-      if (contacts_[i].isSet)
-      {
-        v.push_back(i);
-      }
-    }
-    return v;
-  }
-
-  void KineticsObserver::setStateCovariance(const Matrix & P)
-  {
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::setKinematicsStateCovariance(const Matrix & P_kine)
-  {
-    Matrix P = ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeStateKineTangent>(P,P_kine,kineIndexTangent());
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::setKinematicsInitCovarianceDefault(const Matrix & P_kine)
-  {
-    stateKinematicsInitCovMat_=P_kine;
-  }
-
-  void KineticsObserver::setGyroBiasStateCovariance(const Matrix3 & covMat, unsigned imuNumber)
-  {
-    Matrix P = ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeGyroBias>(P,covMat,gyroBiasIndexTangent(imuNumber));
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::setGyroBiasInitCovarianceDefault(const Matrix3 & covMat)
-  {
-    gyroBiasInitCovMat_ = covMat;
-  }
-
-  void KineticsObserver::setGyroBiasProcessCovariance(const Matrix3 & covMat, unsigned imuNumber)
-  {
-    Matrix P = ekf_.getProcessCovariance();
-    setBlockStateCovariance<sizeGyroBias>(P,covMat,gyroBiasIndexTangent(imuNumber));
-    ekf_.setProcessCovariance(P);
-  }
-
-  void KineticsObserver::setUnmodeledWrenchStateCovMat(const Matrix6 & currentCovMat)
-  {
-    Matrix P = ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeWrench>(P,currentCovMat,unmodeledWrenchIndexTangent());
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::setUnmodeledWrenchIniCovMatDefault(const Matrix6 & initCovMat)
-  {
-    unmodeledWrenchInitCovMat_=initCovMat;
-  }
-
-  void KineticsObserver::setUnmodeledWrenchProcessCovMat(const Matrix6 & processCovMat)
-  {
-    Matrix P = ekf_.getProcessCovariance();
-    setBlockStateCovariance<sizeWrench>(P,processCovMat,unmodeledWrenchIndexTangent());
-    ekf_.setProcessCovariance(P);
-  }
-
-  void KineticsObserver::setContactStateCovMat(int contactNbr, const Matrix12 & contactCovMat)
-  {
-    Matrix P = ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeContactTangent>(P,contactCovMat,contactIndexTangent(contactNbr));
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::setContactInitCovMatDefault(const Matrix12 & contactCovMat)
-  {
-    contactInitCovMat_ = contactCovMat;
-  }
-
-  void KineticsObserver::setContactProcessCovMat(int contactNbr, const Matrix12 & contactCovMat)
-  {
-    Matrix P = ekf_.getProcessCovariance();
-    setBlockStateCovariance<sizeContactTangent>(P,contactCovMat,contactIndexTangent(contactNbr));
-    ekf_.setProcessCovariance(P);
-  }
-
-  Matrix KineticsObserver::getStateCovariance() const
-  {
-    return ekf_.getStateCovariance();
-  }
-
-  void KineticsObserver::setProcessNoiseCovariance(const Matrix & Q)
-  {
-    ekf_.setProcessCovariance(Q);
-  }
-
-
-
-  Vector KineticsObserver::getMeasurementVector()
-  {
-    Vector measurement(getMeasurementSize());
-    Index currIndex = 0;
-    if (k_est_!=k_data_)
-    {
-      for (VectorIMUIterator i = imuSensors_.begin(); i != imuSensors_.end(); ++i)
-      {
-        if (i->time==k_data_)
-        {
-          measurement.segment<sizeIMUSignal>(currIndex) = i->acceleroGyro;
-          currIndex += sizeIMUSignal;
-        }
-      }
-
-      for (VectorContactIterator i= contacts_.begin(); i!=contacts_.end() ; ++i)
-      {
-        if (i->isSet)
-        {
-          if (i->time == k_data_ && i->withRealSensor)
-          {
-            measurement.segment<sizeWrench>(currIndex) = i->wrench;
-            currIndex += sizeWrench;
-          }
-        }
-      }
-
-      if (absPoseSensor_.time == k_data_)
-      {
-        measurement.segment<sizePose>(currIndex) = absPoseSensor_.pose.toVector(flagsPoseKine);
-        currIndex+=sizePose;
-      }
-    }
-    return measurement;
-  }
-
-  const ExtendedKalmanFilter & KineticsObserver::getEKF() const
-  {
-    return ekf_;
-  }
-
-  ExtendedKalmanFilter & KineticsObserver::getEKF()
-  {
-    return ekf_;
-  }
-
-  void KineticsObserver::resetStateCovarianceMat()
-  {
-    resetStateKinematicsCovMat();
-    for (unsigned i=0; i < imuSensors_.size(); ++i)
-    {
-      if (imuSensors_[i].time== k_data_)
-      {
-        resetStateGyroBiasCovMat(i);
-      }
-    }
-    resetStateUnmodeledWrenchCovMat();
-    resetStateContactsCovMat();
-  }
-
-  void KineticsObserver::resetStateKinematicsCovMat()
-  {
-    Matrix P = ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeStateKineTangent>(P,stateKinematicsInitCovMat_,kineIndexTangent());
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::resetStateGyroBiasCovMat( unsigned i)
-  {
-    Matrix P = ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeGyroBias>(P,gyroBiasInitCovMat_,gyroBiasIndexTangent(i));
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::resetStateUnmodeledWrenchCovMat()
-  {
-    Matrix P = ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeWrench>(P,unmodeledWrenchInitCovMat_,unmodeledForceIndexTangent());
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::resetStateContactsCovMat()
-  {
-    for (unsigned i =0 ; i < contacts_.size() ; ++i)
-    {
-      if (contacts_[i].isSet)
-      {
-        resetStateContactCovMat(i);
-      }
-    }
-  }
-
-
-
-  void KineticsObserver::resetStateContactCovMat(unsigned contactNbr)
-  {
-    BOOST_ASSERT(contactNbr < contacts_.size() && contacts_[contactNbr].isSet \
-                     && "Tried to set the covariance of a non existant contact");
-
-    Matrix P = ekf_.getStateCovariance();
-    setBlockStateCovariance<sizeContactTangent>(P, contactInitCovMat_, contacts_[contactNbr].stateIndexTangent);
-    ekf_.setStateCovariance(P);
-  }
-
-  void KineticsObserver::resetProcessCovarianceMat()
-  {
-    resetProcessKinematicsCovMat();
-    for (unsigned i=0;i<imuSensors_.size();++i)
-    {
-      resetProcessGyroBiasCovMat(i);
-    }
-    resetProcessUnmodeledWrenchCovMat();
-    resetProcessContactsCovMat();
-  }
-
-  void KineticsObserver::resetProcessKinematicsCovMat()
-  {
-    Matrix P = ekf_.getProcessCovariance();
-    setBlockStateCovariance<sizeContactTangent>(P,stateKinematicsProcessCovMat_,kineIndexTangent());
-    ekf_.setProcessCovariance(P);
-  }
-
-  void KineticsObserver::resetProcessGyroBiasCovMat(unsigned i)
-  {
-    Matrix P = ekf_.getProcessCovariance();
-    setBlockStateCovariance<sizeGyroBias>(P,gyroBiasProcessCovMat_,gyroBiasIndexTangent(i));
-    ekf_.setProcessCovariance(P);
-  }
-
-  void KineticsObserver::resetProcessUnmodeledWrenchCovMat()
-  {
-    Matrix P = ekf_.getProcessCovariance();
-    setBlockStateCovariance<sizeWrench>(P,unmodeledWrenchProcessCovMat_,unmodeledForceIndexTangent());
-    ekf_.setProcessCovariance(P);
-  }
-
-  Index KineticsObserver::getInputSize() const
-  {
-    return inputSize;
-  }
-
-  void KineticsObserver::resetProcessContactsCovMat()
-  {
-    for (unsigned i =0 ; i < contacts_.size();++i)
-    {
-      if (contacts_[i].isSet)
-      {
-        resetProcessContactCovMat(i);
-      }
-    }
-  }
-
-  void KineticsObserver::resetProcessContactCovMat(unsigned contactNbr)
-  {
-    BOOST_ASSERT( contactNbr < maxContacts_ && contacts_[contactNbr].isSet \
-                   && "Tried to set the covariance of a non existant contact");
-
-    Matrix P = ekf_.getProcessCovariance();
-    setBlockStateCovariance<sizeContactTangent>(P,contactProcessCovMat_,contacts_[contactNbr].stateIndexTangent);
-    ekf_.setProcessCovariance(P);
-  }
-
-  void KineticsObserver::resetSensorsDefaultCovMat()
-  {
-    acceleroCovMatDefault_=Matrix3::Identity()*acceleroVarianceDefault;
-    gyroCovMatDefault_ = Matrix3::Identity()*gyroVarianceDefault;
-    contactWrenchSensorCovMatDefault_ = blockMat6( Matrix3::Identity()*forceSensorVarianceDefault, Matrix3::Zero(),
-                                Matrix3::Zero(), Matrix3::Identity()*torqueSensorVarianceDefault );
-    absPoseSensorCovMatDefault_= blockMat6( Matrix3::Identity()*positionSensorVarianceDefault, Matrix3::Zero(),
-                                Matrix3::Zero(), Matrix3::Identity()*orientationSensorVarianceDefault );
-  }
-
-  void KineticsObserver::resetInputs()
-  {
-    for (VectorIMUIterator i = imuSensors_.begin(); i!= imuSensors_.end();++i)
-    {
-      i->time = k_est_;
-    }
-
-    for (VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
-    {
-      i->time = k_est_;
-    }
-
-    absPoseSensor_.time = k_est_;
-  }
-
-  void KineticsObserver::setFiniteDifferenceStep(const Vector &v)
-  {
-    stateVectorDx_= v;
-  }
-
-  void KineticsObserver::useFiniteDifferencesJacobians(bool b)
-  {
-    finiteDifferencesJacobians_ = b;
-  }
-
-
-
-  Vector KineticsObserver::stateNaNCorrection_()
-  {
-    ///TODO implement this function
-    assert(false && "NaN Correction not yet implemented. Please Contact mehdi.benallegue@gmail.com");
-    return oldStateVector_;
-  }
-
-  void KineticsObserver::startNewIteration_()
-  {
-    if (k_est_==k_data_)
-    {
-      ++k_data_;
-      Contact::numberOfRealSensors=0;
-      IMU::currentNumber=0;
-    }
-  }
-
-  void KineticsObserver::setProcessNoise(NoiseBase * noise)
-  {
-    processNoise_= noise;
-  }
-
-  void KineticsObserver::resetProcessNoise()
-  {
-    processNoise_ = 0x0;
-  }
-
-  NoiseBase* KineticsObserver::getProcessNoise() const
-  {
-    return processNoise_;
-  }
-
-  void KineticsObserver::setMeasurementNoise(NoiseBase * noise)
-  {
-    measurementNoise_ = noise;
-  }
-
-  void KineticsObserver::resetMeasurementNoise()
-  {
-    measurementNoise_ = 0x0;
-  }
-
-  NoiseBase * KineticsObserver::getMeasurementNoise() const
-  {
-    return measurementNoise_;
-  }
-
-  Matrix KineticsObserver::computeAMatrix_()
-  {
-    return ekf_.getAMatrixFD(stateVectorDx_);
-  }
-
-  Matrix KineticsObserver::computeCMatrix_()
-  {
-    return ekf_.getCMatrixFD(stateVectorDx_);
-  }
-
-  void KineticsObserver::updateKine_()
-  {
-    stateKinematics_.fromVector(stateVector_.segment<sizeStateKine>(kineIndex()),
-                                flagsStateKine);
-  }
-
-  void KineticsObserver::addUnmodeledAndContactWrench_(const Vector &stateVector, Vector3 & force, Vector3 & torque)
-  {
-    force += stateVector.segment<sizeForce>(unmodeledWrenchIndex());
-    torque += stateVector.segment<sizeForce>(unmodeledTorqueIndex());
-
-    for (VectorContactIterator i = contacts_.begin(); i!= contacts_.end(); ++i)
-    {
-      if (i->isSet)
-      {
-        Kinematics & localKinei= i->localKine;
-        Vector3 localForcei = localKinei.orientation * stateVector.segment<sizeForce>(contactForceIndex(i));
-        force += localForcei;
-        torque += localKinei.orientation * stateVector.segment<sizeForce>(contactTorqueIndex(i)) +
-                localKinei.position().cross(localForcei);
-      }
-    }
-  }
-
-  void  KineticsObserver::computeAccelerations_(Kinematics & stateKine, const Vector3& totalForceLocal,
-                                const Vector3& totalMomentLocal, Vector3 & linAcc, Vector3& angAcc)
-  {
-    Matrix3 Rt =  stateKine.orientation.matrix3().inverse();
-    Vector3 Rtw = Rt * stateKine.angVel();
-    Vector3 corioCentri = 2* Rtw.cross(comd_()+Rtw.cross(com_()));
-
-    angAcc = stateKine.orientation *( ( I_() + mass_ * kine::skewSymmetric2(com_())).inverse()
-           * (totalMomentLocal - Id_()* Rtw -sigmad_() - Rtw.cross(I_()*Rtw+sigma_())
-           - com_().cross(totalForceLocal - mass_*(comdd_() + corioCentri ))));
-
-    linAcc =  stateKine.orientation * ((totalForceLocal/mass_) - comdd_()
-              - corioCentri + com_().cross(Rt * angAcc) ) - cst::gravity;
-
-  }
-
-  void KineticsObserver::computeContactForces_( VectorContactIterator i, Kinematics &stateKine,
-                                            Kinematics &contactPose , Vector3 & force, Vector3 torque)
-  {
-    Contact & contact = *i;
-
-    Kinematics & localKine = contact.localKine;
-
-    Kinematics globalKine(stateKine,localKine); /// product of kinematics
-
-    Matrix3 globKineOriInverse = globalKine.orientation.inverse();
-
-    force = globKineOriInverse *
-            (contact.linearStiffness* (contactPose.position()-globalKine.position())
-            -  contact.linearDamping * globalKine.linVel());
-    torque = globKineOriInverse *
-            (-0.5 * contact.angularStiffness *
-            ( Quaternion(globalKine.orientation) * Quaternion(contactPose.orientation).inverse() ).vec()
-           -contact.angularDamping * globalKine.angVel()) ;
-
-  }
-
-  void KineticsObserver::stateSum(const Vector& stateVector, const Vector & tangentVector, Vector & sum)
-  {
-    Orientation & o = opt_.ori;
-    sum = stateVector;
-    /// use the exponential map integration to perform the sum of the states
-    sum.segment<sizePos>(posIndex())+=tangentVector.segment<sizePos>(posIndexTangent());
-    o.fromVector4(stateVector.segment<sizeOri>(oriIndex()));
-    o.integrate(tangentVector.segment<sizeOriTangent>(oriIndexTangent()));
-    sum.segment<sizeOri>(oriIndex())=o.toVector4();
-    ///
-    sum.segment<sizeLinVel+sizeAngVel>(linVelIndex()) += tangentVector.segment<sizeLinVel+sizeAngVel>(linVelIndexTangent());
-    if (withGyroBias_)
-    {
-      for (unsigned i = 0 ; i < imuSensors_.size() ; ++i)
-      {
-        sum.segment<sizeGyroBias>(gyroBiasIndex(i))+=tangentVector.segment<sizeGyroBias>(gyroBiasIndexTangent(i));
-      }
-    }
-    if (withUnmodeledWrench_)
-    {
-      sum.segment<sizeWrench>(unmodeledWrenchIndex())+=tangentVector.segment<sizeWrench>(unmodeledWrenchIndexTangent());
-    }
-
-    for (VectorContactConstIterator i= contacts_.begin() ; i != contacts_.end() ; ++i)
-    {
-      if (i->isSet)
-      {
-        sum.segment<sizePos>(contactPosIndex(i))+=tangentVector.segment<sizePos>(contactPosIndexTangent(i));
-        o.fromVector4(stateVector.segment<sizeOri>(contactOriIndex(i)));
-        o.integrate(tangentVector.segment<sizeOriTangent>(contactOriIndexTangent(i)));
-        sum.segment<sizeOri>(contactOriIndex(i)) = o.toVector4();
-        sum.segment<sizeWrench>(contactWrenchIndex(i)) += tangentVector.segment<sizeWrench>(contactWrenchIndexTangent(i));
-      }
-    }
-  }
-
-  void KineticsObserver::stateDifference(const Vector& stateVector1, const Vector& stateVector2, Vector& difference)
-  {
-    Orientation & o1 = opt_.ori1;
-    Orientation & o2 = opt_.ori2;
-    difference.resize(stateTangentSize_);
-    difference.segment<sizePos>(posIndexTangent()).noalias() =
-                        stateVector1.segment<sizePos>(posIndex()) - stateVector2.segment<sizePos>(posIndex());
-    o1.fromVector4(stateVector1.segment<sizeOri>(oriIndex()));
-    o2.fromVector4(stateVector2.segment<sizeOri>(oriIndex()));
-    difference.segment<sizeOriTangent>(oriIndexTangent()) = o2.differentiate(o1);
-    difference.segment<sizeLinVel+sizeAngVel>(linVelIndexTangent()).noalias() =
-                        stateVector1.segment<sizeLinVel+sizeAngVel>(linVelIndex()) -stateVector2.segment<sizeLinVel+sizeAngVel>(linVelIndex());
-    if (withGyroBias_)
-    {
-      for (unsigned i = 0 ; i < imuSensors_.size() ; ++i)
-      {
-        difference.segment<sizeGyroBias>(gyroBiasIndexTangent(i)).noalias() =
-            stateVector1.segment<sizeGyroBias>(gyroBiasIndex(i)) - stateVector2.segment<sizeGyroBias>(gyroBiasIndex(i));
-      }
-    }
-    if (withUnmodeledWrench_)
-    {
-      difference.segment<sizeWrench>(unmodeledForceIndexTangent()).noalias() =
-                        stateVector1.segment<sizeWrench>(unmodeledWrenchIndex()) - stateVector2.segment<sizeWrench>(unmodeledWrenchIndex());
-    }
-
-    for (VectorContactConstIterator i= contacts_.begin(); i!= contacts_.end() ; ++i)
-    {
-      if (i->isSet)
-      {
-        difference.segment<sizePos>(contactPosIndexTangent(i)).noalias() =
-                        stateVector1.segment<sizePos>(contactPosIndex(i)) - stateVector2.segment<sizePos>(contactPosIndex(i));
-        o1.fromVector4(stateVector1.segment<sizeOri>(contactOriIndex(i)));
-        o2.fromVector4(stateVector2.segment<sizeOri>(contactOriIndex(i)));
-        difference.segment<sizeOriTangent>(contactOriIndexTangent(i))= o2.differentiate(o1);
-        difference.segment<sizeWrench>(contactWrenchIndexTangent(i)).noalias() =
-                        stateVector1.segment<sizeWrench>(contactWrenchIndex(i)) - stateVector2.segment<sizeWrench>(contactWrenchIndex(i));
-      }
-    }
-  }
-
-  void KineticsObserver::measurementDifference(const Vector& measureVector1, const Vector& measureVector2, Vector& difference)
-  {
-      Orientation & o1 = opt_.ori1;
-      Orientation & o2 = opt_.ori2;
-      difference.resize(measurementTangentSize_);
-
-      int currentMeasurementSize =sizeIMUSignal*IMU::currentNumber + sizeWrench*Contact::numberOfRealSensors;
-
-      difference.segment(0,currentMeasurementSize).noalias() =
-          measureVector1.segment(0,currentMeasurementSize) -
-            measureVector2.segment(0,currentMeasurementSize);
-
-      if (absPoseSensor_.time == k_data_)
-      {
-
-        difference.segment<sizePos>(currentMeasurementSize).noalias() =
-          measureVector1.segment<sizePos>(currentMeasurementSize) - measureVector2.segment<sizePos>(currentMeasurementSize);
-
-        currentMeasurementSize += sizePos;
-
-        o1.fromVector4(measureVector1.segment<sizeOri>(currentMeasurementSize));
-        o2.fromVector4(measureVector2.segment<sizeOri>(currentMeasurementSize));
-        difference.segment<sizeOriTangent>(currentMeasurementSize) = o2.differentiate(o1);
-      }
-  }
-
-
-
-  Vector KineticsObserver::stateDynamics(const Vector &xInput, const Vector &/*unused*/ , TimeIndex)
-  {
-    Vector x = xInput;
-    Vector3 forceLocal = additionalForce_;
-    Vector3 torqueLocal = additionalTorque_;
-
-    addUnmodeledAndContactWrench_(x,forceLocal,torqueLocal);
-
-    Kinematics stateKine(x.segment<sizeStateKine>(kineIndex()), flagsStateKine);
-
-    /// The accelerations are about to be computed so we set them to "initialized"
-    stateKine.linAcc.set(true);
-    stateKine.angAcc.set(true);
-
-    Vector3& linacc = stateKine.linAcc();///reference (Vector3&)
-    Vector3& angacc = stateKine.angAcc();///reference
-
-    computeAccelerations_(stateKine,forceLocal,torqueLocal, linacc, angacc);
-
-    stateKine.integrate(dt_);
-
-    x.segment<sizeStateKine>(kineIndex()) = stateKine.toVector(flagsStateKine);
-
-    for (VectorContactIterator i = contacts_.begin(); i!= contacts_.end(); ++i)
-    {
-      if (i->isSet)
-      {
-        Kinematics & localKine= i->localKine;
-
-        Matrix3 & Kpt = i->linearStiffness;
-        Matrix3 & Kdt = i->linearDamping;
-        Matrix3 & Kpr = i->angularStiffness;
-        Matrix3 & Kdr = i->angularDamping;
-
-        /// the posiiton of the contact in the global frame
-        Kinematics globalKine;
-
-        globalKine.setToProductNoAlias( stateKine , localKine);
-
-        /// The error between the current kinematics and the rest kinematics
-        /// of the flexibility
-        Kinematics errorKine;
-        errorKine.setToProductNoAlias(globalKine, localKine.getInverse());
-
-        /// Inverse of the orientation of the foot in the global frame
-        Orientation Rcit(globalKine.orientation.inverse());
-
-        x.segment<sizeForce>(contactForceIndex(i)) =
-          -(Rcit*(Kpt*errorKine.position() + Kdt*errorKine.linVel()));
-
-        x.segment<sizeTorque>(contactTorqueIndex(i)) =
-            -(Rcit*(Kpr*kine::vectorComponent(Quaternion(errorKine.orientation))*0.5
-            +Kdr*errorKine.angVel()));
-      }
-    }
-
-    if (processNoise_!=0x0)
-    {
-      processNoise_->getNoisy(x);
-    }
-
-    return x;
-  }
-
-  Vector KineticsObserver::measureDynamics(const Vector &x, const Vector &/*unused*/, TimeIndex k)
-  {
-    Vector y(getMeasurementSize());
-
-    Vector3 forceLocal = additionalForce_;
-    Vector3 torqueLocal = additionalTorque_;
-
-    addUnmodeledAndContactWrench_(x,forceLocal,torqueLocal);
-
-    Kinematics stateKine(x.segment<sizeStateKine>(kineIndex()), flagsStateKine);
-
-    /// The accelerations are about to be computed so we set them to "initialized"
-    stateKine.linAcc.set(true);
-    stateKine.angAcc.set(true);
-
-    Vector3& linacc = (Vector3&)(stateKine.linAcc);
-    Vector3& angacc = (Vector3&)(stateKine.angAcc);
-
-    computeAccelerations_(stateKine,forceLocal,torqueLocal, linacc, angacc);
-
-    Kinematics & localKine = opt_.kine;
-
-    for (VectorIMUConstIterator i = imuSensors_.begin(); i !=  imuSensors_.end() ; ++i)
-    {
-      if (i->time == k_data_)
-      {
-        const IMU & imu= *i;
-        localKine = stateKine * imu.kinematics;
-        localKine.orientation.matrix3();
-
-        ///accelerometer
-        y.segment<sizeAcceleroSignal>(imu.measIndex)
-              = localKine.orientation.getMatrixRefUnsafe()().transpose()  * (localKine.linAcc() + cst::gravity);
-        ///gyrometer
-        y.segment<sizeGyroSignal>(imu.measIndex+sizeAcceleroSignal)
-              = localKine.orientation.getMatrixRefUnsafe()().transpose() * localKine.angVel();
-      }
-
-    }
-
-    for (VectorContactConstIterator i = contacts_.begin(); i != contacts_.end() ; ++i)
-    {
-      if (i->isSet && i->time == k_data_ && i->withRealSensor)
-      {
-        y.segment<sizeWrench>(i->measIndex) = x.segment<sizeWrench>(contactWrenchIndex(i));
-      }
-
-    }
-
-    if (absPoseSensor_.time == k)
-    {
-      y.segment<sizePose>(absPoseSensor_.measIndex) = stateKine.toVector(flagsPoseKine);
-    }
-
-    if (measurementNoise_ != 0x0)
-    {
-      measurementNoise_->getNoisy(y);
-    }
-
-    return y;
-  }
-
-
-
+    double dt = dt_ * double(k_data_ - I_.getTime());
+    fillSymmetricMatrix(Id_(), t::derivate<Vector3>(I_().diagonal(), Iv.head<3>(), dt),
+                        t::derivate(I_()(1, 0), Iv(3), dt), t::derivate(I_()(2, 0), Iv(4), dt),
+                        t::derivate(I_()(2, 1), Iv(5), dt));
+  }
+
+  I_.set();
+  I_.setIndex(k_data_);
+  fillSymmetricMatrix(I_(), Iv.head<3>(), Iv(3), Iv(4), Iv(5));
 }
+
+void KineticsObserver::setCenterOfMass(const Vector3 & com, const Vector3 & com_dot, const Vector3 & com_dot_dot)
+{
+  startNewIteration_();
+  com_.set(com, k_data_);
+  comd_.set(com_dot, k_data_);
+  comdd_.set(com_dot_dot, k_data_);
+}
+
+void KineticsObserver::setCenterOfMass(const Vector3 & com, const Vector3 & com_dot)
+{
+  startNewIteration_();
+  com_.set(com, k_data_);
+
+  if(comd_.getTime() < k_data_)
+  {
+    comdd_.set(tools::derivate(comd_(), com_dot, dt_ * double(k_data_ - comd_.getTime())), k_data_);
+  }
+  comd_.set(com_dot, k_data_);
+}
+
+void KineticsObserver::setCenterOfMass(const Vector3 & com)
+{
+  startNewIteration_();
+
+  if(com_.getTime() < k_data_)
+  {
+    double dt = dt_ * double(k_data_ - com_.getTime());
+    Vector3 com_dot = tools::derivate(com_(), com, dt);
+
+    comdd_.set(tools::derivate(comd_(), com_dot, dt), k_data_);
+
+    comd_.set(com_dot, k_data_);
+  }
+
+  com_.set(com, k_data_);
+}
+
+void KineticsObserver::setAngularMomentum(const Vector3 & sigma, const Vector3 & sigma_dot)
+{
+  startNewIteration_();
+  sigma_.set(sigma, k_data_);
+  sigmad_.set(sigma_dot, k_data_);
+}
+
+void KineticsObserver::setAngularMomentum(const Vector3 & sigma)
+{
+  startNewIteration_();
+  if(sigma_.getTime() < k_data_)
+  {
+    sigmad_.set(tools::derivate(sigma_(), sigma, dt_ * double(k_data_ - sigma_.getTime())), k_data_);
+  }
+  sigma_.set(sigma, k_data_);
+}
+
+int KineticsObserver::addContact(const Kinematics & pose,
+                                 const Matrix12 & initialCovarianceMatrix,
+                                 const Matrix12 & processCovarianceMatrix,
+                                 const Matrix3 & linearStiffness,
+                                 const Matrix3 & linearDamping,
+                                 const Matrix3 & angularStiffness,
+                                 const Matrix3 & angularDamping,
+                                 int contactNumber)
+{
+
+  BOOST_ASSERT(pose.position.isSet() && pose.orientation.isSet()
+               && "The added contact pose is not initialized correctly (position and orientation)");
+
+  if(contactNumber < 0)
+  {
+    contactNumber = 0;
+
+    while(unsigned(contactNumber) < maxContacts_ && contacts_[contactNumber].isSet)
+    {
+      ++contactNumber;
+    }
+  }
+
+  BOOST_ASSERT(unsigned(contactNumber) < maxContacts_
+               && "Trying to add contact: The contact number exceeds the maximum allowed, please give a number of "
+                  "contact between 0 and maxContact-1");
+
+  if(unsigned(contactNumber) >= maxContacts_) /// this is a bug-prone protection code that is here only to guarantee the
+                                              /// consistence of the state
+  {
+    contactNumber = maxContacts_ - 1;
+  }
+
+  BOOST_ASSERT(!contacts_[contactNumber].isSet
+               && "The contact already exists, please remove it before adding it again");
+
+  Contact & contact = contacts_[contactNumber]; /// reference
+
+  contact.isSet = true; /// set the contacts
+  contact.stateIndex = contactsIndex() + contactNumber * sizeContact;
+  contact.stateIndexTangent = contactsIndexTangent() + contactNumber * sizeContactTangent;
+
+  contact.absPose = pose;
+
+  contact.linearStiffness = linearStiffness;
+  contact.linearDamping = linearDamping;
+  contact.angularStiffness = angularStiffness;
+  contact.angularDamping = angularDamping;
+
+  /// update the state vector
+  stateVector_.segment<sizeContact>(contact.stateIndex) << pose.toVector(flagsContactKine), Vector6::Zero();
+
+  /// sets the initial covariance matrix
+  Matrix stateCovMat = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeContactTangent>(stateCovMat, initialCovarianceMatrix, contact.stateIndexTangent);
+  ekf_.setStateCovariance(stateCovMat);
+
+  /// Sets the process cov mat
+  Matrix processCovMat = ekf_.getQ();
+  setBlockStateCovariance<sizeContactTangent>(processCovMat, processCovarianceMatrix, contact.stateIndexTangent);
+  ekf_.setQ(processCovMat);
+
+  return contactNumber;
+}
+
+/// version with default stiffness and damping
+/// use when the contact parameters are known
+int KineticsObserver::addContact(const Kinematics & pose,
+                                 const Matrix12 & initialCovarianceMatrix,
+                                 const Matrix12 & processCovarianceMatrix,
+                                 int contactNumber)
+{
+  return addContact(pose, initialCovarianceMatrix, processCovarianceMatrix, linearStiffnessMatDefault_,
+                    linearDampingMatDefault_, angularDampingMatDefault_, angularDampingMatDefault_, contactNumber);
+}
+
+/// version when the contact position is perfectly known
+int KineticsObserver::addContact(const Kinematics & pose,
+                                 const Matrix3 & linearStiffness,
+                                 const Matrix3 & linearDamping,
+                                 const Matrix3 & angularStiffness,
+                                 const Matrix3 & angularDamping,
+                                 int contactNumber)
+{
+  return addContact(pose, contactInitCovMat_, contactProcessCovMat_, linearStiffness, linearDamping, angularStiffness,
+                    angularDamping, contactNumber);
+}
+
+/// version when the position is perfectly known but not the stiffness and damping
+int KineticsObserver::addContact(const Kinematics & pose, int contactNumber)
+{
+  return addContact(pose, contactInitCovMat_, contactProcessCovMat_, linearStiffnessMatDefault_,
+                    linearDampingMatDefault_, angularDampingMatDefault_, angularDampingMatDefault_, contactNumber);
+}
+
+void KineticsObserver::removeContact(int contactNbr)
+{
+  BOOST_ASSERT(!contacts_[contactNbr].isSet && "Tried to remove a non-existing contact.");
+  if(contacts_[contactNbr].isSet)
+  {
+    contacts_[contactNbr].isSet = false;
+    if(contacts_[contactNbr].withRealSensor)
+    {
+      contacts_[contactNbr].withRealSensor = false;
+      --Contact::numberOfRealSensors;
+    }
+  }
+}
+
+void KineticsObserver::clearContacts()
+{
+  contacts_.clear();
+  Contact::numberOfRealSensors = 0;
+}
+
+Index KineticsObserver::getNumberOfContacts() const
+{
+  return contacts_.size();
+}
+
+std::vector<int> KineticsObserver::getListOfContacts() const
+{
+  std::vector<int> v;
+
+  for(unsigned i = 0; i < contacts_.size(); ++i)
+  {
+    if(contacts_[i].isSet)
+    {
+      v.push_back(i);
+    }
+  }
+  return v;
+}
+
+void KineticsObserver::setStateCovariance(const Matrix & P)
+{
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::setKinematicsStateCovariance(const Matrix & P_kine)
+{
+  Matrix P = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeStateKineTangent>(P, P_kine, kineIndexTangent());
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::setKinematicsInitCovarianceDefault(const Matrix & P_kine)
+{
+  stateKinematicsInitCovMat_ = P_kine;
+}
+
+void KineticsObserver::setGyroBiasStateCovariance(const Matrix3 & covMat, unsigned imuNumber)
+{
+  Matrix P = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeGyroBias>(P, covMat, gyroBiasIndexTangent(imuNumber));
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::setGyroBiasInitCovarianceDefault(const Matrix3 & covMat)
+{
+  gyroBiasInitCovMat_ = covMat;
+}
+
+void KineticsObserver::setGyroBiasProcessCovariance(const Matrix3 & covMat, unsigned imuNumber)
+{
+  Matrix P = ekf_.getProcessCovariance();
+  setBlockStateCovariance<sizeGyroBias>(P, covMat, gyroBiasIndexTangent(imuNumber));
+  ekf_.setProcessCovariance(P);
+}
+
+void KineticsObserver::setUnmodeledWrenchStateCovMat(const Matrix6 & currentCovMat)
+{
+  Matrix P = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeWrench>(P, currentCovMat, unmodeledWrenchIndexTangent());
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::setUnmodeledWrenchIniCovMatDefault(const Matrix6 & initCovMat)
+{
+  unmodeledWrenchInitCovMat_ = initCovMat;
+}
+
+void KineticsObserver::setUnmodeledWrenchProcessCovMat(const Matrix6 & processCovMat)
+{
+  Matrix P = ekf_.getProcessCovariance();
+  setBlockStateCovariance<sizeWrench>(P, processCovMat, unmodeledWrenchIndexTangent());
+  ekf_.setProcessCovariance(P);
+}
+
+void KineticsObserver::setContactStateCovMat(int contactNbr, const Matrix12 & contactCovMat)
+{
+  Matrix P = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeContactTangent>(P, contactCovMat, contactIndexTangent(contactNbr));
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::setContactInitCovMatDefault(const Matrix12 & contactCovMat)
+{
+  contactInitCovMat_ = contactCovMat;
+}
+
+void KineticsObserver::setContactProcessCovMat(int contactNbr, const Matrix12 & contactCovMat)
+{
+  Matrix P = ekf_.getProcessCovariance();
+  setBlockStateCovariance<sizeContactTangent>(P, contactCovMat, contactIndexTangent(contactNbr));
+  ekf_.setProcessCovariance(P);
+}
+
+Matrix KineticsObserver::getStateCovariance() const
+{
+  return ekf_.getStateCovariance();
+}
+
+void KineticsObserver::setProcessNoiseCovariance(const Matrix & Q)
+{
+  ekf_.setProcessCovariance(Q);
+}
+
+Vector KineticsObserver::getMeasurementVector()
+{
+  Vector measurement(getMeasurementSize());
+  Index currIndex = 0;
+  if(k_est_ != k_data_)
+  {
+    for(VectorIMUIterator i = imuSensors_.begin(); i != imuSensors_.end(); ++i)
+    {
+      if(i->time == k_data_)
+      {
+        measurement.segment<sizeIMUSignal>(currIndex) = i->acceleroGyro;
+        currIndex += sizeIMUSignal;
+      }
+    }
+
+    for(VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+    {
+      if(i->isSet)
+      {
+        if(i->time == k_data_ && i->withRealSensor)
+        {
+          measurement.segment<sizeWrench>(currIndex) = i->wrench;
+          currIndex += sizeWrench;
+        }
+      }
+    }
+
+    if(absPoseSensor_.time == k_data_)
+    {
+      measurement.segment<sizePose>(currIndex) = absPoseSensor_.pose.toVector(flagsPoseKine);
+      currIndex += sizePose;
+    }
+  }
+  return measurement;
+}
+
+const ExtendedKalmanFilter & KineticsObserver::getEKF() const
+{
+  return ekf_;
+}
+
+ExtendedKalmanFilter & KineticsObserver::getEKF()
+{
+  return ekf_;
+}
+
+void KineticsObserver::resetStateCovarianceMat()
+{
+  resetStateKinematicsCovMat();
+  for(unsigned i = 0; i < imuSensors_.size(); ++i)
+  {
+    if(imuSensors_[i].time == k_data_)
+    {
+      resetStateGyroBiasCovMat(i);
+    }
+  }
+  resetStateUnmodeledWrenchCovMat();
+  resetStateContactsCovMat();
+}
+
+void KineticsObserver::resetStateKinematicsCovMat()
+{
+  Matrix P = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeStateKineTangent>(P, stateKinematicsInitCovMat_, kineIndexTangent());
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::resetStateGyroBiasCovMat(unsigned i)
+{
+  Matrix P = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeGyroBias>(P, gyroBiasInitCovMat_, gyroBiasIndexTangent(i));
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::resetStateUnmodeledWrenchCovMat()
+{
+  Matrix P = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeWrench>(P, unmodeledWrenchInitCovMat_, unmodeledForceIndexTangent());
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::resetStateContactsCovMat()
+{
+  for(unsigned i = 0; i < contacts_.size(); ++i)
+  {
+    if(contacts_[i].isSet)
+    {
+      resetStateContactCovMat(i);
+    }
+  }
+}
+
+void KineticsObserver::resetStateContactCovMat(unsigned contactNbr)
+{
+  BOOST_ASSERT(contactNbr < contacts_.size() && contacts_[contactNbr].isSet
+               && "Tried to set the covariance of a non existant contact");
+
+  Matrix P = ekf_.getStateCovariance();
+  setBlockStateCovariance<sizeContactTangent>(P, contactInitCovMat_, contacts_[contactNbr].stateIndexTangent);
+  ekf_.setStateCovariance(P);
+}
+
+void KineticsObserver::resetProcessCovarianceMat()
+{
+  resetProcessKinematicsCovMat();
+  for(unsigned i = 0; i < imuSensors_.size(); ++i)
+  {
+    resetProcessGyroBiasCovMat(i);
+  }
+  resetProcessUnmodeledWrenchCovMat();
+  resetProcessContactsCovMat();
+}
+
+void KineticsObserver::resetProcessKinematicsCovMat()
+{
+  Matrix P = ekf_.getProcessCovariance();
+  setBlockStateCovariance<sizeContactTangent>(P, stateKinematicsProcessCovMat_, kineIndexTangent());
+  ekf_.setProcessCovariance(P);
+}
+
+void KineticsObserver::resetProcessGyroBiasCovMat(unsigned i)
+{
+  Matrix P = ekf_.getProcessCovariance();
+  setBlockStateCovariance<sizeGyroBias>(P, gyroBiasProcessCovMat_, gyroBiasIndexTangent(i));
+  ekf_.setProcessCovariance(P);
+}
+
+void KineticsObserver::resetProcessUnmodeledWrenchCovMat()
+{
+  Matrix P = ekf_.getProcessCovariance();
+  setBlockStateCovariance<sizeWrench>(P, unmodeledWrenchProcessCovMat_, unmodeledForceIndexTangent());
+  ekf_.setProcessCovariance(P);
+}
+
+Index KineticsObserver::getInputSize() const
+{
+  return inputSize;
+}
+
+void KineticsObserver::resetProcessContactsCovMat()
+{
+  for(unsigned i = 0; i < contacts_.size(); ++i)
+  {
+    if(contacts_[i].isSet)
+    {
+      resetProcessContactCovMat(i);
+    }
+  }
+}
+
+void KineticsObserver::resetProcessContactCovMat(unsigned contactNbr)
+{
+  BOOST_ASSERT(contactNbr < maxContacts_ && contacts_[contactNbr].isSet
+               && "Tried to set the covariance of a non existant contact");
+
+  Matrix P = ekf_.getProcessCovariance();
+  setBlockStateCovariance<sizeContactTangent>(P, contactProcessCovMat_, contacts_[contactNbr].stateIndexTangent);
+  ekf_.setProcessCovariance(P);
+}
+
+void KineticsObserver::resetSensorsDefaultCovMat()
+{
+  acceleroCovMatDefault_ = Matrix3::Identity() * acceleroVarianceDefault;
+  gyroCovMatDefault_ = Matrix3::Identity() * gyroVarianceDefault;
+  contactWrenchSensorCovMatDefault_ = blockMat6(Matrix3::Identity() * forceSensorVarianceDefault, Matrix3::Zero(),
+                                                Matrix3::Zero(), Matrix3::Identity() * torqueSensorVarianceDefault);
+  absPoseSensorCovMatDefault_ = blockMat6(Matrix3::Identity() * positionSensorVarianceDefault, Matrix3::Zero(),
+                                          Matrix3::Zero(), Matrix3::Identity() * orientationSensorVarianceDefault);
+}
+
+void KineticsObserver::resetInputs()
+{
+  for(VectorIMUIterator i = imuSensors_.begin(); i != imuSensors_.end(); ++i)
+  {
+    i->time = k_est_;
+  }
+
+  for(VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+  {
+    i->time = k_est_;
+  }
+
+  absPoseSensor_.time = k_est_;
+}
+
+void KineticsObserver::setFiniteDifferenceStep(const Vector & v)
+{
+  stateVectorDx_ = v;
+}
+
+void KineticsObserver::useFiniteDifferencesJacobians(bool b)
+{
+  finiteDifferencesJacobians_ = b;
+}
+
+Vector KineticsObserver::stateNaNCorrection_()
+{
+  /// TODO implement this function
+  assert(false && "NaN Correction not yet implemented. Please Contact mehdi.benallegue@gmail.com");
+  return oldStateVector_;
+}
+
+void KineticsObserver::startNewIteration_()
+{
+  if(k_est_ == k_data_)
+  {
+    ++k_data_;
+    Contact::numberOfRealSensors = 0;
+    IMU::currentNumber = 0;
+  }
+}
+
+void KineticsObserver::setProcessNoise(NoiseBase * noise)
+{
+  processNoise_ = noise;
+}
+
+void KineticsObserver::resetProcessNoise()
+{
+  processNoise_ = 0x0;
+}
+
+NoiseBase * KineticsObserver::getProcessNoise() const
+{
+  return processNoise_;
+}
+
+void KineticsObserver::setMeasurementNoise(NoiseBase * noise)
+{
+  measurementNoise_ = noise;
+}
+
+void KineticsObserver::resetMeasurementNoise()
+{
+  measurementNoise_ = 0x0;
+}
+
+NoiseBase * KineticsObserver::getMeasurementNoise() const
+{
+  return measurementNoise_;
+}
+
+Matrix KineticsObserver::computeAMatrix_()
+{
+  return ekf_.getAMatrixFD(stateVectorDx_);
+}
+
+Matrix KineticsObserver::computeCMatrix_()
+{
+  return ekf_.getCMatrixFD(stateVectorDx_);
+}
+
+void KineticsObserver::updateKine_()
+{
+  stateKinematics_.fromVector(stateVector_.segment<sizeStateKine>(kineIndex()), flagsStateKine);
+}
+
+void KineticsObserver::addUnmodeledAndContactWrench_(const Vector & stateVector, Vector3 & force, Vector3 & torque)
+{
+  force += stateVector.segment<sizeForce>(unmodeledWrenchIndex());
+  torque += stateVector.segment<sizeForce>(unmodeledTorqueIndex());
+
+  for(VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+  {
+    if(i->isSet)
+    {
+      Kinematics & localKinei = i->localKine;
+      Vector3 localForcei = localKinei.orientation * stateVector.segment<sizeForce>(contactForceIndex(i));
+      force += localForcei;
+      torque += localKinei.orientation * stateVector.segment<sizeForce>(contactTorqueIndex(i))
+                + localKinei.position().cross(localForcei);
+    }
+  }
+}
+
+void KineticsObserver::computeAccelerations_(Kinematics & stateKine,
+                                             const Vector3 & totalForceLocal,
+                                             const Vector3 & totalMomentLocal,
+                                             Vector3 & linAcc,
+                                             Vector3 & angAcc)
+{
+  Matrix3 Rt = stateKine.orientation.matrix3().inverse();
+  Vector3 Rtw = Rt * stateKine.angVel();
+  Vector3 corioCentri = 2 * Rtw.cross(comd_() + Rtw.cross(com_()));
+
+  angAcc = stateKine.orientation
+           * ((I_() + mass_ * kine::skewSymmetric2(com_())).inverse()
+              * (totalMomentLocal - Id_() * Rtw - sigmad_() - Rtw.cross(I_() * Rtw + sigma_())
+                 - com_().cross(totalForceLocal - mass_ * (comdd_() + corioCentri))));
+
+  linAcc = stateKine.orientation * ((totalForceLocal / mass_) - comdd_() - corioCentri + com_().cross(Rt * angAcc))
+           - cst::gravity;
+}
+
+void KineticsObserver::computeContactForces_(VectorContactIterator i,
+                                             Kinematics & stateKine,
+                                             Kinematics & contactPose,
+                                             Vector3 & force,
+                                             Vector3 torque)
+{
+  Contact & contact = *i;
+
+  Kinematics & localKine = contact.localKine;
+
+  Kinematics globalKine(stateKine, localKine); /// product of kinematics
+
+  Matrix3 globKineOriInverse = globalKine.orientation.inverse();
+
+  force = globKineOriInverse
+          * (contact.linearStiffness * (contactPose.position() - globalKine.position())
+             - contact.linearDamping * globalKine.linVel());
+  torque = globKineOriInverse
+           * (-0.5 * contact.angularStiffness
+                  * (Quaternion(globalKine.orientation) * Quaternion(contactPose.orientation).inverse()).vec()
+              - contact.angularDamping * globalKine.angVel());
+}
+
+void KineticsObserver::stateSum(const Vector & stateVector, const Vector & tangentVector, Vector & sum)
+{
+  Orientation & o = opt_.ori;
+  sum = stateVector;
+  /// use the exponential map integration to perform the sum of the states
+  sum.segment<sizePos>(posIndex()) += tangentVector.segment<sizePos>(posIndexTangent());
+  o.fromVector4(stateVector.segment<sizeOri>(oriIndex()));
+  o.integrate(tangentVector.segment<sizeOriTangent>(oriIndexTangent()));
+  sum.segment<sizeOri>(oriIndex()) = o.toVector4();
+  ///
+  sum.segment<sizeLinVel + sizeAngVel>(linVelIndex()) +=
+      tangentVector.segment<sizeLinVel + sizeAngVel>(linVelIndexTangent());
+  if(withGyroBias_)
+  {
+    for(unsigned i = 0; i < imuSensors_.size(); ++i)
+    {
+      sum.segment<sizeGyroBias>(gyroBiasIndex(i)) += tangentVector.segment<sizeGyroBias>(gyroBiasIndexTangent(i));
+    }
+  }
+  if(withUnmodeledWrench_)
+  {
+    sum.segment<sizeWrench>(unmodeledWrenchIndex()) += tangentVector.segment<sizeWrench>(unmodeledWrenchIndexTangent());
+  }
+
+  for(VectorContactConstIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+  {
+    if(i->isSet)
+    {
+      sum.segment<sizePos>(contactPosIndex(i)) += tangentVector.segment<sizePos>(contactPosIndexTangent(i));
+      o.fromVector4(stateVector.segment<sizeOri>(contactOriIndex(i)));
+      o.integrate(tangentVector.segment<sizeOriTangent>(contactOriIndexTangent(i)));
+      sum.segment<sizeOri>(contactOriIndex(i)) = o.toVector4();
+      sum.segment<sizeWrench>(contactWrenchIndex(i)) += tangentVector.segment<sizeWrench>(contactWrenchIndexTangent(i));
+    }
+  }
+}
+
+void KineticsObserver::stateDifference(const Vector & stateVector1, const Vector & stateVector2, Vector & difference)
+{
+  Orientation & o1 = opt_.ori1;
+  Orientation & o2 = opt_.ori2;
+  difference.resize(stateTangentSize_);
+  difference.segment<sizePos>(posIndexTangent()).noalias() =
+      stateVector1.segment<sizePos>(posIndex()) - stateVector2.segment<sizePos>(posIndex());
+  o1.fromVector4(stateVector1.segment<sizeOri>(oriIndex()));
+  o2.fromVector4(stateVector2.segment<sizeOri>(oriIndex()));
+  difference.segment<sizeOriTangent>(oriIndexTangent()) = o2.differentiate(o1);
+  difference.segment<sizeLinVel + sizeAngVel>(linVelIndexTangent()).noalias() =
+      stateVector1.segment<sizeLinVel + sizeAngVel>(linVelIndex())
+      - stateVector2.segment<sizeLinVel + sizeAngVel>(linVelIndex());
+  if(withGyroBias_)
+  {
+    for(unsigned i = 0; i < imuSensors_.size(); ++i)
+    {
+      difference.segment<sizeGyroBias>(gyroBiasIndexTangent(i)).noalias() =
+          stateVector1.segment<sizeGyroBias>(gyroBiasIndex(i)) - stateVector2.segment<sizeGyroBias>(gyroBiasIndex(i));
+    }
+  }
+  if(withUnmodeledWrench_)
+  {
+    difference.segment<sizeWrench>(unmodeledForceIndexTangent()).noalias() =
+        stateVector1.segment<sizeWrench>(unmodeledWrenchIndex())
+        - stateVector2.segment<sizeWrench>(unmodeledWrenchIndex());
+  }
+
+  for(VectorContactConstIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+  {
+    if(i->isSet)
+    {
+      difference.segment<sizePos>(contactPosIndexTangent(i)).noalias() =
+          stateVector1.segment<sizePos>(contactPosIndex(i)) - stateVector2.segment<sizePos>(contactPosIndex(i));
+      o1.fromVector4(stateVector1.segment<sizeOri>(contactOriIndex(i)));
+      o2.fromVector4(stateVector2.segment<sizeOri>(contactOriIndex(i)));
+      difference.segment<sizeOriTangent>(contactOriIndexTangent(i)) = o2.differentiate(o1);
+      difference.segment<sizeWrench>(contactWrenchIndexTangent(i)).noalias() =
+          stateVector1.segment<sizeWrench>(contactWrenchIndex(i))
+          - stateVector2.segment<sizeWrench>(contactWrenchIndex(i));
+    }
+  }
+}
+
+void KineticsObserver::measurementDifference(const Vector & measureVector1,
+                                             const Vector & measureVector2,
+                                             Vector & difference)
+{
+  Orientation & o1 = opt_.ori1;
+  Orientation & o2 = opt_.ori2;
+  difference.resize(measurementTangentSize_);
+
+  int currentMeasurementSize = sizeIMUSignal * IMU::currentNumber + sizeWrench * Contact::numberOfRealSensors;
+
+  difference.segment(0, currentMeasurementSize).noalias() =
+      measureVector1.segment(0, currentMeasurementSize) - measureVector2.segment(0, currentMeasurementSize);
+
+  if(absPoseSensor_.time == k_data_)
+  {
+
+    difference.segment<sizePos>(currentMeasurementSize).noalias() =
+        measureVector1.segment<sizePos>(currentMeasurementSize)
+        - measureVector2.segment<sizePos>(currentMeasurementSize);
+
+    currentMeasurementSize += sizePos;
+
+    o1.fromVector4(measureVector1.segment<sizeOri>(currentMeasurementSize));
+    o2.fromVector4(measureVector2.segment<sizeOri>(currentMeasurementSize));
+    difference.segment<sizeOriTangent>(currentMeasurementSize) = o2.differentiate(o1);
+  }
+}
+
+Vector KineticsObserver::stateDynamics(const Vector & xInput, const Vector & /*unused*/, TimeIndex)
+{
+  Vector x = xInput;
+  Vector3 forceLocal = additionalForce_;
+  Vector3 torqueLocal = additionalTorque_;
+
+  addUnmodeledAndContactWrench_(x, forceLocal, torqueLocal);
+
+  Kinematics stateKine(x.segment<sizeStateKine>(kineIndex()), flagsStateKine);
+
+  /// The accelerations are about to be computed so we set them to "initialized"
+  stateKine.linAcc.set(true);
+  stateKine.angAcc.set(true);
+
+  Vector3 & linacc = stateKine.linAcc(); /// reference (Vector3&)
+  Vector3 & angacc = stateKine.angAcc(); /// reference
+
+  computeAccelerations_(stateKine, forceLocal, torqueLocal, linacc, angacc);
+
+  stateKine.integrate(dt_);
+
+  x.segment<sizeStateKine>(kineIndex()) = stateKine.toVector(flagsStateKine);
+
+  for(VectorContactIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+  {
+    if(i->isSet)
+    {
+      Kinematics & localKine = i->localKine;
+
+      Matrix3 & Kpt = i->linearStiffness;
+      Matrix3 & Kdt = i->linearDamping;
+      Matrix3 & Kpr = i->angularStiffness;
+      Matrix3 & Kdr = i->angularDamping;
+
+      /// the posiiton of the contact in the global frame
+      Kinematics globalKine;
+
+      globalKine.setToProductNoAlias(stateKine, localKine);
+
+      /// The error between the current kinematics and the rest kinematics
+      /// of the flexibility
+      Kinematics errorKine;
+      errorKine.setToProductNoAlias(globalKine, localKine.getInverse());
+
+      /// Inverse of the orientation of the foot in the global frame
+      Orientation Rcit(globalKine.orientation.inverse());
+
+      x.segment<sizeForce>(contactForceIndex(i)) = -(Rcit * (Kpt * errorKine.position() + Kdt * errorKine.linVel()));
+
+      x.segment<sizeTorque>(contactTorqueIndex(i)) =
+          -(Rcit * (Kpr * kine::vectorComponent(Quaternion(errorKine.orientation)) * 0.5 + Kdr * errorKine.angVel()));
+    }
+  }
+
+  if(processNoise_ != 0x0)
+  {
+    processNoise_->getNoisy(x);
+  }
+
+  return x;
+}
+
+Vector KineticsObserver::measureDynamics(const Vector & x, const Vector & /*unused*/, TimeIndex k)
+{
+  Vector y(getMeasurementSize());
+
+  Vector3 forceLocal = additionalForce_;
+  Vector3 torqueLocal = additionalTorque_;
+
+  addUnmodeledAndContactWrench_(x, forceLocal, torqueLocal);
+
+  Kinematics stateKine(x.segment<sizeStateKine>(kineIndex()), flagsStateKine);
+
+  /// The accelerations are about to be computed so we set them to "initialized"
+  stateKine.linAcc.set(true);
+  stateKine.angAcc.set(true);
+
+  Vector3 & linacc = (Vector3 &)(stateKine.linAcc);
+  Vector3 & angacc = (Vector3 &)(stateKine.angAcc);
+
+  computeAccelerations_(stateKine, forceLocal, torqueLocal, linacc, angacc);
+
+  Kinematics & localKine = opt_.kine;
+
+  for(VectorIMUConstIterator i = imuSensors_.begin(); i != imuSensors_.end(); ++i)
+  {
+    if(i->time == k_data_)
+    {
+      const IMU & imu = *i;
+      localKine = stateKine * imu.kinematics;
+      localKine.orientation.matrix3();
+
+      /// accelerometer
+      y.segment<sizeAcceleroSignal>(imu.measIndex) =
+          localKine.orientation.getMatrixRefUnsafe()().transpose() * (localKine.linAcc() + cst::gravity);
+      /// gyrometer
+      y.segment<sizeGyroSignal>(imu.measIndex + sizeAcceleroSignal) =
+          localKine.orientation.getMatrixRefUnsafe()().transpose() * localKine.angVel();
+    }
+  }
+
+  for(VectorContactConstIterator i = contacts_.begin(); i != contacts_.end(); ++i)
+  {
+    if(i->isSet && i->time == k_data_ && i->withRealSensor)
+    {
+      y.segment<sizeWrench>(i->measIndex) = x.segment<sizeWrench>(contactWrenchIndex(i));
+    }
+  }
+
+  if(absPoseSensor_.time == k)
+  {
+    y.segment<sizePose>(absPoseSensor_.measIndex) = stateKine.toVector(flagsPoseKine);
+  }
+
+  if(measurementNoise_ != 0x0)
+  {
+    measurementNoise_->getNoisy(y);
+  }
+
+  return y;
+}
+
+} // namespace stateObservation

--- a/src/linear-acceleration.cpp
+++ b/src/linear-acceleration.cpp
@@ -2,12 +2,12 @@
 
 namespace stateObservation
 {
-    namespace algorithm
-    {
-        Vector3 LinearAcceleration::accelerationMeasure(const Vector3 & acceleration, const Matrix3 & orientation) const
-        {
-          return  Vector3(orientation.transpose()*(acceleration + cst::gravity));
-        }
-
-    }
+namespace algorithm
+{
+Vector3 LinearAcceleration::accelerationMeasure(const Vector3 & acceleration, const Matrix3 & orientation) const
+{
+  return Vector3(orientation.transpose() * (acceleration + cst::gravity));
 }
+
+} // namespace algorithm
+} // namespace stateObservation

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,139 +1,134 @@
 #include <fstream>
 #include <state-observation/tools/logger.hpp>
 
-
 namespace stateObservation
 {
-  namespace tools
+namespace tools
+{
+Logger::Logger()
+{
+  scalar_.resize(1, 1);
+}
+
+Logger::~Logger()
+{
+  // dtor
+}
+
+void Logger::setPath(const std::string & path)
+{
+  path_ = path;
+}
+
+void Logger::save(bool clear, bool append)
+{
+  for(std::map<const void *, log_s>::iterator i = logs_.begin(); i != logs_.end(); ++i)
   {
-    Logger::Logger()
+    if(i->second.filename != std::string(""))
     {
-      scalar_.resize(1,1);
+      i->second.array.writeInFile((path_ + std::string("/") + i->second.filename).c_str(), clear, append);
     }
-
-    Logger::~Logger()
-    {
-      //dtor
-    }
-
-     void Logger::setPath(const std::string& path)
-    {
-      path_=path;
-
-    }
-
-    void Logger::save(bool clear, bool append)
-    {
-      for (std::map<const void *, log_s >::iterator i=logs_.begin();i!=logs_.end();++i)
-      {
-        if (i->second.filename!=std::string(""))
-        {
-          i->second.array.writeInFile((path_+std::string("/")+i->second.filename).c_str(),
-                                      clear,append);
-        }
-      }
-    }
-
-    void Logger::clearTracking()
-    {
-      logs_.clear();
-    }
-
-    void Logger::clearLogs()
-    {
-      for (std::map<const void *, log_s >::iterator i=logs_.begin();i!=logs_.end();++i)
-      {
-        i->second.array.clear();
-      }
-    }
-
-    const IndexedMatrixArray & Logger::getRecord(const void* address) const
-    {
-      Tmap::const_iterator i= logs_.find(address);
-      if (i==logs_.end())
-      {
-        BOOST_ASSERT(false && "The logger cannot find the data, please use record function");
-        throw std::invalid_argument
-                ("The logger cannot find the data, please use record function");
-      }
-      else
-        return i->second.array;
-    }
-
-    IndexedMatrixArray & Logger::getRecord(const void* address)
-    {
-      Tmap::iterator i= logs_.find(address);
-      if (i==logs_.end())
-      {
-        BOOST_ASSERT(false && "The logger cannot find the data, please use record function");
-        throw std::invalid_argument
-                ("The logger cannot find the data, please use record function");
-      }
-      else
-        return i->second.array;
-    }
-
-    void Logger::push()
-    {
-      for (std::map<const void *, log_s >::iterator i=logs_.begin();i!=logs_.end();++i)
-      {
-        update_(i);
-      }
-    }
-
-    void Logger::update_(const Tmap::iterator & i)
-    {
-
-      ///If it is a Matrix or a Vector type
-      if (*i->second.type == typeid(Matrix))
-      {
-        i->second.array.pushBack(*static_cast<const Matrix *>(i->first));
-        return;
-      }
-      if (*i->second.type == typeid(Vector))
-      {
-        i->second.array.pushBack(*static_cast<const Vector *>(i->first));
-        return;
-      }
-      if (*i->second.type == typeid(Matrix3))
-      {
-        i->second.array.pushBack(*static_cast<const Matrix3 *>(i->first));
-        return;
-      }
-      if (*i->second.type == typeid(Vector3))
-      {
-        i->second.array.pushBack(*static_cast<const Vector3 *>(i->first));
-        return;
-      }
-
-      ///if it is a scalar type
-      if (*i->second.type == typeid(int))
-      {
-        scalar_(0,0)=double(*static_cast<const int *>(i->first));
-      }
-      else if (*i->second.type == typeid(unsigned))
-      {
-        scalar_(0,0)=double(*static_cast<const unsigned *>(i->first));
-      }
-      else if (*i->second.type == typeid(long))
-      {
-        scalar_(0,0)=double(*static_cast<const long *>(i->first));
-      }
-      else if (*i->second.type == typeid(Index))
-      {
-        scalar_(0,0)=double(*static_cast<const Index *>(i->first));
-      }
-      else if (*i->second.type == typeid(double))
-      {
-        scalar_(0,0)=*static_cast<const double *>(i->first);
-      }
-      else if (*i->second.type == typeid(float))
-      {
-        scalar_(0,0)=double(*static_cast<const float *>(i->first));
-      }
-
-      i->second.array.pushBack(scalar_);
-    }
-
   }
 }
+
+void Logger::clearTracking()
+{
+  logs_.clear();
+}
+
+void Logger::clearLogs()
+{
+  for(std::map<const void *, log_s>::iterator i = logs_.begin(); i != logs_.end(); ++i)
+  {
+    i->second.array.clear();
+  }
+}
+
+const IndexedMatrixArray & Logger::getRecord(const void * address) const
+{
+  Tmap::const_iterator i = logs_.find(address);
+  if(i == logs_.end())
+  {
+    BOOST_ASSERT(false && "The logger cannot find the data, please use record function");
+    throw std::invalid_argument("The logger cannot find the data, please use record function");
+  }
+  else
+    return i->second.array;
+}
+
+IndexedMatrixArray & Logger::getRecord(const void * address)
+{
+  Tmap::iterator i = logs_.find(address);
+  if(i == logs_.end())
+  {
+    BOOST_ASSERT(false && "The logger cannot find the data, please use record function");
+    throw std::invalid_argument("The logger cannot find the data, please use record function");
+  }
+  else
+    return i->second.array;
+}
+
+void Logger::push()
+{
+  for(std::map<const void *, log_s>::iterator i = logs_.begin(); i != logs_.end(); ++i)
+  {
+    update_(i);
+  }
+}
+
+void Logger::update_(const Tmap::iterator & i)
+{
+
+  /// If it is a Matrix or a Vector type
+  if(*i->second.type == typeid(Matrix))
+  {
+    i->second.array.pushBack(*static_cast<const Matrix *>(i->first));
+    return;
+  }
+  if(*i->second.type == typeid(Vector))
+  {
+    i->second.array.pushBack(*static_cast<const Vector *>(i->first));
+    return;
+  }
+  if(*i->second.type == typeid(Matrix3))
+  {
+    i->second.array.pushBack(*static_cast<const Matrix3 *>(i->first));
+    return;
+  }
+  if(*i->second.type == typeid(Vector3))
+  {
+    i->second.array.pushBack(*static_cast<const Vector3 *>(i->first));
+    return;
+  }
+
+  /// if it is a scalar type
+  if(*i->second.type == typeid(int))
+  {
+    scalar_(0, 0) = double(*static_cast<const int *>(i->first));
+  }
+  else if(*i->second.type == typeid(unsigned))
+  {
+    scalar_(0, 0) = double(*static_cast<const unsigned *>(i->first));
+  }
+  else if(*i->second.type == typeid(long))
+  {
+    scalar_(0, 0) = double(*static_cast<const long *>(i->first));
+  }
+  else if(*i->second.type == typeid(Index))
+  {
+    scalar_(0, 0) = double(*static_cast<const Index *>(i->first));
+  }
+  else if(*i->second.type == typeid(double))
+  {
+    scalar_(0, 0) = *static_cast<const double *>(i->first);
+  }
+  else if(*i->second.type == typeid(float))
+  {
+    scalar_(0, 0) = double(*static_cast<const float *>(i->first));
+  }
+
+  i->second.array.pushBack(scalar_);
+}
+
+} // namespace tools
+} // namespace stateObservation

--- a/src/magnetic-field.cpp
+++ b/src/magnetic-field.cpp
@@ -2,18 +2,14 @@
 
 namespace stateObservation
 {
-    namespace algorithm
-    {
+namespace algorithm
+{
 
-        MagneticField::MagneticField()
-        :earthLocalMagneticField_ (Vector3 (0, 28, -33.7))
-        {
-        }
+MagneticField::MagneticField() : earthLocalMagneticField_(Vector3(0, 28, -33.7)) {}
 
-
-        Vector3 MagneticField::magneticFieldMeasure(const Matrix3 & orientation) const
-        {
-            return Vector3(orientation.transpose()*earthLocalMagneticField_);
-        }
-    }
+Vector3 MagneticField::magneticFieldMeasure(const Matrix3 & orientation) const
+{
+  return Vector3(orientation.transpose() * earthLocalMagneticField_);
 }
+} // namespace algorithm
+} // namespace stateObservation

--- a/src/model-base-ekf-flex-estimator-imu.cpp
+++ b/src/model-base-ekf-flex-estimator-imu.cpp
@@ -6,639 +6,609 @@ const int stateSize = 35;
 
 namespace stateObservation
 {
-  namespace flexibilityEstimation
+namespace flexibilityEstimation
+{
+typedef IMUElasticLocalFrameDynamicalSystem::state state;
+
+ModelBaseEKFFlexEstimatorIMU::ModelBaseEKFFlexEstimatorIMU(double dt)
+: EKFFlexibilityEstimatorBase(stateSize,
+                              measurementSizeBase_,
+                              inputSizeBase_,
+                              Matrix::Constant(stateSize, 1, dxFactor)),
+  functor_(dt), stateSize_(stateSize), unmodeledForceVariance_(1e-6), forceVariance_(Matrix::Identity(6, 6) * 1e-4),
+  absPosVariance_(1e-4), useFTSensors_(false), withAbsolutePos_(false), withComBias_(false),
+  withUnmodeledForces_(false), limitOn_(true)
+{
+  ekf_.setMeasureSize(functor_.getMeasurementSize());
+  ekf_.setStateSize(stateSize_);
+  ekf_.setInputSize(functor_.getInputSize());
+  inputSize_ = functor_.getInputSize();
+
+  ModelBaseEKFFlexEstimatorIMU::resetCovarianceMatrices();
+
+  Vector dx(Matrix::Constant(getStateSize(), 1, dxFactor));
+
+  dx.segment(state::ori, 3).fill(1e-4);
+  dx.segment(state::angVel, 3).fill(1e-4);
+
+  ModelBaseEKFFlexEstimatorIMU::useFiniteDifferencesJacobians(dx);
+
+  Vector x0(ekf_.stateVectorZero());
+
+  lastX_ = x0;
+  ekf_.setState(x0, 0);
+
+  ekf_.setStateCovariance(Q_);
+
+  ekf_.setFunctor(&functor_);
+
+  functor_.setFDstep(dx_);
+
+  on_ = true;
+
+  Vector3 v1, v2;
+  Matrix3 v;
+  v1 << 100, 100, 1000;
+  v2 << 10, 10, 100;
+  v.setIdentity();
+  v *= cst::gravityConstant * hrp2::m;
+  limitForces_ = v * v1;
+  limitTorques_ = v * v2;
+}
+
+ModelBaseEKFFlexEstimatorIMU::~ModelBaseEKFFlexEstimatorIMU()
+{
+  // dtor
+}
+
+Matrix ModelBaseEKFFlexEstimatorIMU::getDefaultQ()
+{
+  Matrix Q = Matrix::Identity(stateSize, stateSize);
+
+  Q.block(state::pos, state::pos, 3, 3) = Matrix3::Identity() * 1.e-8;
+  Q.block(state::ori, state::ori, 3, 3) = Matrix3::Identity() * 1.e-8;
+  Q.block(state::linVel, state::linVel, 3, 3) = Matrix3::Identity() * 1.e-8;
+  Q.block(state::angVel, state::angVel, 3, 3) = Matrix3::Identity() * 1.e-8;
+
+  Q.block(state::fc, state::fc, 3, 3) = Matrix3::Identity() * 1.e-4;
+  Q.block(state::fc + 3, state::fc + 3, 3, 3) = Matrix3::Identity() * 1.e-4;
+  Q.block(state::fc + 6, state::fc + 6, 3, 3) = Matrix3::Identity() * 1.e-4;
+  Q.block(state::fc + 6 + 3, state::fc + 6 + 3, 3, 3) = Matrix3::Identity() * 1.e-4;
+
+  return Q;
+}
+
+Matrix6 ModelBaseEKFFlexEstimatorIMU::getDefaultRIMU()
+{
+  Matrix6 R;
+
+  R.block<3, 3>(0, 0) = Matrix3::Identity() * 1.e-6; // accelerometer
+  R.block<3, 3>(3, 3) = Matrix3::Identity() * 1.e-6; // gyrometer
+
+  return R;
+}
+
+void ModelBaseEKFFlexEstimatorIMU::resetCovarianceMatrices()
+{
+
+  /////// std::cout << "\n\n\n ============> RESET COVARIANCE MATRIX <=============== \n\n\n" << std::endl;
+
+  R_ = Matrix::Identity(getMeasurementSize(), getMeasurementSize());
+  R_.block<6, 6>(0, 0) = getDefaultRIMU();
+
+  updateMeasurementCovarianceMatrix_();
+  stateObservation::Matrix m;
+  m.resize(6, 6);
+  m.setIdentity();
+
+  Q_ = getDefaultQ();
+
+  if(withUnmodeledForces_)
+    Q_.block(state::unmodeledForces, state::unmodeledForces, 6, 6) = Matrix6::Identity() * m * 1.e-2;
+  else
+    Q_.block(state::unmodeledForces, state::unmodeledForces, 6, 6).setZero();
+
+  if(withComBias_)
+    Q_.block(state::comBias, state::comBias, 2, 2) = Matrix::Identity(2, 2) * 2.5e-10;
+  else
+    Q_.block(state::comBias, state::comBias, 2, 2).setZero();
+
+  if(withAbsolutePos_)
+    Q_.block(state::drift, state::drift, 3, 3) = Matrix::Identity(3, 3) * 1e-8;
+  else
+    Q_.block(state::drift, state::drift, 3, 3).setZero();
+
+  ekf_.setQ(Q_);
+  resetStateCovarianceMatrix();
+}
+
+void ModelBaseEKFFlexEstimatorIMU::resetStateCovarianceMatrix()
+{
+  P_ = Q_;
+  ekf_.setStateCovariance(P_);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setContactsNumber(unsigned i)
+{
+  functor_.setContactsNumber(i);
+
+  inputSize_ = functor_.getInputSize();
+  ekf_.setInputSize(inputSize_);
+
+  if(useFTSensors_)
   {
-    typedef IMUElasticLocalFrameDynamicalSystem::state state;
+    ekf_.setMeasureSize(functor_.getMeasurementSize());
+    updateMeasurementCovarianceMatrix_();
+  }
+}
 
-    ModelBaseEKFFlexEstimatorIMU::ModelBaseEKFFlexEstimatorIMU(double dt):
-      EKFFlexibilityEstimatorBase
-      (stateSize,measurementSizeBase_,inputSizeBase_,
-       Matrix::Constant(stateSize,1,dxFactor)),
-      functor_(dt),
-      stateSize_(stateSize),
-      unmodeledForceVariance_(1e-6),
-      forceVariance_(Matrix::Identity(6,6)*1e-4),
-      absPosVariance_(1e-4),
-      useFTSensors_(false),
-      withAbsolutePos_(false),
-      withComBias_(false),
-      withUnmodeledForces_(false),
-      limitOn_(true)
-    {
-      ekf_.setMeasureSize(functor_.getMeasurementSize());
-      ekf_.setStateSize(stateSize_);
-      ekf_.setInputSize(functor_.getInputSize());
-      inputSize_=functor_.getInputSize();
+void ModelBaseEKFFlexEstimatorIMU::setContactModel(unsigned nb)
+{
+  functor_.setContactModel(nb);
+}
 
-      ModelBaseEKFFlexEstimatorIMU::resetCovarianceMatrices();
+void ModelBaseEKFFlexEstimatorIMU::setMeasurement(const Vector & y)
+{
+  BOOST_ASSERT((getMeasurementSize() == y.size()) && "ERROR: The measurement vector has incorrect size");
 
-      Vector dx(Matrix::Constant(getStateSize(),1,dxFactor));
+  ekf_.setMeasurement(y, k_ + 1);
+}
 
-      dx.segment(state::ori,3).fill(1e-4) ;
-      dx.segment(state::angVel,3).fill(1e-4) ;
+void ModelBaseEKFFlexEstimatorIMU::setFlexibilityGuess(const Matrix & x)
+{
+  bool bstate = ekf_.checkStateVector(x);
+  bool b6 = (x.rows() == 6 && x.cols() == 1);
+  bool bhomogeneous = (x.rows() == 4 && x.cols() == 4);
 
-      ModelBaseEKFFlexEstimatorIMU::useFiniteDifferencesJacobians(dx);
+  (void)b6; // avoid warning
 
-      Vector x0(ekf_.stateVectorZero());
-
-      lastX_=x0;
-      ekf_.setState(x0,0);
-
-      ekf_.setStateCovariance(Q_);
-
-      ekf_.setFunctor(& functor_);
-
-      functor_.setFDstep(dx_);
-
-      on_=true;
-
-      Vector3 v1, v2;
-      Matrix3 v;
-      v1 << 100,
-      100,
-      1000;
-      v2 << 10,
-      10,
-      100;
-      v.setIdentity();
-      v*=cst::gravityConstant*hrp2::m;
-      limitForces_=v*v1;
-      limitTorques_=v*v2;
-
-    }
-
-    ModelBaseEKFFlexEstimatorIMU::~ModelBaseEKFFlexEstimatorIMU()
-    {
-      //dtor
-    }
-
-    Matrix ModelBaseEKFFlexEstimatorIMU::getDefaultQ()
-    {
-      Matrix Q=Matrix::Identity(stateSize,stateSize);
-
-      Q.block(state::pos,state::pos,3,3)=Matrix3::Identity()*1.e-8;
-      Q.block(state::ori,state::ori,3,3)=Matrix3::Identity()*1.e-8;
-      Q.block(state::linVel,state::linVel,3,3)=Matrix3::Identity()*1.e-8;
-      Q.block(state::angVel,state::angVel,3,3)=Matrix3::Identity()*1.e-8;
-
-      Q.block(state::fc,state::fc,3,3)=Matrix3::Identity()*1.e-4;
-      Q.block(state::fc+3,state::fc+3,3,3)=Matrix3::Identity()*1.e-4;
-      Q.block(state::fc+6,state::fc+6,3,3)=Matrix3::Identity()*1.e-4;
-      Q.block(state::fc+6+3,state::fc+6+3,3,3)=Matrix3::Identity()*1.e-4;
-
-      return Q;
-    }
-
-    Matrix6 ModelBaseEKFFlexEstimatorIMU::getDefaultRIMU()
-    {
-      Matrix6 R;
-
-      R.block<3,3>(0,0)=Matrix3::Identity()*1.e-6;//accelerometer
-      R.block<3,3>(3,3)=Matrix3::Identity()*1.e-6;//gyrometer
-
-      return R;
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::resetCovarianceMatrices()
-    {
-
-/////// std::cout << "\n\n\n ============> RESET COVARIANCE MATRIX <=============== \n\n\n" << std::endl;
-
-      R_=Matrix::Identity(getMeasurementSize(),getMeasurementSize());
-      R_.block<6,6>(0,0)=getDefaultRIMU();
-
-      updateMeasurementCovarianceMatrix_();
-      stateObservation::Matrix m;
-      m.resize(6,6);
-      m.setIdentity();
-
-      Q_=getDefaultQ();
-
-      if(withUnmodeledForces_)
-        Q_.block(state::unmodeledForces,state::unmodeledForces,6,6)=Matrix6::Identity()*m*1.e-2;
-      else
-        Q_.block(state::unmodeledForces,state::unmodeledForces,6,6).setZero();
-
-      if(withComBias_)
-        Q_.block(state::comBias,state::comBias,2,2)=Matrix::Identity(2,2)*2.5e-10;
-      else
-        Q_.block(state::comBias,state::comBias,2,2).setZero();
-
-      if (withAbsolutePos_)
-        Q_.block(state::drift,state::drift,3,3)=Matrix::Identity(3,3)*1e-8;
-      else
-        Q_.block(state::drift,state::drift,3,3).setZero();
-
-      ekf_.setQ(Q_);
-      resetStateCovarianceMatrix();
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::resetStateCovarianceMatrix()
-    {
-      P_=Q_;
-      ekf_.setStateCovariance(P_);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setContactsNumber(unsigned i)
-    {
-      functor_.setContactsNumber(i);
-
-      inputSize_ = functor_.getInputSize();
-      ekf_.setInputSize(inputSize_);
-
-      if (useFTSensors_)
-      {
-        ekf_.setMeasureSize(functor_.getMeasurementSize());
-        updateMeasurementCovarianceMatrix_();
-      }
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setContactModel(unsigned nb)
-    {
-      functor_.setContactModel(nb);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setMeasurement(const Vector & y)
-    {
-      BOOST_ASSERT((getMeasurementSize()==y.size()) &&
-                   "ERROR: The measurement vector has incorrect size");
-
-
-      ekf_.setMeasurement(y,k_+1);
-
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setFlexibilityGuess(const Matrix & x)
-    {
-      bool bstate =ekf_.checkStateVector(x);
-      bool b6= (x.rows()==6 && x.cols()==1);
-      bool bhomogeneous = (x.rows()==4 && x.cols()==4);
-
-      (void)b6;//avoid warning
-
-      BOOST_ASSERT((bstate||b6||bhomogeneous) &&
-                   "ERROR: The flexibility state has incorrect size \
+  BOOST_ASSERT((bstate || b6 || bhomogeneous) && "ERROR: The flexibility state has incorrect size \
                     must be 23x1 vector, 6x1 vector or 4x4 matrix");
 
-      Vector x0 (x);
+  Vector x0(x);
 
-      if (bstate)
-      {
-        ekf_.setState(x0,k_);
-      }
-      else
-      {
-        if (bhomogeneous)
-          x0=kine::homogeneousMatrixToVector6(x);
+  if(bstate)
+  {
+    ekf_.setState(x0, k_);
+  }
+  else
+  {
+    if(bhomogeneous) x0 = kine::homogeneousMatrixToVector6(x);
 
-        Vector x_s = ekf_.stateVectorZero();
+    Vector x_s = ekf_.stateVectorZero();
 
-        x_s.segment(state::pos,3)=x0.head<3> ();
+    x_s.segment(state::pos, 3) = x0.head<3>();
 
-        x_s.segment(state::ori,3)=x0.tail<3> ();
+    x_s.segment(state::ori, 3) = x0.tail<3>();
 
-        ekf_.setState(x_s,k_);
+    ekf_.setState(x_s, k_);
 
-        ekf_.setQ(Q_);
-      }
-    }
+    ekf_.setQ(Q_);
+  }
+}
 
-    void ModelBaseEKFFlexEstimatorIMU::setComBiasGuess(const stateObservation::Vector & x)
-    {
-      lastX_.segment(state::comBias,2)=x.segment(0,2);
-      setFlexibilityGuess(lastX_);
-    }
+void ModelBaseEKFFlexEstimatorIMU::setComBiasGuess(const stateObservation::Vector & x)
+{
+  lastX_.segment(state::comBias, 2) = x.segment(0, 2);
+  setFlexibilityGuess(lastX_);
+}
 
-    void ModelBaseEKFFlexEstimatorIMU::setMeasurementNoiseCovariance
-    (const Matrix & R)
-    {
-      BOOST_ASSERT(R.rows()==R.cols() &&
-                    R.rows() >0 &&
-                    (R.rows() % 6) ==0 &&
-                   "ERROR: The measurement noise covariance matrix R has \
+void ModelBaseEKFFlexEstimatorIMU::setMeasurementNoiseCovariance(const Matrix & R)
+{
+  BOOST_ASSERT(R.rows() == R.cols() && R.rows() > 0 && (R.rows() % 6) == 0
+               && "ERROR: The measurement noise covariance matrix R has \
                         incorrect size");
-                        ///the matrix should be square
-                        ///and have a size multiple of 6
+  /// the matrix should be square
+  /// and have a size multiple of 6
 
-      R_=R;
-      updateMeasurementCovarianceMatrix_();
-    }
+  R_ = R;
+  updateMeasurementCovarianceMatrix_();
+}
 
+void ModelBaseEKFFlexEstimatorIMU::setProcessNoiseCovariance(const Matrix & Q)
+{
+  Q_ = Q;
+  ekf_.setQ(Q_);
+}
 
-    void ModelBaseEKFFlexEstimatorIMU::setProcessNoiseCovariance
-    (const Matrix & Q)
+Matrix ModelBaseEKFFlexEstimatorIMU::getProcessNoiseCovariance() const
+{
+  return Q_;
+}
+
+Matrix ModelBaseEKFFlexEstimatorIMU::getMeasurementNoiseCovariance() const
+{
+  return R_;
+}
+
+Vector ModelBaseEKFFlexEstimatorIMU::getMomentaDotFromForces()
+{
+  if(on_ == true)
+  {
+    return functor_.getMomentaDotFromForces(getFlexibilityVector(), getInput());
+  }
+  else
+  {
+    Vector6 v;
+    v.setZero();
+    return v;
+  }
+}
+
+Vector ModelBaseEKFFlexEstimatorIMU::getMomentaDotFromKinematics()
+{
+  if(on_ == true)
+  {
+    return functor_.getMomentaDotFromKinematics(getFlexibilityVector(), getInput());
+  }
+  else
+  {
+    Vector6 v;
+    v.setZero();
+    return v;
+  }
+}
+
+Vector ModelBaseEKFFlexEstimatorIMU::getForcesAndMoments()
+{
+  const Vector & v(getFlexibilityVector());
+
+  Vector v2;
+  v2.resize(functor_.getContactsNumber() * 6);
+  v2 << v.segment(state::fc, functor_.getContactsNumber() * 6);
+
+  return v2;
+}
+
+void ModelBaseEKFFlexEstimatorIMU::updateMeasurementCovarianceMatrix_()
+{
+
+  if(R_.rows() != getMeasurementSize())
+  {
+
+    Index realIndex = R_.rows();
+    R_.conservativeResize(getMeasurementSize(), getMeasurementSize());
+
+    Index currIndex = 6;
+    if(useFTSensors_)
     {
-      Q_=Q;
-      ekf_.setQ(Q_);
-    }
-
-    Matrix ModelBaseEKFFlexEstimatorIMU::getProcessNoiseCovariance() const
-    {
-      return Q_;
-    }
-
-
-    Matrix ModelBaseEKFFlexEstimatorIMU::getMeasurementNoiseCovariance() const
-    {
-      return R_;
-    }
-
-    Vector ModelBaseEKFFlexEstimatorIMU::getMomentaDotFromForces()
-    {
-      if(on_==true)
+      /// if the force part of the matrix is not filled
+      if(realIndex < currIndex + functor_.getContactsNumber() * 6)
       {
-        return functor_.getMomentaDotFromForces(getFlexibilityVector(),getInput());
-      }
-      else
-      {
-        Vector6 v;
-        v.setZero();
-        return v;
-      }
-    }
-
-    Vector ModelBaseEKFFlexEstimatorIMU::getMomentaDotFromKinematics()
-    {
-      if(on_==true)
-      {
-        return functor_.getMomentaDotFromKinematics(getFlexibilityVector(),getInput());
-      }
-      else
-      {
-        Vector6 v;
-        v.setZero();
-        return v;
-      }
-    }
-
-    Vector ModelBaseEKFFlexEstimatorIMU::getForcesAndMoments()
-    {
-      const Vector & v (getFlexibilityVector());
-
-      Vector v2;
-      v2.resize(functor_.getContactsNumber()*6);
-      v2 << v.segment(state::fc,functor_.getContactsNumber()*6);
-
-      return v2;
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::updateMeasurementCovarianceMatrix_()
-    {
-
-      if (R_.rows()!=getMeasurementSize())
-      {
-
-        Index realIndex = R_.rows();
-        R_.conservativeResize(getMeasurementSize(),getMeasurementSize());
-
-        Index currIndex = 6;
-        if(useFTSensors_)
+        R_.block(currIndex, 0, functor_.getContactsNumber() * 6, currIndex).setZero();
+        R_.block(0, currIndex, currIndex, functor_.getContactsNumber() * 6).setZero();
+        for(Index i = 0; i < functor_.getContactsNumber(); ++i)
         {
-          ///if the force part of the matrix is not filled
-          if (realIndex < currIndex + functor_.getContactsNumber() * 6)
-          {
-            R_.block(currIndex,0,functor_.getContactsNumber()*6,currIndex).setZero();
-            R_.block(0,currIndex,currIndex,functor_.getContactsNumber()*6).setZero();
-            for (Index i=0; i<functor_.getContactsNumber(); ++i)
-            {
-              R_.block(currIndex,currIndex,6,6) = forceVariance_;
-              currIndex +=6;
-            }
-          }
-        }
-
-        if(withAbsolutePos_)
-        {
-          if (realIndex < currIndex + 6)
-          {
-
-
-            R_.block(currIndex,0,6,currIndex).setZero();
-            R_.block(0,currIndex,currIndex,6).setZero();
-            R_.block(currIndex,currIndex,6,6) = Matrix::Identity(6,6)*absPosVariance_;
-
-            currIndex += 6;
-          }
+          R_.block(currIndex, currIndex, 6, 6) = forceVariance_;
+          currIndex += 6;
         }
       }
-      ekf_.setR(R_);
     }
 
-    Index ModelBaseEKFFlexEstimatorIMU::getStateSize() const
+    if(withAbsolutePos_)
     {
-      return stateSize;
-    }
-
-
-    Index ModelBaseEKFFlexEstimatorIMU::getInputSize() const
-    {
-      return ekf_.getInputSize();
-    }
-
-    Index ModelBaseEKFFlexEstimatorIMU::getMeasurementSize() const
-    {
-      return functor_.getMeasurementSize();
-    }
-
-    Matrix4 ModelBaseEKFFlexEstimatorIMU::getFlexibility()
-    {
-
-      const Vector & v (getFlexibilityVector());
-
-      Vector6 v2;
-      v2 << v.segment(state::pos,3), v.segment(state::ori,3);
-      //v2.head<3>() = v.segment(kine::pos,3);
-      //v2.tail<3>() = v.segment(kine::ori,3);
-
-      return kine::vector6ToHomogeneousMatrix(v2);
-
-    }
-
-    timespec diff(const timespec & start, const timespec & end)
-    {
-      timespec temp;
-      if ((end.tv_nsec-start.tv_nsec)<0)
+      if(realIndex < currIndex + 6)
       {
-        temp.tv_sec = end.tv_sec-start.tv_sec-1;
-        temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
+
+        R_.block(currIndex, 0, 6, currIndex).setZero();
+        R_.block(0, currIndex, currIndex, 6).setZero();
+        R_.block(currIndex, currIndex, 6, 6) = Matrix::Identity(6, 6) * absPosVariance_;
+
+        currIndex += 6;
       }
-      else
-      {
-        temp.tv_sec = end.tv_sec-start.tv_sec;
-        temp.tv_nsec = end.tv_nsec-start.tv_nsec;
-      }
-      return temp;
     }
+  }
+  ekf_.setR(R_);
+}
 
-    const Vector & ModelBaseEKFFlexEstimatorIMU::getFlexibilityVector()
+Index ModelBaseEKFFlexEstimatorIMU::getStateSize() const
+{
+  return stateSize;
+}
+
+Index ModelBaseEKFFlexEstimatorIMU::getInputSize() const
+{
+  return ekf_.getInputSize();
+}
+
+Index ModelBaseEKFFlexEstimatorIMU::getMeasurementSize() const
+{
+  return functor_.getMeasurementSize();
+}
+
+Matrix4 ModelBaseEKFFlexEstimatorIMU::getFlexibility()
+{
+
+  const Vector & v(getFlexibilityVector());
+
+  Vector6 v2;
+  v2 << v.segment(state::pos, 3), v.segment(state::ori, 3);
+  // v2.head<3>() = v.segment(kine::pos,3);
+  // v2.tail<3>() = v.segment(kine::ori,3);
+
+  return kine::vector6ToHomogeneousMatrix(v2);
+}
+
+timespec diff(const timespec & start, const timespec & end)
+{
+  timespec temp;
+  if((end.tv_nsec - start.tv_nsec) < 0)
+  {
+    temp.tv_sec = end.tv_sec - start.tv_sec - 1;
+    temp.tv_nsec = 1000000000 + end.tv_nsec - start.tv_nsec;
+  }
+  else
+  {
+    temp.tv_sec = end.tv_sec - start.tv_sec;
+    temp.tv_nsec = end.tv_nsec - start.tv_nsec;
+  }
+  return temp;
+}
+
+const Vector & ModelBaseEKFFlexEstimatorIMU::getFlexibilityVector()
+{
+
+  if(on_ == true)
+  {
+
+    if(ekf_.getMeasurementsNumber() > 0)
     {
+      k_ = ekf_.getMeasurementTime();
 
-
-      if(on_==true)
+      TimeIndex i;
+      for(i = ekf_.getCurrentTime() + 1; i <= k_; ++i)
       {
-
-        if (ekf_.getMeasurementsNumber()>0)
+        if(finiteDifferencesJacobians_)
         {
-          k_=ekf_.getMeasurementTime();
+          ekf_.updateStateAndMeasurementPrediction();
 
-          TimeIndex i;
-          for (i=ekf_.getCurrentTime()+1; i<=k_; ++i)
-          {
-            if (finiteDifferencesJacobians_)
-            {
-              ekf_.updateStateAndMeasurementPrediction();
+          // ekf_.setA(ekf_.getAMatrixFD(dx_));
+          // ekf_.setC(ekf_.getCMatrixFD(dx_));
+          ekf_.setA(functor_.stateDynamicsJacobian());
+          ekf_.setC(functor_.measureDynamicsJacobian());
+        }
 
-              //ekf_.setA(ekf_.getAMatrixFD(dx_));
-              //ekf_.setC(ekf_.getCMatrixFD(dx_));
-             ekf_.setA(functor_.stateDynamicsJacobian());
-             ekf_.setC(functor_.measureDynamicsJacobian());
-
-            }
-
-
-            ekf_.getEstimatedState(i);
-
-          }
-          x_=ekf_.getEstimatedState(k_);
+        ekf_.getEstimatedState(i);
+      }
+      x_ = ekf_.getEstimatedState(k_);
 #ifndef EIGEN_VERSION_LESS_THAN_3_2
-          if (! x_.hasNaN())//detect NaN values
-          {
+      if(!x_.hasNaN()) // detect NaN values
+      {
 #else
-          if (x_==x_)//detect NaN values
-          {
+      if(x_ == x_) // detect NaN values
+      {
 #endif // EIGEN_VERSION_LESS_THAN_3_2
-            lastX_=x_;
+        lastX_ = x_;
 
-            ///regulate the part of orientation vector in the state vector
-            lastX_.segment(state::ori,3)=kine::regulateOrientationVector(lastX_.segment(state::ori,3));
-            if(limitOn_)
-            {
-              for(int i=0; i<3; i++)
-              {
-                // Saturation for bounded forces and torques
-                lastX_[Index(state::fc+6+i)]=std::min(lastX_[Index(state::fc+6+i)],limitTorques_[i]);
-                lastX_[Index(state::fc+i)]=std::min(lastX_[Index(state::fc+i)],limitForces_[i]);
-                lastX_[Index(state::fc+6+i)]=std::max(lastX_[Index(state::fc+6+i)],-limitTorques_[i]);
-                lastX_[Index(state::fc+i)]=std::max(lastX_[Index(state::fc+i)],-limitForces_[i]);
-              }
-            }
-            ekf_.setState(lastX_,ekf_.getCurrentTime());
-          }
-          else //delete NaN values
+        /// regulate the part of orientation vector in the state vector
+        lastX_.segment(state::ori, 3) = kine::regulateOrientationVector(lastX_.segment(state::ori, 3));
+        if(limitOn_)
+        {
+          for(int i = 0; i < 3; i++)
           {
-            ekf_.setState(lastX_,k_);
-
-            if(k_>1) //the first iteration give always nan when not
-              //initialized
-            {
-              resetCovarianceMatrices();
-              resetStateCovarianceMatrix();
-            }
+            // Saturation for bounded forces and torques
+            lastX_[Index(state::fc + 6 + i)] = std::min(lastX_[Index(state::fc + 6 + i)], limitTorques_[i]);
+            lastX_[Index(state::fc + i)] = std::min(lastX_[Index(state::fc + i)], limitForces_[i]);
+            lastX_[Index(state::fc + 6 + i)] = std::max(lastX_[Index(state::fc + 6 + i)], -limitTorques_[i]);
+            lastX_[Index(state::fc + i)] = std::max(lastX_[Index(state::fc + i)], -limitForces_[i]);
           }
         }
-
-
-        // To be deleted: constrain the internal linear velocity of the flexibility of each foot to zero.
-//        x_.segment<3>(state::linVel).setZero();
-//        for(int i=0; i<functor_.getContactsNumber();++i)
-//        {
-//          x_.segment<3>(state::linVel) += kine::skewSymmetric(kine::rotationVectorToRotationMatrix(x_.segment<3>(state::ori))*contactPositions_[i])*x_.segment<3>(state::angVel);
-//        }
-//        x_.segment<3>(state::linVel)=x_.segment<3>(state::linVel)/functor_.getContactsNumber();
+        ekf_.setState(lastX_, ekf_.getCurrentTime());
       }
-      else
+      else // delete NaN values
       {
-        lastX_.setZero();
-        ekf_.setState(lastX_,ekf_.getCurrentTime());
+        ekf_.setState(lastX_, k_);
 
-        if (ekf_.getMeasurementsNumber()>0)
+        if(k_ > 1) // the first iteration give always nan when not
+                   // initialized
         {
-          ekf_.clearMeasurements();
-          ekf_.clearInputs();
+          resetCovarianceMatrices();
           resetStateCovarianceMatrix();
         }
       }
-
-      functor_.setPrinted(false);
-      return lastX_;
     }
 
-    stateObservation::Matrix& ModelBaseEKFFlexEstimatorIMU::computeLocalObservationMatrix()
+    // To be deleted: constrain the internal linear velocity of the flexibility of each foot to zero.
+    //        x_.segment<3>(state::linVel).setZero();
+    //        for(int i=0; i<functor_.getContactsNumber();++i)
+    //        {
+    //          x_.segment<3>(state::linVel) +=
+    //          kine::skewSymmetric(kine::rotationVectorToRotationMatrix(x_.segment<3>(state::ori))*contactPositions_[i])*x_.segment<3>(state::angVel);
+    //        }
+    //        x_.segment<3>(state::linVel)=x_.segment<3>(state::linVel)/functor_.getContactsNumber();
+  }
+  else
+  {
+    lastX_.setZero();
+    ekf_.setState(lastX_, ekf_.getCurrentTime());
+
+    if(ekf_.getMeasurementsNumber() > 0)
     {
-      op_.O.resize(getMeasurementSize()*2,getStateSize());
-      op_.CA.resize(getMeasurementSize(),getStateSize());
-      op_.CA  = ekf_.getC();
-      op_.O.block(0,0,getMeasurementSize(),getStateSize()) = op_.CA;
-      op_.CA = op_.CA * ekf_.getA();
-      op_.O.block(getMeasurementSize(),0,getMeasurementSize(),getStateSize()) = op_.CA;
-      return op_.O;
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setSamplingPeriod(double dt)
-    {
-      dt_=dt;
-      functor_.setSamplingPeriod(dt);
-    }
-
-    /// Enable or disable the estimation
-    void ModelBaseEKFFlexEstimatorIMU::setOn(bool & b)
-    {
-      on_=b;
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setKfe(const Matrix3 & m)
-    {
-      functor_.setKfe(m);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setKfv(const Matrix3 & m)
-    {
-      functor_.setKfv(m);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setKte(const Matrix3 & m)
-    {
-      functor_.setKte(m);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setKtv(const Matrix3 & m)
-    {
-      functor_.setKtv(m);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setKfeRopes(const Matrix3 & m)
-    {
-      functor_.setKfeRopes(m);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setKfvRopes(const Matrix3 & m)
-    {
-      functor_.setKfvRopes(m);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setKteRopes(const Matrix3 & m)
-    {
-      functor_.setKteRopes(m);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setKtvRopes(const Matrix3 & m)
-    {
-      functor_.setKtvRopes(m);
-    }
-
-    Matrix ModelBaseEKFFlexEstimatorIMU::getKfe() const
-    {
-      return functor_.getKfe();
-    }
-
-    Matrix ModelBaseEKFFlexEstimatorIMU::getKfv() const
-    {
-      return functor_.getKfv();
-    }
-
-    Matrix ModelBaseEKFFlexEstimatorIMU::getKte() const
-    {
-      return functor_.getKte();
-    }
-
-    Matrix ModelBaseEKFFlexEstimatorIMU::getKtv() const
-    {
-      return functor_.getKtv();
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setWithForcesMeasurements(bool b)
-    {
-      if (useFTSensors_!= b)
-      {
-        useFTSensors_=b;
-        functor_.setWithForceMeasurements(b);
-        ekf_.setMeasureSize(functor_.getMeasurementSize());
-
-        updateMeasurementCovarianceMatrix_();
-      }
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setWithAbsolutePos(bool b)
-    {
-      if (withAbsolutePos_!= b)
-      {
-        functor_.setWithAbsolutePosition(b);
-        ekf_.setMeasureSize(functor_.getMeasurementSize());
-        withAbsolutePos_=b;
-        updateMeasurementCovarianceMatrix_();
-      }
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setWithUnmodeledForces(bool b)
-    {
-      if (withUnmodeledForces_!= b)
-      {
-        functor_.setWithUnmodeledForces(b);
-        ekf_.setMeasureSize(functor_.getMeasurementSize());
-        ekf_.setInputSize(functor_.getInputSize());
-        withUnmodeledForces_=b;
-        updateMeasurementCovarianceMatrix_();
-      }
-    }
-
-    bool ModelBaseEKFFlexEstimatorIMU::getWithForcesMeasurements()
-    {
-      return useFTSensors_;
-    }
-
-
-    void ModelBaseEKFFlexEstimatorIMU::setWithComBias(bool b)
-    {
-      if (withComBias_!= b)
-      {
-        withComBias_=b;
-        functor_.setWithComBias(b);
-      }
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setUnmodeledForceVariance(double d)
-    {
-      unmodeledForceVariance_ = d;
-      if (d>0)
-      {
-        setWithUnmodeledForces(true);
-      }
-      P_=ekf_.getStateCovariance();
-      P_.diagonal().segment<6>(state::unmodeledForces).setConstant(unmodeledForceVariance_);
-      ekf_.setStateCovariance(P_);
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setUnmodeledForceProcessVariance(double d)
-    {
-      Q_.diagonal().segment<6>(state::unmodeledForces).setConstant(d);
-      ekf_.setQ(Q_);
-      if (d>0)
-      {
-        setWithUnmodeledForces(true);
-      }
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setForceVariance(double d)
-    {
-      forceVariance_ = Matrix::Identity(6,6)*d;
-      updateMeasurementCovarianceMatrix_();
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setForceVariance(const Matrix3 &v)
-    {
-      forceVariance_ = v;
-      updateMeasurementCovarianceMatrix_();
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setAbsolutePosVariance(double d)
-    {
-      absPosVariance_ = d;
-      updateMeasurementCovarianceMatrix_();
-    }
-
-    void ModelBaseEKFFlexEstimatorIMU::setRobotMass(double m)
-    {
-      functor_.setRobotMass(m);
+      ekf_.clearMeasurements();
+      ekf_.clearInputs();
+      resetStateCovarianceMatrix();
     }
   }
+
+  functor_.setPrinted(false);
+  return lastX_;
 }
+
+stateObservation::Matrix & ModelBaseEKFFlexEstimatorIMU::computeLocalObservationMatrix()
+{
+  op_.O.resize(getMeasurementSize() * 2, getStateSize());
+  op_.CA.resize(getMeasurementSize(), getStateSize());
+  op_.CA = ekf_.getC();
+  op_.O.block(0, 0, getMeasurementSize(), getStateSize()) = op_.CA;
+  op_.CA = op_.CA * ekf_.getA();
+  op_.O.block(getMeasurementSize(), 0, getMeasurementSize(), getStateSize()) = op_.CA;
+  return op_.O;
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setSamplingPeriod(double dt)
+{
+  dt_ = dt;
+  functor_.setSamplingPeriod(dt);
+}
+
+/// Enable or disable the estimation
+void ModelBaseEKFFlexEstimatorIMU::setOn(bool & b)
+{
+  on_ = b;
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setKfe(const Matrix3 & m)
+{
+  functor_.setKfe(m);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setKfv(const Matrix3 & m)
+{
+  functor_.setKfv(m);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setKte(const Matrix3 & m)
+{
+  functor_.setKte(m);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setKtv(const Matrix3 & m)
+{
+  functor_.setKtv(m);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setKfeRopes(const Matrix3 & m)
+{
+  functor_.setKfeRopes(m);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setKfvRopes(const Matrix3 & m)
+{
+  functor_.setKfvRopes(m);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setKteRopes(const Matrix3 & m)
+{
+  functor_.setKteRopes(m);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setKtvRopes(const Matrix3 & m)
+{
+  functor_.setKtvRopes(m);
+}
+
+Matrix ModelBaseEKFFlexEstimatorIMU::getKfe() const
+{
+  return functor_.getKfe();
+}
+
+Matrix ModelBaseEKFFlexEstimatorIMU::getKfv() const
+{
+  return functor_.getKfv();
+}
+
+Matrix ModelBaseEKFFlexEstimatorIMU::getKte() const
+{
+  return functor_.getKte();
+}
+
+Matrix ModelBaseEKFFlexEstimatorIMU::getKtv() const
+{
+  return functor_.getKtv();
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setWithForcesMeasurements(bool b)
+{
+  if(useFTSensors_ != b)
+  {
+    useFTSensors_ = b;
+    functor_.setWithForceMeasurements(b);
+    ekf_.setMeasureSize(functor_.getMeasurementSize());
+
+    updateMeasurementCovarianceMatrix_();
+  }
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setWithAbsolutePos(bool b)
+{
+  if(withAbsolutePos_ != b)
+  {
+    functor_.setWithAbsolutePosition(b);
+    ekf_.setMeasureSize(functor_.getMeasurementSize());
+    withAbsolutePos_ = b;
+    updateMeasurementCovarianceMatrix_();
+  }
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setWithUnmodeledForces(bool b)
+{
+  if(withUnmodeledForces_ != b)
+  {
+    functor_.setWithUnmodeledForces(b);
+    ekf_.setMeasureSize(functor_.getMeasurementSize());
+    ekf_.setInputSize(functor_.getInputSize());
+    withUnmodeledForces_ = b;
+    updateMeasurementCovarianceMatrix_();
+  }
+}
+
+bool ModelBaseEKFFlexEstimatorIMU::getWithForcesMeasurements()
+{
+  return useFTSensors_;
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setWithComBias(bool b)
+{
+  if(withComBias_ != b)
+  {
+    withComBias_ = b;
+    functor_.setWithComBias(b);
+  }
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setUnmodeledForceVariance(double d)
+{
+  unmodeledForceVariance_ = d;
+  if(d > 0)
+  {
+    setWithUnmodeledForces(true);
+  }
+  P_ = ekf_.getStateCovariance();
+  P_.diagonal().segment<6>(state::unmodeledForces).setConstant(unmodeledForceVariance_);
+  ekf_.setStateCovariance(P_);
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setUnmodeledForceProcessVariance(double d)
+{
+  Q_.diagonal().segment<6>(state::unmodeledForces).setConstant(d);
+  ekf_.setQ(Q_);
+  if(d > 0)
+  {
+    setWithUnmodeledForces(true);
+  }
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setForceVariance(double d)
+{
+  forceVariance_ = Matrix::Identity(6, 6) * d;
+  updateMeasurementCovarianceMatrix_();
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setForceVariance(const Matrix3 & v)
+{
+  forceVariance_ = v;
+  updateMeasurementCovarianceMatrix_();
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setAbsolutePosVariance(double d)
+{
+  absPosVariance_ = d;
+  updateMeasurementCovarianceMatrix_();
+}
+
+void ModelBaseEKFFlexEstimatorIMU::setRobotMass(double m)
+{
+  functor_.setRobotMass(m);
+}
+} // namespace flexibilityEstimation
+} // namespace stateObservation

--- a/src/observer-base.cpp
+++ b/src/observer-base.cpp
@@ -1,122 +1,110 @@
-#include  <state-observation/observer/observer-base.hpp>
+#include <state-observation/observer/observer-base.hpp>
 
 namespace stateObservation
 {
 
-
-
-    void ObserverBase::reset()
-    {
-        clearStates();
-        clearMeasurements();
-        clearInputs();
-    }
-
-    ObserverBase::ObserverBase()
-    {
-        n_=m_=p_=0;
-    }
-
-    ObserverBase::ObserverBase(Index n, Index m, Index p):
-            n_(n),m_(m),p_(p)
-    {
-
-    }
-
-
-
-    ObserverBase::StateVector ObserverBase::stateVectorConstant( double c ) const
-    {
-        return StateVector::Constant(n_,1,c);
-    }
-
-    ObserverBase::StateVector ObserverBase::stateVectorRandom() const
-    {
-        return StateVector::Random(n_,1);
-    }
-
-    ObserverBase::StateVector ObserverBase::stateVectorZero() const
-    {
-        return StateVector::Zero(n_,1);
-    }
-
-    bool ObserverBase::checkStateVector(const StateVector & v) const
-    {
-        return (v.rows()==n_ && v.cols()==1);
-    }
-
-
-    ObserverBase::MeasureVector ObserverBase::measureVectorConstant( double c ) const
-    {
-        return MeasureVector::Constant(m_,1,c);
-    }
-
-    ObserverBase::MeasureVector ObserverBase::measureVectorRandom() const
-    {
-        return MeasureVector::Random(m_,1);
-    }
-
-    ObserverBase::MeasureVector ObserverBase::measureVectorZero() const
-    {
-        return MeasureVector::Zero(m_,1);
-    }
-
-    bool ObserverBase::checkMeasureVector(const MeasureVector & v) const
-    {
-        return (v.rows()==m_ && v.cols()==1);
-    }
-
-
-    ObserverBase::InputVector ObserverBase::inputVectorConstant( double c ) const
-    {
-        return InputVector::Constant(p_,1,c);
-    }
-
-    ObserverBase::InputVector ObserverBase::inputVectorRandom() const
-    {
-        return InputVector::Random(p_,1);
-    }
-
-    ObserverBase::InputVector ObserverBase::inputVectorZero() const
-    {
-        return InputVector::Zero(p_,1);
-    }
-
-    bool ObserverBase::checkInputVector(const InputVector & v) const
-    {
-        return (v.rows()==p_ && v.cols()==1);
-    }
-
-
-    void ObserverBase::setStateSize(Index n)
-    {
-        n_=n;
-    }
-
-    Index ObserverBase::getStateSize() const
-    {
-        return n_;
-    }
-
-    void ObserverBase::setMeasureSize(Index m)
-    {
-        m_=m;
-    }
-
-    Index ObserverBase::getMeasureSize() const
-    {
-        return m_;
-    }
-
-
-    void ObserverBase::setInputSize(Index p)
-    {
-        p_=p;
-    }
-
-    Index ObserverBase::getInputSize() const
-    {
-        return p_;
-    }
-
+void ObserverBase::reset()
+{
+  clearStates();
+  clearMeasurements();
+  clearInputs();
 }
+
+ObserverBase::ObserverBase()
+{
+  n_ = m_ = p_ = 0;
+}
+
+ObserverBase::ObserverBase(Index n, Index m, Index p) : n_(n), m_(m), p_(p) {}
+
+ObserverBase::StateVector ObserverBase::stateVectorConstant(double c) const
+{
+  return StateVector::Constant(n_, 1, c);
+}
+
+ObserverBase::StateVector ObserverBase::stateVectorRandom() const
+{
+  return StateVector::Random(n_, 1);
+}
+
+ObserverBase::StateVector ObserverBase::stateVectorZero() const
+{
+  return StateVector::Zero(n_, 1);
+}
+
+bool ObserverBase::checkStateVector(const StateVector & v) const
+{
+  return (v.rows() == n_ && v.cols() == 1);
+}
+
+ObserverBase::MeasureVector ObserverBase::measureVectorConstant(double c) const
+{
+  return MeasureVector::Constant(m_, 1, c);
+}
+
+ObserverBase::MeasureVector ObserverBase::measureVectorRandom() const
+{
+  return MeasureVector::Random(m_, 1);
+}
+
+ObserverBase::MeasureVector ObserverBase::measureVectorZero() const
+{
+  return MeasureVector::Zero(m_, 1);
+}
+
+bool ObserverBase::checkMeasureVector(const MeasureVector & v) const
+{
+  return (v.rows() == m_ && v.cols() == 1);
+}
+
+ObserverBase::InputVector ObserverBase::inputVectorConstant(double c) const
+{
+  return InputVector::Constant(p_, 1, c);
+}
+
+ObserverBase::InputVector ObserverBase::inputVectorRandom() const
+{
+  return InputVector::Random(p_, 1);
+}
+
+ObserverBase::InputVector ObserverBase::inputVectorZero() const
+{
+  return InputVector::Zero(p_, 1);
+}
+
+bool ObserverBase::checkInputVector(const InputVector & v) const
+{
+  return (v.rows() == p_ && v.cols() == 1);
+}
+
+void ObserverBase::setStateSize(Index n)
+{
+  n_ = n;
+}
+
+Index ObserverBase::getStateSize() const
+{
+  return n_;
+}
+
+void ObserverBase::setMeasureSize(Index m)
+{
+  m_ = m;
+}
+
+Index ObserverBase::getMeasureSize() const
+{
+  return m_;
+}
+
+void ObserverBase::setInputSize(Index p)
+{
+  p_ = p;
+}
+
+Index ObserverBase::getInputSize() const
+{
+  return p_;
+}
+
+} // namespace stateObservation

--- a/src/probability-law-simulation.cpp
+++ b/src/probability-law-simulation.cpp
@@ -1,34 +1,30 @@
 #include <state-observation/tools/probability-law-simulation.hpp>
 
-
 namespace stateObservation
 {
-    namespace tools
-    {
+namespace tools
+{
 
-        boost::lagged_fibonacci1279 ProbabilityLawSimulation::gen_;
+boost::lagged_fibonacci1279 ProbabilityLawSimulation::gen_;
 
-        double ProbabilityLawSimulation::getGaussianScalar(double std , double bias)
-        {
-            boost::normal_distribution<> g(0, 1);
-            return g(gen_)*std+bias;
-
-        }
-
-        Matrix ProbabilityLawSimulation::getGaussianVector(const Matrix& std,
-                                          const Matrix& bias,Index rows, Index cols)
-        {
-            boost::normal_distribution<> g(0, 1);
-            Matrix ret= Matrix::Zero(rows,cols);
-            for (Index i=0;i<rows;++i)
-            {
-                for (Index j=0; j<cols; ++j)
-                    ret(i,j)=g(gen_);
-            }
-            ret=std*ret+bias;
-
-            return ret;
-        }
-    }
-
+double ProbabilityLawSimulation::getGaussianScalar(double std, double bias)
+{
+  boost::normal_distribution<> g(0, 1);
+  return g(gen_) * std + bias;
 }
+
+Matrix ProbabilityLawSimulation::getGaussianVector(const Matrix & std, const Matrix & bias, Index rows, Index cols)
+{
+  boost::normal_distribution<> g(0, 1);
+  Matrix ret = Matrix::Zero(rows, cols);
+  for(Index i = 0; i < rows; ++i)
+  {
+    for(Index j = 0; j < cols; ++j) ret(i, j) = g(gen_);
+  }
+  ret = std * ret + bias;
+
+  return ret;
+}
+} // namespace tools
+
+} // namespace stateObservation

--- a/src/rotation-velocity.cpp
+++ b/src/rotation-velocity.cpp
@@ -2,12 +2,12 @@
 
 namespace stateObservation
 {
-    namespace algorithm
-    {
-        Vector3 RotationVelocity::rotationVelocityMeasure(const Vector3 & angVelocityVector, const Matrix3 & orientation) const
-        {
-          return Vector3(orientation.transpose()*angVelocityVector);
-        }
-
-    }
+namespace algorithm
+{
+Vector3 RotationVelocity::rotationVelocityMeasure(const Vector3 & angVelocityVector, const Matrix3 & orientation) const
+{
+  return Vector3(orientation.transpose() * angVelocityVector);
 }
+
+} // namespace algorithm
+} // namespace stateObservation

--- a/src/sensor-base.cpp
+++ b/src/sensor-base.cpp
@@ -2,34 +2,31 @@
 
 namespace stateObservation
 {
-    SensorBase::SensorBase()
-        :noise_(0x0)
-    {
-    }
+SensorBase::SensorBase() : noise_(0x0) {}
 
-    bool SensorBase::checkStateVector(const Vector & state) const
-    {
-        return (state.rows()==getStateSize() && state.cols()==1);
-    }
-
-    void SensorBase::setNoise(NoiseBase * noise)
-    {
-        noise_=noise;
-    }
-
-    void SensorBase::resetNoise()
-    {
-        noise_=0x0;
-    }
-
-    Vector SensorBase::stateVectorZero()const
-    {
-        return Vector::Zero(getStateSize(),1);
-    }
-
-    NoiseBase * SensorBase::getNoise() const
-    {
-        return noise_;
-    }
-
+bool SensorBase::checkStateVector(const Vector & state) const
+{
+  return (state.rows() == getStateSize() && state.cols() == 1);
 }
+
+void SensorBase::setNoise(NoiseBase * noise)
+{
+  noise_ = noise;
+}
+
+void SensorBase::resetNoise()
+{
+  noise_ = 0x0;
+}
+
+Vector SensorBase::stateVectorZero() const
+{
+  return Vector::Zero(getStateSize(), 1);
+}
+
+NoiseBase * SensorBase::getNoise() const
+{
+  return noise_;
+}
+
+} // namespace stateObservation

--- a/src/stable-imu-fixed-contact-dynamical-system.cpp
+++ b/src/stable-imu-fixed-contact-dynamical-system.cpp
@@ -5,228 +5,206 @@ namespace stateObservation
 {
 namespace flexibilityEstimation
 {
-    using namespace stateObservation;
+using namespace stateObservation;
 
-
-
-    StableIMUFixedContactDynamicalSystem::
-    	StableIMUFixedContactDynamicalSystem(double dt):
-        processNoise_(0x0), dt_(dt),orientationVector_(Vector3::Zero()),
-        quaternion_(Quaternion::Identity()),
-        measurementSize_(measurementSizeBase_)
-    {
+StableIMUFixedContactDynamicalSystem::StableIMUFixedContactDynamicalSystem(double dt)
+: processNoise_(0x0), dt_(dt), orientationVector_(Vector3::Zero()), quaternion_(Quaternion::Identity()),
+  measurementSize_(measurementSizeBase_){
 #ifdef STATEOBSERVATION_VERBOUS_CONSTRUCTORS
 //        std::cout<<std::endl<<"IMUFixedContactDynamicalSystem Constructor"<<std::endl;
-#endif //STATEOBSERVATION_VERBOUS_CONSTRUCTOR
-    }
+#endif // STATEOBSERVATION_VERBOUS_CONSTRUCTOR
+  }
 
-    StableIMUFixedContactDynamicalSystem::
-                    ~StableIMUFixedContactDynamicalSystem()
-    {
-        //dtor
-    }
-
-    Vector3 StableIMUFixedContactDynamicalSystem::stabilizeAccelerationLinear
-    	(Vector3 x, Vector3 xdot)
-    {
-
-        const Vector3 WLinear(5,5,5);
-        const Vector3 ELinear(0.1,0.1,0.1);
-        return -WLinear.cwiseProduct(WLinear.cwiseProduct(x))-2*ELinear.cwiseProduct(WLinear.cwiseProduct(xdot));
-
-    }
-
-    Vector3 StableIMUFixedContactDynamicalSystem::stabilizeAccelerationAngular
-    	(Vector3 x, Vector3 xdot)
-    {
-
-        const Vector3 WAngular(5,5,5);
-        const Vector3 EAngular(0.1,0.1,0.1);
-        return -WAngular.cwiseProduct(WAngular.cwiseProduct(x))-2*EAngular.cwiseProduct(WAngular.cwiseProduct(xdot));
-
-    }
-
-
-    Vector StableIMUFixedContactDynamicalSystem::stateDynamics
-        (const Vector& x, const Vector& , TimeIndex )
-    {
-        assertStateVector_(x);
-
-        Vector3 positionFlex(x.segment(indexes::pos,3));
-        Vector3 velocityFlex(x.segment(indexes::linVel,3));
-        //Vector3 accelerationFlex(x.segment(indexes::linAcc,3));
-        Vector3 accelerationFlex(stabilizeAccelerationLinear(positionFlex, velocityFlex));
-
-        Vector3 orientationFlexV(x.segment(indexes::ori,3));
-        Vector3 angularVelocityFlex(x.segment(indexes::angVel,3));
-        //Vector3 angularAccelerationFlex(x.segment(indexes::angAcc,3));
-        Vector3 angularAccelerationFlex(stabilizeAccelerationAngular(orientationFlexV, angularVelocityFlex));
-
-        Quaternion orientationFlex(computeQuaternion_(orientationFlexV));
-
-        kine::integrateKinematics
-                (positionFlex, velocityFlex, accelerationFlex, orientationFlex,
-                 angularVelocityFlex, angularAccelerationFlex, dt_);
-
-        //x_{k+1}
-        Vector xk1(x);
-
-        xk1.segment(indexes::pos,3) = positionFlex;
-        xk1.segment(indexes::linVel,3) = velocityFlex;
-        xk1.segment(indexes::linAcc,3) = accelerationFlex;
-
-        AngleAxis orientationAA(orientationFlex);
-        orientationFlexV=orientationAA.angle()*orientationAA.axis();
-
-        xk1.segment(indexes::ori,3) =  orientationFlexV;
-        xk1.segment(indexes::angVel,3) = angularVelocityFlex;
-        xk1.segment(indexes::angAcc,3) = angularAccelerationFlex;
-
-         if (processNoise_!=0x0)
-            return processNoise_->getNoisy(xk1);
-        else
-            return xk1;
-    }
-
-    Quaternion StableIMUFixedContactDynamicalSystem::computeQuaternion_
-                (const Vector3 & x)
-    {
-        if (orientationVector_!=x)
-        {
-            orientationVector_ = x;
-            quaternion_ = kine::rotationVectorToAngleAxis(x);
-        }
-
-        return quaternion_;
-    }
-
-    Vector StableIMUFixedContactDynamicalSystem::measureDynamics
-                (const Vector& x, const Vector& u, TimeIndex k)
-    {
-        assertStateVector_(x);
-
-        Vector3 positionFlex(x.segment(indexes::pos,3));
-        Vector3 velocityFlex(x.segment(indexes::linVel,3));
-        Vector3 accelerationFlex(x.segment(indexes::linAcc,3));
-
-        Vector3 orientationFlexV(x.segment(indexes::ori,3));
-        Vector3 angularVelocityFlex(x.segment(indexes::angVel,3));
-        Vector3 angularAccelerationFlex(x.segment(indexes::angAcc,3));
-
-        Quaternion qFlex (computeQuaternion_(orientationFlexV));
-        Matrix3 rFlex (qFlex.toRotationMatrix());
-
-
-        assertInputVector_(u);
-
-        Vector3 positionControl(u.segment(indexes::pos,3));
-        Vector3 velocityControl(u.segment(indexes::linVel,3));
-        Vector3 accelerationControl(u.segment(indexes::linAcc,3));
-
-        Vector3 orientationControlV(u.segment(indexes::ori,3));
-        Vector3 angularVelocityControl(u.segment(indexes::angVel,3));
-
-        Quaternion qControl(computeQuaternion_(orientationControlV));
-
-        Quaternion q = qFlex * qControl;
-
-        Vector3 acceleration (
-         (kine::skewSymmetric(angularAccelerationFlex)
-              + tools::square(kine::skewSymmetric(angularVelocityFlex)))
-                  * rFlex * positionControl
-         + 2*kine::skewSymmetric(angularVelocityFlex) * rFlex * velocityControl
-         + accelerationFlex + rFlex * accelerationControl);
-
-        Vector3 angularVelocity( angularVelocityFlex +
-                                    rFlex * angularVelocityControl);
-
-        Vector v(Vector::Zero(10,1));
-
-        v.head<4>() = q.coeffs();
-
-        v.segment(4,3)=acceleration;
-        v.tail(3)=angularVelocity;
-
-        sensor_.setState(v,k);
-
-        Vector y (Matrix::Zero(measurementSize_,1));
-
-        y.head(sensor_.getMeasurementSize()) = sensor_.getMeasurements();
-
-        for (unsigned i=0; i<contactPositions_.size();++i)
-        {
-            y.segment(sensor_.getMeasurementSize()+i*3,3)=
-                rFlex * contactPositions_[i] + positionFlex - contactPositions_[i];
-        }
-
-        return y;
-    }
-
-    void StableIMUFixedContactDynamicalSystem::setProcessNoise(NoiseBase * n)
-    {
-        processNoise_=n;
-    }
-
-    void StableIMUFixedContactDynamicalSystem::resetProcessNoise()
-    {
-        processNoise_=0x0;
-    }
-
-    void StableIMUFixedContactDynamicalSystem::setMeasurementNoise
-                ( NoiseBase * n)
-    {
-        sensor_.setNoise(n);
-    }
-
-    void StableIMUFixedContactDynamicalSystem::resetMeasurementNoise()
-    {
-        sensor_.resetNoise();
-    }
-
-    void StableIMUFixedContactDynamicalSystem::setSamplingPeriod(double dt)
-    {
-        dt_=dt;
-    }
-
-    Index StableIMUFixedContactDynamicalSystem::getStateSize() const
-    {
-        return stateSize_;
-    }
-
-    Index StableIMUFixedContactDynamicalSystem::getInputSize() const
-    {
-        return inputSize_;
-    }
-
-    Index StableIMUFixedContactDynamicalSystem::getMeasurementSize() const
-    {
-        return measurementSize_;
-    }
-
-    NoiseBase * StableIMUFixedContactDynamicalSystem::getProcessNoise() const
-    {
-        return processNoise_;
-    }
-
-    NoiseBase * StableIMUFixedContactDynamicalSystem::
-                                                    getMeasurementNoise() const
-    {
-        return sensor_.getNoise();
-    }
-
-    void StableIMUFixedContactDynamicalSystem::setContactsNumber(unsigned i)
-    {
-        measurementSize_ = measurementSizeBase_ + 3 * i;
-        contactPositions_.resize(i, Vector3::Zero());
-    }
-
-    void StableIMUFixedContactDynamicalSystem::setContactPosition
-                                        (unsigned i, const Vector3 & position)
-    {
-        BOOST_ASSERT( i< contactPositions_.size() &&
-                    "ERROR: The index of contact is out of range.");
-
-        contactPositions_[i] = position;
-    }
+  StableIMUFixedContactDynamicalSystem::~StableIMUFixedContactDynamicalSystem()
+{
+  // dtor
 }
+
+Vector3 StableIMUFixedContactDynamicalSystem::stabilizeAccelerationLinear(Vector3 x, Vector3 xdot)
+{
+
+  const Vector3 WLinear(5, 5, 5);
+  const Vector3 ELinear(0.1, 0.1, 0.1);
+  return -WLinear.cwiseProduct(WLinear.cwiseProduct(x)) - 2 * ELinear.cwiseProduct(WLinear.cwiseProduct(xdot));
 }
+
+Vector3 StableIMUFixedContactDynamicalSystem::stabilizeAccelerationAngular(Vector3 x, Vector3 xdot)
+{
+
+  const Vector3 WAngular(5, 5, 5);
+  const Vector3 EAngular(0.1, 0.1, 0.1);
+  return -WAngular.cwiseProduct(WAngular.cwiseProduct(x)) - 2 * EAngular.cwiseProduct(WAngular.cwiseProduct(xdot));
+}
+
+Vector StableIMUFixedContactDynamicalSystem::stateDynamics(const Vector & x, const Vector &, TimeIndex)
+{
+  assertStateVector_(x);
+
+  Vector3 positionFlex(x.segment(indexes::pos, 3));
+  Vector3 velocityFlex(x.segment(indexes::linVel, 3));
+  // Vector3 accelerationFlex(x.segment(indexes::linAcc,3));
+  Vector3 accelerationFlex(stabilizeAccelerationLinear(positionFlex, velocityFlex));
+
+  Vector3 orientationFlexV(x.segment(indexes::ori, 3));
+  Vector3 angularVelocityFlex(x.segment(indexes::angVel, 3));
+  // Vector3 angularAccelerationFlex(x.segment(indexes::angAcc,3));
+  Vector3 angularAccelerationFlex(stabilizeAccelerationAngular(orientationFlexV, angularVelocityFlex));
+
+  Quaternion orientationFlex(computeQuaternion_(orientationFlexV));
+
+  kine::integrateKinematics(positionFlex, velocityFlex, accelerationFlex, orientationFlex, angularVelocityFlex,
+                            angularAccelerationFlex, dt_);
+
+  // x_{k+1}
+  Vector xk1(x);
+
+  xk1.segment(indexes::pos, 3) = positionFlex;
+  xk1.segment(indexes::linVel, 3) = velocityFlex;
+  xk1.segment(indexes::linAcc, 3) = accelerationFlex;
+
+  AngleAxis orientationAA(orientationFlex);
+  orientationFlexV = orientationAA.angle() * orientationAA.axis();
+
+  xk1.segment(indexes::ori, 3) = orientationFlexV;
+  xk1.segment(indexes::angVel, 3) = angularVelocityFlex;
+  xk1.segment(indexes::angAcc, 3) = angularAccelerationFlex;
+
+  if(processNoise_ != 0x0)
+    return processNoise_->getNoisy(xk1);
+  else
+    return xk1;
+}
+
+Quaternion StableIMUFixedContactDynamicalSystem::computeQuaternion_(const Vector3 & x)
+{
+  if(orientationVector_ != x)
+  {
+    orientationVector_ = x;
+    quaternion_ = kine::rotationVectorToAngleAxis(x);
+  }
+
+  return quaternion_;
+}
+
+Vector StableIMUFixedContactDynamicalSystem::measureDynamics(const Vector & x, const Vector & u, TimeIndex k)
+{
+  assertStateVector_(x);
+
+  Vector3 positionFlex(x.segment(indexes::pos, 3));
+  Vector3 velocityFlex(x.segment(indexes::linVel, 3));
+  Vector3 accelerationFlex(x.segment(indexes::linAcc, 3));
+
+  Vector3 orientationFlexV(x.segment(indexes::ori, 3));
+  Vector3 angularVelocityFlex(x.segment(indexes::angVel, 3));
+  Vector3 angularAccelerationFlex(x.segment(indexes::angAcc, 3));
+
+  Quaternion qFlex(computeQuaternion_(orientationFlexV));
+  Matrix3 rFlex(qFlex.toRotationMatrix());
+
+  assertInputVector_(u);
+
+  Vector3 positionControl(u.segment(indexes::pos, 3));
+  Vector3 velocityControl(u.segment(indexes::linVel, 3));
+  Vector3 accelerationControl(u.segment(indexes::linAcc, 3));
+
+  Vector3 orientationControlV(u.segment(indexes::ori, 3));
+  Vector3 angularVelocityControl(u.segment(indexes::angVel, 3));
+
+  Quaternion qControl(computeQuaternion_(orientationControlV));
+
+  Quaternion q = qFlex * qControl;
+
+  Vector3 acceleration(
+      (kine::skewSymmetric(angularAccelerationFlex) + tools::square(kine::skewSymmetric(angularVelocityFlex))) * rFlex
+          * positionControl
+      + 2 * kine::skewSymmetric(angularVelocityFlex) * rFlex * velocityControl + accelerationFlex
+      + rFlex * accelerationControl);
+
+  Vector3 angularVelocity(angularVelocityFlex + rFlex * angularVelocityControl);
+
+  Vector v(Vector::Zero(10, 1));
+
+  v.head<4>() = q.coeffs();
+
+  v.segment(4, 3) = acceleration;
+  v.tail(3) = angularVelocity;
+
+  sensor_.setState(v, k);
+
+  Vector y(Matrix::Zero(measurementSize_, 1));
+
+  y.head(sensor_.getMeasurementSize()) = sensor_.getMeasurements();
+
+  for(unsigned i = 0; i < contactPositions_.size(); ++i)
+  {
+    y.segment(sensor_.getMeasurementSize() + i * 3, 3) =
+        rFlex * contactPositions_[i] + positionFlex - contactPositions_[i];
+  }
+
+  return y;
+}
+
+void StableIMUFixedContactDynamicalSystem::setProcessNoise(NoiseBase * n)
+{
+  processNoise_ = n;
+}
+
+void StableIMUFixedContactDynamicalSystem::resetProcessNoise()
+{
+  processNoise_ = 0x0;
+}
+
+void StableIMUFixedContactDynamicalSystem::setMeasurementNoise(NoiseBase * n)
+{
+  sensor_.setNoise(n);
+}
+
+void StableIMUFixedContactDynamicalSystem::resetMeasurementNoise()
+{
+  sensor_.resetNoise();
+}
+
+void StableIMUFixedContactDynamicalSystem::setSamplingPeriod(double dt)
+{
+  dt_ = dt;
+}
+
+Index StableIMUFixedContactDynamicalSystem::getStateSize() const
+{
+  return stateSize_;
+}
+
+Index StableIMUFixedContactDynamicalSystem::getInputSize() const
+{
+  return inputSize_;
+}
+
+Index StableIMUFixedContactDynamicalSystem::getMeasurementSize() const
+{
+  return measurementSize_;
+}
+
+NoiseBase * StableIMUFixedContactDynamicalSystem::getProcessNoise() const
+{
+  return processNoise_;
+}
+
+NoiseBase * StableIMUFixedContactDynamicalSystem::getMeasurementNoise() const
+{
+  return sensor_.getNoise();
+}
+
+void StableIMUFixedContactDynamicalSystem::setContactsNumber(unsigned i)
+{
+  measurementSize_ = measurementSizeBase_ + 3 * i;
+  contactPositions_.resize(i, Vector3::Zero());
+}
+
+void StableIMUFixedContactDynamicalSystem::setContactPosition(unsigned i, const Vector3 & position)
+{
+  BOOST_ASSERT(i < contactPositions_.size() && "ERROR: The index of contact is out of range.");
+
+  contactPositions_[i] = position;
+}
+} // namespace flexibilityEstimation
+} // namespace stateObservation

--- a/src/state-vector-arithmetics.cpp
+++ b/src/state-vector-arithmetics.cpp
@@ -2,29 +2,33 @@
 
 namespace stateObservation
 {
-void detail::defaultSum(const Vector &stateVector, const Vector &tangentVector, Vector &result)
+void detail::defaultSum(const Vector & stateVector, const Vector & tangentVector, Vector & result)
 {
-    result.noalias() = stateVector + tangentVector;
+  result.noalias() = stateVector + tangentVector;
 }
 
-void detail::defaultDifference(const Vector &stateVector1, const Vector &stateVector2, Vector &difference)
+void detail::defaultDifference(const Vector & stateVector1, const Vector & stateVector2, Vector & difference)
 {
-    difference.noalias() = stateVector1 - stateVector2;
+  difference.noalias() = stateVector1 - stateVector2;
 }
 
-void StateVectorArithmetics::stateSum(const Vector &stateVector, const Vector &tangentVector, Vector &sum)
+void StateVectorArithmetics::stateSum(const Vector & stateVector, const Vector & tangentVector, Vector & sum)
 {
-    detail::defaultSum(stateVector, tangentVector, sum);
+  detail::defaultSum(stateVector, tangentVector, sum);
 }
 
-void StateVectorArithmetics::stateDifference(const Vector &stateVector1, const Vector &stateVector2, Vector &difference)
+void StateVectorArithmetics::stateDifference(const Vector & stateVector1,
+                                             const Vector & stateVector2,
+                                             Vector & difference)
 {
-    detail::defaultDifference(stateVector1, stateVector2, difference);
+  detail::defaultDifference(stateVector1, stateVector2, difference);
 }
 
-void StateVectorArithmetics::measurementDifference(const Vector &measureVector1, const Vector &measureVector2, Vector &difference)
+void StateVectorArithmetics::measurementDifference(const Vector & measureVector1,
+                                                   const Vector & measureVector2,
+                                                   Vector & difference)
 {
-    detail::defaultDifference(measureVector1, measureVector2, difference);
+  detail::defaultDifference(measureVector1, measureVector2, difference);
 }
 
 } // namespace stateObservation

--- a/src/tilt-estimator.cpp
+++ b/src/tilt-estimator.cpp
@@ -3,57 +3,48 @@
 namespace stateObservation
 {
 
-  TiltEstimator::TiltEstimator(double alpha, double beta, double gamma)
-    : ZeroDelayObserver(9, 6), 
-      alpha_(alpha), 
-      beta_(beta), 
-      gamma_(gamma),
-      dt_(0.005),
-      p_S_C_(Vector3::Zero()),
-      R_S_C_(Matrix3::Identity()), 
-      v_S_C_(Vector3::Zero()), 
-      w_S_C_(Vector3::Zero()), 
-      v_C_(Vector3::Zero())
-  {
-  }
-  
-  void TiltEstimator::setMeasurement(const Vector3 ya_k, const Vector3 yg_k, TimeIndex k)
-  {
-    ObserverBase::MeasureVector y_k(6);
-    y_k << ya_k, yg_k;
-
-    ZeroDelayObserver::setMeasurement(y_k, k);
-  }
-
-  ObserverBase::StateVector TiltEstimator::oneStepEstimation_()
-  {
-    TimeIndex k = this->x_.getTime();
-    
-    BOOST_ASSERT(this->y_.size() > 0 && this->y_.checkIndex(k+1) && "ERROR: The measurement vector is not set");
-
-    Vector3 ya = getMeasurement(k+1).head<3>();
-    Vector3 yg = getMeasurement(k+1).tail<3>();
-    
-    x1_ = R_S_C_.transpose() * (v_C_ + v_S_C_) + (yg - R_S_C_.transpose() * w_S_C_).cross(R_S_C_.transpose() * p_S_C_);
-
-    ObserverBase::StateVector x_hat = getEstimatedState(k);
-    x1_hat_ = x_hat.segment<3>(0);
-    x2_hat_prime_ = x_hat.segment<3>(3);
-    x2_hat_ = x_hat.segment<3>(6);
-    
-    Vector dx_hat(9);
-    dx_hat.segment<3>(0) = x1_hat_.cross(yg) - cst::gravityConstant * x2_hat_prime_ + ya + alpha_ * (x1_ - x1_hat_);
-    dx_hat.segment<3>(3) = x2_hat_prime_.cross(yg) - beta_ * (x1_ - x1_hat_);
-    dx_hat.segment<3>(6) = x2_hat_.cross(yg - gamma_ * x2_hat_.cross(x2_hat_prime_));
-    
-    x_hat += dx_hat * dt_;
-
-    x_hat.tail<3>() /= x_hat.tail<3>().norm();
-    
-    setState(x_hat, k+1);
-    
-    return x_hat;
-  }
-
-  
+TiltEstimator::TiltEstimator(double alpha, double beta, double gamma)
+: ZeroDelayObserver(9, 6), alpha_(alpha), beta_(beta), gamma_(gamma), dt_(0.005), p_S_C_(Vector3::Zero()),
+  R_S_C_(Matrix3::Identity()), v_S_C_(Vector3::Zero()), w_S_C_(Vector3::Zero()), v_C_(Vector3::Zero())
+{
 }
+
+void TiltEstimator::setMeasurement(const Vector3 ya_k, const Vector3 yg_k, TimeIndex k)
+{
+  ObserverBase::MeasureVector y_k(6);
+  y_k << ya_k, yg_k;
+
+  ZeroDelayObserver::setMeasurement(y_k, k);
+}
+
+ObserverBase::StateVector TiltEstimator::oneStepEstimation_()
+{
+  TimeIndex k = this->x_.getTime();
+
+  BOOST_ASSERT(this->y_.size() > 0 && this->y_.checkIndex(k + 1) && "ERROR: The measurement vector is not set");
+
+  Vector3 ya = getMeasurement(k + 1).head<3>();
+  Vector3 yg = getMeasurement(k + 1).tail<3>();
+
+  x1_ = R_S_C_.transpose() * (v_C_ + v_S_C_) + (yg - R_S_C_.transpose() * w_S_C_).cross(R_S_C_.transpose() * p_S_C_);
+
+  ObserverBase::StateVector x_hat = getEstimatedState(k);
+  x1_hat_ = x_hat.segment<3>(0);
+  x2_hat_prime_ = x_hat.segment<3>(3);
+  x2_hat_ = x_hat.segment<3>(6);
+
+  Vector dx_hat(9);
+  dx_hat.segment<3>(0) = x1_hat_.cross(yg) - cst::gravityConstant * x2_hat_prime_ + ya + alpha_ * (x1_ - x1_hat_);
+  dx_hat.segment<3>(3) = x2_hat_prime_.cross(yg) - beta_ * (x1_ - x1_hat_);
+  dx_hat.segment<3>(6) = x2_hat_.cross(yg - gamma_ * x2_hat_.cross(x2_hat_prime_));
+
+  x_hat += dx_hat * dt_;
+
+  x_hat.tail<3>() /= x_hat.tail<3>().norm();
+
+  setState(x_hat, k + 1);
+
+  return x_hat;
+}
+
+} // namespace stateObservation

--- a/src/zero-delay-observer.cpp
+++ b/src/zero-delay-observer.cpp
@@ -3,174 +3,157 @@
 namespace stateObservation
 {
 
-    void ZeroDelayObserver::setState
-                            (const ObserverBase::StateVector& x_k,TimeIndex k)
+void ZeroDelayObserver::setState(const ObserverBase::StateVector & x_k, TimeIndex k)
+{
+  BOOST_ASSERT(checkStateVector(x_k) && "The size of the state vector is incorrect");
+
+  x_.set(x_k, k);
+  while(y_.size() > 0 && y_.getFirstIndex() <= k)
+  {
+    y_.popFront();
+  }
+
+  if(p_ > 0)
+    while(u_.size() > 0 && u_.getFirstIndex() < k)
     {
-        BOOST_ASSERT(checkStateVector(x_k)
-                            && "The size of the state vector is incorrect");
-
-        x_.set(x_k,k);
-        while (y_.size()>0 && y_.getFirstIndex()<=k)
-        {
-            y_.popFront();
-        }
-
-        if (p_>0)
-            while (u_.size()>0 && u_.getFirstIndex()<k)
-            {
-                u_.popFront();
-            }
-    }
-
-    void ZeroDelayObserver::clearStates()
-    {
-        x_.reset();
-    }
-
-    void ZeroDelayObserver::setMeasurement
-                    (const ObserverBase::MeasureVector& y_k,TimeIndex k)
-    {
-
-        BOOST_ASSERT(checkMeasureVector(y_k)
-                && "The size of the measure vector is incorrect");
-        if (y_.size()>0)
-            BOOST_ASSERT ((y_.getNextIndex()==k || y_.checkIndex(k))
-                && "ERROR: The time is set incorrectly for \
-                                the measurements (order or gap)");
-        else
-            BOOST_ASSERT ( (!x_.isSet() || x_.getTime()==k-1)
-                && "ERROR: The time is set incorrectly for the measurements \
-                                (must be [current_time+1])");
-
-        y_.setValue(y_k,k);
-    }
-
-    void ZeroDelayObserver::clearMeasurements()
-    {
-        y_.reset();
-    }
-
-    void ZeroDelayObserver::setInput
-                    (const ObserverBase::InputVector& u_k,TimeIndex k)
-    {
-        if (p_>0)
-        {
-            BOOST_ASSERT(checkInputVector(u_k)
-                        && "The size of the input vector is incorrect");
-
-            if (u_.size()>0)
-                BOOST_ASSERT ((u_.getNextIndex()==k || u_.checkIndex(k))
-                        && "ERROR: The time is set incorrectly \
-                                for the inputs (order or gap)");
-            else
-            {
-                BOOST_ASSERT ( (!x_.isSet() || x_.getTime()==k || x_.getTime()==k-1)
-                    && "ERROR: The time is set incorrectly for the \
-                          inputs (must be [current_time] or [current_time+1])");
-            }
-
-            u_.setValue(u_k,k);
-        }
-    }
-
-    void ZeroDelayObserver::clearInputs()
-    {
-        if (p_>0)
-            u_.reset();
-    }
-
-    ObserverBase::StateVector
-    ZeroDelayObserver::getEstimatedState(TimeIndex k)
-    {
-        TimeIndex k0=x_.getTime();
-
-        BOOST_ASSERT(k0<=k
-                && "ERROR: The observer cannot estimate previous states");
-
-        for (TimeIndex i=k0;i<k;++i)
-        {
-            oneStepEstimation_();
-            if (y_.getFirstIndex()<k)
-                y_.popFront();
-
-            if (p_>0)
-                if (u_.getFirstIndex()<k)
-                    u_.popFront();
-        }
-
-        return x_();
-    }
-
-
-    TimeIndex ZeroDelayObserver::getCurrentTime()const
-    {
-        return x_.getTime();
-    }
-
-    Vector ZeroDelayObserver::getInput(TimeIndex k) const
-    {
-        return u_[k];
-    }
-
-    TimeSize ZeroDelayObserver::getInputsNumber()const
-    {
-        return u_.size();
-    }
-
-    TimeIndex ZeroDelayObserver::getInputTime()const
-    {
-        if (u_.size()>0)
-        {
-            return u_.getLastIndex();
-        }
-        else
-        {
-            return 0;
-        }
-    }
-
-    Vector ZeroDelayObserver::getMeasurement(TimeIndex k) const
-    {
-        return y_[k];
-    }
-
-    TimeIndex ZeroDelayObserver::getMeasurementTime()const
-    {
-        BOOST_ASSERT(y_.size()>0
-                && "ERROR: There is no measurements registered (past measurements are erased)");
-        return y_.getLastIndex();
-    }
-
-    TimeSize ZeroDelayObserver::getMeasurementsNumber()const
-    {
-        return TimeSize(y_.size());
-    }
-
-
-    void ZeroDelayObserver::setStateSize(Index n)
-    {
-        if (n!=n_)
-        {
-            ObserverBase::setStateSize(n);
-            clearStates();
-        }
-    }
-
-    void ZeroDelayObserver::setMeasureSize(Index m)
-    {
-        if (m!=m_)
-        {
-            ObserverBase::setMeasureSize(m);
-            clearMeasurements();
-        }
-    }
-
-    void ZeroDelayObserver::setInputSize(Index p)
-    {
-        if (p!=p_)
-        {
-            ObserverBase::setInputSize(p);
-            clearInputs();
-        }
+      u_.popFront();
     }
 }
+
+void ZeroDelayObserver::clearStates()
+{
+  x_.reset();
+}
+
+void ZeroDelayObserver::setMeasurement(const ObserverBase::MeasureVector & y_k, TimeIndex k)
+{
+
+  BOOST_ASSERT(checkMeasureVector(y_k) && "The size of the measure vector is incorrect");
+  if(y_.size() > 0)
+    BOOST_ASSERT((y_.getNextIndex() == k || y_.checkIndex(k)) && "ERROR: The time is set incorrectly for \
+                                the measurements (order or gap)");
+  else
+    BOOST_ASSERT((!x_.isSet() || x_.getTime() == k - 1) && "ERROR: The time is set incorrectly for the measurements \
+                                (must be [current_time+1])");
+
+  y_.setValue(y_k, k);
+}
+
+void ZeroDelayObserver::clearMeasurements()
+{
+  y_.reset();
+}
+
+void ZeroDelayObserver::setInput(const ObserverBase::InputVector & u_k, TimeIndex k)
+{
+  if(p_ > 0)
+  {
+    BOOST_ASSERT(checkInputVector(u_k) && "The size of the input vector is incorrect");
+
+    if(u_.size() > 0)
+      BOOST_ASSERT((u_.getNextIndex() == k || u_.checkIndex(k)) && "ERROR: The time is set incorrectly \
+                                for the inputs (order or gap)");
+    else
+    {
+      BOOST_ASSERT((!x_.isSet() || x_.getTime() == k || x_.getTime() == k - 1)
+                   && "ERROR: The time is set incorrectly for the \
+                          inputs (must be [current_time] or [current_time+1])");
+    }
+
+    u_.setValue(u_k, k);
+  }
+}
+
+void ZeroDelayObserver::clearInputs()
+{
+  if(p_ > 0) u_.reset();
+}
+
+ObserverBase::StateVector ZeroDelayObserver::getEstimatedState(TimeIndex k)
+{
+  TimeIndex k0 = x_.getTime();
+
+  BOOST_ASSERT(k0 <= k && "ERROR: The observer cannot estimate previous states");
+
+  for(TimeIndex i = k0; i < k; ++i)
+  {
+    oneStepEstimation_();
+    if(y_.getFirstIndex() < k) y_.popFront();
+
+    if(p_ > 0)
+      if(u_.getFirstIndex() < k) u_.popFront();
+  }
+
+  return x_();
+}
+
+TimeIndex ZeroDelayObserver::getCurrentTime() const
+{
+  return x_.getTime();
+}
+
+Vector ZeroDelayObserver::getInput(TimeIndex k) const
+{
+  return u_[k];
+}
+
+TimeSize ZeroDelayObserver::getInputsNumber() const
+{
+  return u_.size();
+}
+
+TimeIndex ZeroDelayObserver::getInputTime() const
+{
+  if(u_.size() > 0)
+  {
+    return u_.getLastIndex();
+  }
+  else
+  {
+    return 0;
+  }
+}
+
+Vector ZeroDelayObserver::getMeasurement(TimeIndex k) const
+{
+  return y_[k];
+}
+
+TimeIndex ZeroDelayObserver::getMeasurementTime() const
+{
+  BOOST_ASSERT(y_.size() > 0 && "ERROR: There is no measurements registered (past measurements are erased)");
+  return y_.getLastIndex();
+}
+
+TimeSize ZeroDelayObserver::getMeasurementsNumber() const
+{
+  return TimeSize(y_.size());
+}
+
+void ZeroDelayObserver::setStateSize(Index n)
+{
+  if(n != n_)
+  {
+    ObserverBase::setStateSize(n);
+    clearStates();
+  }
+}
+
+void ZeroDelayObserver::setMeasureSize(Index m)
+{
+  if(m != m_)
+  {
+    ObserverBase::setMeasureSize(m);
+    clearMeasurements();
+  }
+}
+
+void ZeroDelayObserver::setInputSize(Index p)
+{
+  if(p != p_)
+  {
+    ObserverBase::setInputSize(p);
+    clearInputs();
+  }
+}
+} // namespace stateObservation

--- a/unit-testings/flex-estimation-test.cpp
+++ b/unit-testings/flex-estimation-test.cpp
@@ -1,324 +1,299 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
-#include <state-observation/noise/gaussian-white-noise.hpp>
-#include <state-observation/examples/offline-ekf-flexibility-estimation.hpp>
 #include <state-observation/dynamical-system/dynamical-system-simulator.hpp>
+#include <state-observation/examples/offline-ekf-flexibility-estimation.hpp>
+#include <state-observation/noise/gaussian-white-noise.hpp>
 #include <state-observation/tools/miscellaneous-algorithms.hpp>
-
 
 using namespace stateObservation;
 typedef kine::indexes<kine::rotationVector> indexes;
 
 int testConstant()
 {
-    /// The number of samples
-    const Index kmax=5000;
+  /// The number of samples
+  const Index kmax = 5000;
 
-    ///sampling period
-    const double dt=1e-3;
+  /// sampling period
+  const double dt = 1e-3;
 
-    ///Sizes of the states for the state, the measurement, and the input vector
-    const unsigned stateSize=18;
-    const unsigned measurementSize=6;
-    const unsigned inputSize=15;
+  /// Sizes of the states for the state, the measurement, and the input vector
+  const unsigned stateSize = 18;
+  const unsigned measurementSize = 6;
+  const unsigned inputSize = 15;
 
-    ///The array containing all the states, the measurements and the inputs
-    IndexedVectorArray y;
-    IndexedVectorArray u;
+  /// The array containing all the states, the measurements and the inputs
+  IndexedVectorArray y;
+  IndexedVectorArray u;
 
-    Vector3 contact(Vector3::Zero());
+  Vector3 contact(Vector3::Zero());
 
-    contact[0]=0.31123600000000001;
-    contact[1]=-0.35577300000000001;
-    contact[2]=1.1000000000000001;
+  contact[0] = 0.31123600000000001;
+  contact[1] = -0.35577300000000001;
+  contact[2] = 1.1000000000000001;
 
-    Vector yConstant = Vector::Zero(measurementSize,1);
-    yConstant[1]=9.8;
+  Vector yConstant = Vector::Zero(measurementSize, 1);
+  yConstant[1] = 9.8;
 
+  Vector uConstant = Vector::Zero(inputSize, 1);
+  uConstant[2] = 1.8;
 
-
-    Vector uConstant = Vector::Zero(inputSize,1);
-    uConstant[2]=1.8;
-
+  {
+    for(Index i = 1; i < kmax + 1; ++i)
     {
-        for ( Index i=1 ; i<kmax+1 ; ++i )
-        {
-            y.setValue(yConstant,i);
-            u.setValue(uConstant,i);
-        }
+      y.setValue(yConstant, i);
+      u.setValue(uConstant, i);
     }
+  }
 
-    u.pushBack(uConstant);
+  u.pushBack(uConstant);
 
-    ///the initalization of a random estimation of the initial state
-    Vector xh0=Vector::Zero(stateSize,1);
+  /// the initalization of a random estimation of the initial state
+  Vector xh0 = Vector::Zero(stateSize, 1);
 
-    std::vector<Vector3, Eigen::aligned_allocator<Vector3> > contactPositions;
+  std::vector<Vector3, Eigen::aligned_allocator<Vector3>> contactPositions;
 
-    contactPositions.push_back(contact);
+  contactPositions.push_back(contact);
 
-    stateObservation::IndexedVectorArray xh=
-        stateObservation::examples::offlineEKFFlexibilityEstimation
-        (y,u,xh0,1,contactPositions,dt);
+  stateObservation::IndexedVectorArray xh =
+      stateObservation::examples::offlineEKFFlexibilityEstimation(y, u, xh0, 1, contactPositions, dt);
 
-    ///file of output
-    std::ofstream f;
-    f.open("trajectory.dat");
+  /// file of output
+  std::ofstream f;
+  f.open("trajectory.dat");
 
-    ///the reconstruction of the state
-    for (TimeIndex i=xh.getFirstIndex();i<xh.getNextIndex();++i)
-    {
-       f << i<<" "<< xh[i].transpose()
-          << std::endl;
+  /// the reconstruction of the state
+  for(TimeIndex i = xh.getFirstIndex(); i < xh.getNextIndex(); ++i)
+  {
+    f << i << " " << xh[i].transpose() << std::endl;
 
-       Vector v2 (Matrix::Zero(6,1));
+    Vector v2(Matrix::Zero(6, 1));
 
-       v2.head(3) = Vector(xh[i]).segment(indexes::pos,3);
-       v2.tail(3) = Vector(xh[i]).segment(indexes::ori,3);
+    v2.head(3) = Vector(xh[i]).segment(indexes::pos, 3);
+    v2.tail(3) = Vector(xh[i]).segment(indexes::ori, 3);
 
-       Matrix4 m= kine::vector6ToHomogeneousMatrix(v2);
-       Vector4 v;
-       v.head(3)=contact;
-       v[3]=1;
+    Matrix4 m = kine::vector6ToHomogeneousMatrix(v2);
+    Vector4 v;
+    v.head(3) = contact;
+    v[3] = 1;
 
-       std::cout << m - kine::invertHomoMatrix(
-                            kine::invertHomoMatrix(m))
-                                        << std::endl << std::endl;
+    std::cout << m - kine::invertHomoMatrix(kine::invertHomoMatrix(m)) << std::endl << std::endl;
+  }
 
-    }
-
-    return 0;
+  return 0;
 }
-
-
 
 int test()
 {
-    /// The number of samples
-    const Index kmax=3000;
+  /// The number of samples
+  const Index kmax = 3000;
 
-    ///sampling period
-    const double dt=1e-3;
+  /// sampling period
+  const double dt = 1e-3;
 
-    ///Sizes of the states for the state, the measurement, and the input vector
-    const unsigned stateSize=18;
-    const unsigned measurementSize=6;
-    //const unsigned inputSize=15;
+  /// Sizes of the states for the state, the measurement, and the input vector
+  const unsigned stateSize = 18;
+  const unsigned measurementSize = 6;
+  // const unsigned inputSize=15;
 
-    ///The array containing all the states, the measurements and the inputs
-    IndexedVectorArray x;
-    IndexedVectorArray y;
-    IndexedVectorArray u;
+  /// The array containing all the states, the measurements and the inputs
+  IndexedVectorArray x;
+  IndexedVectorArray y;
+  IndexedVectorArray u;
 
-    ///The covariance matrix of the process noise and the measurement noise
-    Matrix q;
-    Matrix r;
+  /// The covariance matrix of the process noise and the measurement noise
+  Matrix q;
+  Matrix r;
 
-    Vector3 contact(Vector3::Random());
+  Vector3 contact(Vector3::Random());
 
+  {
+    /// simulation of the signal
+    /// the IMU dynamical system functor
+    flexibilityEstimation::IMUFixedContactDynamicalSystem imu(dt);
 
+    /// The process noise initialization
+    Matrix q1 = Matrix::Zero(stateSize, stateSize);
+    q1(indexes::angAcc, indexes::angAcc) = q1(indexes::angAcc + 1, indexes::angAcc + 1) =
+        q1(indexes::angAcc + 2, indexes::angAcc + 2) = 0.000001;
+    q1(indexes::angVel, indexes::angVel) = q1(indexes::angVel + 1, indexes::angVel + 1) =
+        q1(indexes::angVel + 2, indexes::angVel + 2) = 0.0001;
+    q1(indexes::ori, indexes::ori) = q1(indexes::ori + 1, indexes::ori + 1) = q1(indexes::ori + 2, indexes::ori + 2) =
+        0.001;
+
+    GaussianWhiteNoise processNoise(imu.getStateSize());
+    processNoise.setStandardDeviation(q1);
+    imu.setProcessNoise(&processNoise);
+
+    /// The measurement noise initialization
+    Matrix r1 = Matrix::Identity(measurementSize, measurementSize) * 0.0001;
+    GaussianWhiteNoise MeasurementNoise(imu.getMeasurementSize());
+    MeasurementNoise.setStandardDeviation(r1);
+    imu.setMeasurementNoise(&MeasurementNoise);
+
+    /// the simulator initalization
+    DynamicalSystemSimulator sim;
+    sim.setDynamicsFunctor(&imu);
+
+    /// initialization of the state vector
+    Vector x0 = Vector::Zero(stateSize, 1);
+
+    x0[indexes::angAcc] = x0[indexes::angAcc + 1] = x0[indexes::angAcc + 2] = 0.00001;
+
+    x0[indexes::angVel] = x0[indexes::angVel + 1] = x0[indexes::angVel + 2] = 0.0001;
+
+    x0[indexes::ori] = x0[indexes::ori + 1] = x0[indexes::ori + 2] = 0.3;
+
+    // x0=x0*100;
+
+    sim.setState(x0, 0);
+
+    Vector uk = Vector::Zero(imu.getInputSize(), 1);
+
+    int i;
+    /// construction of the input
+    /// the input is constant over 10 time samples
+    for(i = 0; i < kmax / 10.0; ++i)
     {
-        ///simulation of the signal
-        /// the IMU dynamical system functor
-         flexibilityEstimation::IMUFixedContactDynamicalSystem imu(dt);
+      uk[indexes::pos] = 0.4 * sin(M_PI / 10 * i);
+      uk[indexes::pos + 1] = 0.6 * sin(M_PI / 12 * i);
+      uk[indexes::pos + 2] = 0.2 * sin(M_PI / 5 * i);
 
-        ///The process noise initialization
-        Matrix q1=Matrix::Zero(stateSize,stateSize);
-        q1(indexes::angAcc,indexes::angAcc)
-                    = q1(indexes::angAcc+1,indexes::angAcc+1)
-                    = q1(indexes::angAcc+2,indexes::angAcc+2) = 0.000001;
-        q1(indexes::angVel,indexes::angVel)
-                    = q1(indexes::angVel+1,indexes::angVel+1)
-                    = q1(indexes::angVel+2,indexes::angVel+2) = 0.0001;
-        q1(indexes::ori,indexes::ori)
-                    = q1(indexes::ori+1,indexes::ori+1)
-                    = q1(indexes::ori+2,indexes::ori+2) = 0.001;
+      uk[indexes::linVel] = 0.1 * sin(M_PI / 12 * i);
+      uk[indexes::linVel + 1] = 0.07 * sin(M_PI / 15 * i);
+      uk[indexes::linVel + 2] = 0.05 * sin(M_PI / 5 * i);
 
-        GaussianWhiteNoise processNoise(imu.getStateSize());
-        processNoise.setStandardDeviation(q1);
-        imu.setProcessNoise( & processNoise );
+      uk[indexes::linAcc] = 1 * sin(M_PI / 12 * i);
+      uk[indexes::linAcc + 1] = 0.07 * sin(M_PI / 15 * i);
+      uk[indexes::linAcc + 2] = 0.05 * sin(M_PI / 10 * i);
 
-        ///The measurement noise initialization
-        Matrix r1=Matrix::Identity(measurementSize,measurementSize)*0.0001;
-        GaussianWhiteNoise MeasurementNoise(imu.getMeasurementSize());
-        MeasurementNoise.setStandardDeviation(r1);
-        imu.setMeasurementNoise( & MeasurementNoise );
+      uk[indexes::ori] = 2 * sin(M_PI / 12 * i);
+      uk[indexes::ori + 1] = 1.5 * sin(M_PI / 18 * i);
+      uk[indexes::ori + 2] = 0.8 * sin(M_PI / 6 * i);
 
-        ///the simulator initalization
-        DynamicalSystemSimulator sim;
-        sim.setDynamicsFunctor( & imu);
+      uk[indexes::angVel] = 0.2 * sin(M_PI / 12 * i);
+      uk[indexes::angVel + 1] = 0.07 * sin(M_PI / 12 * i);
+      uk[indexes::angVel + 2] = 0.05 * sin(M_PI / 5 * i);
 
-        ///initialization of the state vector
-        Vector x0=Vector::Zero(stateSize,1);
+      /// filling the 10 time samples of the constant input
+      for(int j = 0; j < 10; ++j)
+      {
+        u.setValue(uk, i * 10 + j);
+      }
 
-        x0[indexes::angAcc]=x0[indexes::angAcc+1]=x0[indexes::angAcc+2]=0.00001;
-
-        x0[indexes::angVel]=x0[indexes::angVel+1]=x0[indexes::angVel+2]=0.0001;
-
-        x0[indexes::ori]=x0[indexes::ori+1]=x0[indexes::ori+2]=0.3;
-
-        //x0=x0*100;
-
-        sim.setState(x0,0);
-
-        Vector uk=Vector::Zero(imu.getInputSize(),1);
-
-        int i;
-        /// construction of the input
-        /// the input is constant over 10 time samples
-        for (i=0;i<kmax/10.0;++i)
-        {
-            uk[indexes::pos     ]=0.4 * sin(M_PI/10*i);
-            uk[indexes::pos+1   ]=0.6 * sin(M_PI/12*i);
-            uk[indexes::pos+2   ]=0.2 * sin(M_PI/5*i);
-
-            uk[indexes::linVel  ]=0.1  * sin(M_PI/12*i);
-            uk[indexes::linVel+1]=0.07  * sin(M_PI/15*i);
-            uk[indexes::linVel+2]=0.05 * sin(M_PI/5*i);
-
-            uk[indexes::linAcc  ]=1  * sin(M_PI/12*i);
-            uk[indexes::linAcc+1]=0.07  * sin(M_PI/15*i);
-            uk[indexes::linAcc+2]=0.05 * sin(M_PI/10*i);
-
-            uk[indexes::ori     ]=2  * sin(M_PI/12*i);
-            uk[indexes::ori+1   ]=1.5  * sin(M_PI/18*i);
-            uk[indexes::ori+2   ]=0.8 * sin(M_PI/6*i);
-
-            uk[indexes::angVel  ]=0.2  * sin(M_PI/12*i);
-            uk[indexes::angVel+1]=0.07  * sin(M_PI/12*i);
-            uk[indexes::angVel+2]=0.05 * sin(M_PI/5*i);
-
-            ///filling the 10 time samples of the constant input
-            for (int j=0;j<10;++j)
-            {
-                u.setValue(uk,i*10+j);
-            }
-
-            ///give the input to the simulator
-            ///we only need to give one value and the
-            ///simulator takes automatically the appropriate value
-            sim.setInput(uk,10*i);
-        }
-
-        ///Last sample needed
-        u.setValue(uk,i*10);
-
-        ///set the sampling perdiod to the functor
-        imu.setSamplingPeriod(dt);
-
-        ///launched the simulation to the time kmax+1
-        for (Index i=0; i<kmax+1; ++i)
-        {
-            Vector x=sim.getState(i);
-
-            Vector3 orientationFlexV=x.segment(indexes::ori,3);
-            Vector3 angularVelocityFlex=x.segment(indexes::angVel,3);
-            Vector3 angularAccelerationFlex=x.segment(indexes::angAcc,3);
-
-            Matrix3 orientationFlexR =
-                kine::rotationVectorToAngleAxis(orientationFlexV).matrix();
-
-            Vector3 positionFlex;
-            Vector3 velocityFlex;
-            Vector3 accelerationFlex;
-
-            kine::fixedPointRotationToTranslation
-                (orientationFlexR, angularVelocityFlex, angularAccelerationFlex,
-                contact, positionFlex, velocityFlex, accelerationFlex);
-
-            x.segment(indexes::pos,3) = positionFlex;
-            x.segment(indexes::linVel,3) = velocityFlex;
-            x.segment(indexes::linAcc,3) = accelerationFlex;
-
-            sim.setState(x,i);
-
-            sim.simulateDynamics();
-        }
-
-
-        ///extract the array of measurements and states
-        y = sim.getMeasurementArray(1,kmax);
-        x = sim.getStateArray(1,kmax);
+      /// give the input to the simulator
+      /// we only need to give one value and the
+      /// simulator takes automatically the appropriate value
+      sim.setInput(uk, 10 * i);
     }
 
-    ///the initalization of a random estimation of the initial state
-    Vector xh0=Vector::Zero(stateSize,1);
+    /// Last sample needed
+    u.setValue(uk, i * 10);
 
-    std::vector<Vector3, Eigen::aligned_allocator<Vector3> > contactPositions;
+    /// set the sampling perdiod to the functor
+    imu.setSamplingPeriod(dt);
 
-    contactPositions.push_back(contact);
-
-
-    stateObservation::IndexedVectorArray xh=
-        stateObservation::examples::offlineEKFFlexibilityEstimation
-        (y,u,xh0,1,contactPositions,dt);
-
-    ///file of output
-    std::ofstream f;
-    f.open("trajectory.dat");
-
-    double error=0;
-
-    ///the reconstruction of the state
-    for (TimeIndex i=y.getFirstIndex();i<y.getNextIndex();++i)
+    /// launched the simulation to the time kmax+1
+    for(Index i = 0; i < kmax + 1; ++i)
     {
-        ///display part, useless
-        Vector3 g;
-        {
-            Matrix3 R;
-            Vector3 orientationV=Vector(x[i]).segment(indexes::ori,3);
-            double angle=orientationV.norm();
-            if (angle > cst::epsilonAngle)
-                R = AngleAxis(angle, orientationV/angle).toRotationMatrix();
-            else
-                R = Matrix3::Identity();
-            g=R.transpose()*Vector3::UnitZ();
-            g.normalize();
-        }
+      Vector x = sim.getState(i);
 
-        Vector3 gh;
-        {
-            Matrix3 Rh;
+      Vector3 orientationFlexV = x.segment(indexes::ori, 3);
+      Vector3 angularVelocityFlex = x.segment(indexes::angVel, 3);
+      Vector3 angularAccelerationFlex = x.segment(indexes::angAcc, 3);
 
-            Vector3 orientationV=Vector(xh[i]).segment(indexes::ori,3);
-            double angle=orientationV.norm();
-            if (angle > cst::epsilonAngle)
-                Rh = AngleAxis(angle, orientationV/angle).toRotationMatrix();
-            else
-                Rh = Matrix3::Identity();
-            gh=Rh.transpose()*Vector3::UnitZ();
-            gh.normalize();
-        }
+      Matrix3 orientationFlexR = kine::rotationVectorToAngleAxis(orientationFlexV).matrix();
 
-        error = acos(double(g.transpose()*gh)) * 180 / M_PI;
+      Vector3 positionFlex;
+      Vector3 velocityFlex;
+      Vector3 accelerationFlex;
 
+      kine::fixedPointRotationToTranslation(orientationFlexR, angularVelocityFlex, angularAccelerationFlex, contact,
+                                            positionFlex, velocityFlex, accelerationFlex);
 
-        f << i<< " \t "<< error << " \t\t\t "
-          << g.transpose() << " \t\t\t " << gh.transpose() << " \t\t\t "
-          << x[i].transpose()<< " \t\t\t%%%%%%\t\t\t " << xh[i].transpose()
-          << std::endl;
+      x.segment(indexes::pos, 3) = positionFlex;
+      x.segment(indexes::linVel, 3) = velocityFlex;
+      x.segment(indexes::linAcc, 3) = accelerationFlex;
 
+      sim.setState(x, i);
+
+      sim.simulateDynamics();
     }
 
-    std::cout << "Error " << error << ", test: " ;
+    /// extract the array of measurements and states
+    y = sim.getMeasurementArray(1, kmax);
+    x = sim.getStateArray(1, kmax);
+  }
 
-    if (error > 2)
+  /// the initalization of a random estimation of the initial state
+  Vector xh0 = Vector::Zero(stateSize, 1);
+
+  std::vector<Vector3, Eigen::aligned_allocator<Vector3>> contactPositions;
+
+  contactPositions.push_back(contact);
+
+  stateObservation::IndexedVectorArray xh =
+      stateObservation::examples::offlineEKFFlexibilityEstimation(y, u, xh0, 1, contactPositions, dt);
+
+  /// file of output
+  std::ofstream f;
+  f.open("trajectory.dat");
+
+  double error = 0;
+
+  /// the reconstruction of the state
+  for(TimeIndex i = y.getFirstIndex(); i < y.getNextIndex(); ++i)
+  {
+    /// display part, useless
+    Vector3 g;
     {
-        std::cout << "FAILED !!!!!!!";
-        return 1;
+      Matrix3 R;
+      Vector3 orientationV = Vector(x[i]).segment(indexes::ori, 3);
+      double angle = orientationV.norm();
+      if(angle > cst::epsilonAngle)
+        R = AngleAxis(angle, orientationV / angle).toRotationMatrix();
+      else
+        R = Matrix3::Identity();
+      g = R.transpose() * Vector3::UnitZ();
+      g.normalize();
     }
-    else
+
+    Vector3 gh;
     {
-        std::cout << "SUCCEEDED !!!!!!!";
-        return 0;
+      Matrix3 Rh;
+
+      Vector3 orientationV = Vector(xh[i]).segment(indexes::ori, 3);
+      double angle = orientationV.norm();
+      if(angle > cst::epsilonAngle)
+        Rh = AngleAxis(angle, orientationV / angle).toRotationMatrix();
+      else
+        Rh = Matrix3::Identity();
+      gh = Rh.transpose() * Vector3::UnitZ();
+      gh.normalize();
     }
+
+    error = acos(double(g.transpose() * gh)) * 180 / M_PI;
+
+    f << i << " \t " << error << " \t\t\t " << g.transpose() << " \t\t\t " << gh.transpose() << " \t\t\t "
+      << x[i].transpose() << " \t\t\t%%%%%%\t\t\t " << xh[i].transpose() << std::endl;
+  }
+
+  std::cout << "Error " << error << ", test: ";
+
+  if(error > 2)
+  {
+    std::cout << "FAILED !!!!!!!";
+    return 1;
+  }
+  else
+  {
+    std::cout << "SUCCEEDED !!!!!!!";
+    return 0;
+  }
 }
 
 int main()
 {
 
-
-    return test();
-
+  return test();
 }

--- a/unit-testings/imu-multiplicative-test.cpp
+++ b/unit-testings/imu-multiplicative-test.cpp
@@ -1,9 +1,9 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
-#include <state-observation/noise/gaussian-white-noise.hpp>
 #include <state-observation/examples/imu-attitude-trajectory-reconstruction.hpp>
 #include <state-observation/examples/imu-multiplicative-attitude-reconstruction.hpp>
+#include <state-observation/noise/gaussian-white-noise.hpp>
 
 using namespace stateObservation;
 
@@ -12,185 +12,170 @@ typedef kine::indexes<kine::quaternion> indexes2;
 
 int test()
 {
-    /// The number of samples
-    const Index kmax=10000;
+  /// The number of samples
+  const Index kmax = 10000;
 
-    ///sampling period
-    const double dt=1e-3;
+  /// sampling period
+  const double dt = 1e-3;
 
+  /// The array containing all the states, the measurements and the inputs
+  IndexedVectorArray x;
+  IndexedVectorArray y;
+  IndexedVectorArray u;
 
+  const unsigned measurementSize = 6;
 
-    ///The array containing all the states, the measurements and the inputs
-    IndexedVectorArray x;
-    IndexedVectorArray y;
-    IndexedVectorArray u;
+  /// The covariance matrix of the process noise and the measurement noise
+  Matrix q;
+  Matrix r;
 
-    const unsigned measurementSize=6;
+  {
 
-    ///The covariance matrix of the process noise and the measurement noise
-    Matrix q;
-    Matrix r;
+    /// Sizes of the states for the state, the measurement, and the input vector
+    const unsigned stateSize = 18;
 
+    // const unsigned inputSize=6;
+    /// simulation of the signal
+    /// the IMU dynamical system functor
+    IMUDynamicalSystem imu;
+
+    /// The process noise initialization
+    Matrix q1 = Matrix::Identity(stateSize, stateSize) * 0.001;
+    GaussianWhiteNoise processNoise(imu.getStateSize());
+    processNoise.setStandardDeviation(q1);
+    imu.setProcessNoise(&processNoise);
+    q = q1 * q1.transpose();
+
+    /// The measurement noise initialization
+    Matrix r1 = Matrix::Identity(measurementSize, measurementSize) * 0.01;
+    GaussianWhiteNoise MeasurementNoise(imu.getMeasurementSize());
+    MeasurementNoise.setStandardDeviation(r1);
+    imu.setMeasurementNoise(&MeasurementNoise);
+    r = r1 * r1.transpose();
+
+    /// the simulator initalization
+    DynamicalSystemSimulator sim;
+    sim.setDynamicsFunctor(&imu);
+
+    /// initialization of the state vector
+    Vector x0 = Vector::Zero(stateSize, 1);
+    sim.setState(x0, 0);
+
+    /// construction of the input
+    /// the input is constant over 10 time samples
+    for(Index i = 0; i < kmax / 10; ++i)
     {
+      Vector uk = Vector::Zero(imu.getInputSize(), 1);
 
-        ///Sizes of the states for the state, the measurement, and the input vector
-        const unsigned stateSize=18;
+      double id = double(i);
 
-        //const unsigned inputSize=6;
-        ///simulation of the signal
-        /// the IMU dynamical system functor
-        IMUDynamicalSystem imu;
+      uk[0] = 0.4 * sin(M_PI / 10 * id);
+      uk[1] = 0.6 * sin(M_PI / 12 * id);
+      uk[2] = 0.2 * sin(M_PI / 5 * id);
 
-        ///The process noise initialization
-        Matrix q1=Matrix::Identity(stateSize,stateSize)*0.001;
-        GaussianWhiteNoise processNoise(imu.getStateSize());
-        processNoise.setStandardDeviation(q1);
-        imu.setProcessNoise( & processNoise );
-        q=q1*q1.transpose();
+      uk[3] = 10 * sin(M_PI / 12 * id);
+      uk[4] = 0.07 * sin(M_PI / 15 * id);
+      uk[5] = 0.05 * sin(M_PI / 5 * id);
 
-        ///The measurement noise initialization
-        Matrix r1=Matrix::Identity(measurementSize,measurementSize)*0.01;
-        GaussianWhiteNoise MeasurementNoise(imu.getMeasurementSize());
-        MeasurementNoise.setStandardDeviation(r1);
-        imu.setMeasurementNoise( & MeasurementNoise );
-        r=r1*r1.transpose();
+      /// filling the 10 time samples of the constant input
+      for(int j = 0; j < 10; ++j)
+      {
+        u.setValue(uk, i * 10 + j);
+      }
 
-        ///the simulator initalization
-        DynamicalSystemSimulator sim;
-        sim.setDynamicsFunctor(&imu);
-
-        ///initialization of the state vector
-        Vector x0=Vector::Zero(stateSize,1);
-        sim.setState(x0,0);
-
-        ///construction of the input
-        /// the input is constant over 10 time samples
-        for (Index i=0;i<kmax/10;++i)
-        {
-            Vector uk=Vector::Zero(imu.getInputSize(),1);
-
-            double id = double(i);
-
-            uk[0]=0.4 * sin(M_PI/10*id);
-            uk[1]=0.6 * sin(M_PI/12*id);
-            uk[2]=0.2 * sin(M_PI/5*id);
-
-            uk[3]=10  * sin(M_PI/12*id);
-            uk[4]=0.07  * sin(M_PI/15*id);
-            uk[5]=0.05 * sin(M_PI/5*id);
-
-            ///filling the 10 time samples of the constant input
-            for (int j=0;j<10;++j)
-            {
-                u.setValue(uk,i*10+j);
-            }
-
-            ///give the input to the simulator
-            ///we only need to give one value and the
-            ///simulator takes automatically the appropriate value
-            sim.setInput(uk,10*i);
-
-        }
-
-        ///set the sampling perdiod to the functor
-        imu.setSamplingPeriod(dt);
-
-        ///launched the simulation to the time kmax+1
-        sim.simulateDynamicsTo(kmax+1);
-
-        ///extract the array of measurements and states
-        y = sim.getMeasurementArray(1,kmax);
-        x = sim.getStateArray(1,kmax);
+      /// give the input to the simulator
+      /// we only need to give one value and the
+      /// simulator takes automatically the appropriate value
+      sim.setInput(uk, 10 * i);
     }
 
-    const unsigned stateSize=19;
-    const unsigned stateTangentSize=18;
+    /// set the sampling perdiod to the functor
+    imu.setSamplingPeriod(dt);
 
-    Matrix q1=Matrix::Identity(stateTangentSize,stateTangentSize)*0.001;
-    q=q1*q1.transpose();
+    /// launched the simulation to the time kmax+1
+    sim.simulateDynamicsTo(kmax + 1);
 
+    /// extract the array of measurements and states
+    y = sim.getMeasurementArray(1, kmax);
+    x = sim.getStateArray(1, kmax);
+  }
 
-    ///the initalization of a random estimation of the initial state
-    Vector xh0=Vector::Random(stateSize,1)*3.14;
-    xh0.segment<4>(indexes2::ori).normalize();
-//    xh0.segment<4>(indexes2::ori)=Quaternion::Identity().coeffs();
+  const unsigned stateSize = 19;
+  const unsigned stateTangentSize = 18;
 
+  Matrix q1 = Matrix::Identity(stateTangentSize, stateTangentSize) * 0.001;
+  q = q1 * q1.transpose();
 
-    ///computation and initialization of the covariance matrix of the initial state
-    Matrix p=Matrix::Identity(stateTangentSize,stateTangentSize);
+  /// the initalization of a random estimation of the initial state
+  Vector xh0 = Vector::Random(stateSize, 1) * 3.14;
+  xh0.segment<4>(indexes2::ori).normalize();
+  //    xh0.segment<4>(indexes2::ori)=Quaternion::Identity().coeffs();
 
+  /// computation and initialization of the covariance matrix of the initial state
+  Matrix p = Matrix::Identity(stateTangentSize, stateTangentSize);
 
-    tools::SimplestStopwatch timer;
-    timer.start();
-    IndexedVectorArray xh = examples::imuMultiplicativeAttitudeReconstruction
-                                                    (y, u, xh0, p, q, r, dt);
+  tools::SimplestStopwatch timer;
+  timer.start();
+  IndexedVectorArray xh = examples::imuMultiplicativeAttitudeReconstruction(y, u, xh0, p, q, r, dt);
 
-    double duration = timer.stop();
+  double duration = timer.stop();
 
-    ///file of output
-    std::ofstream f;
-    f.open("trajectory.dat");
+  /// file of output
+  std::ofstream f;
+  f.open("trajectory.dat");
 
+  double dx;
 
-    double dx;
-
-
-
-
-    ///the reconstruction of the state
-    for (TimeIndex i=y.getFirstIndex();i<y.getNextIndex();++i)
+  /// the reconstruction of the state
+  for(TimeIndex i = y.getFirstIndex(); i < y.getNextIndex(); ++i)
+  {
+    /// display part, useless
+    Vector3 g;
     {
-        ///display part, useless
-        Vector3 g;
-        {
-            Matrix3 R;
-            Vector3 orientationV=Vector(x[i]).segment(indexes1::ori,3);
-            double angle=orientationV.norm();
-            if (angle > cst::epsilonAngle)
-                R = AngleAxis(angle, orientationV/angle).toRotationMatrix();
-            else
-                R = Matrix3::Identity();
-            g=R.transpose()*Vector3::UnitZ();
-            g.normalize();
-        }
-
-        Vector3 gh;
-        {
-            Matrix3 Rh;
-            Quaternion orientation(Vector(xh[i]).segment<4>(indexes2::ori));
-            Rh = orientation.toRotationMatrix();
-            gh=Rh.transpose()*Vector3::UnitZ();
-            gh.normalize();
-        }
-
-        dx= acos(double(g.transpose()*gh));
-
-
-        f << i<< " \t "<<  dx * 180 / M_PI << " \t\t\t "
-        << g.transpose() << " \t\t\t " << gh.transpose() << std::endl;
+      Matrix3 R;
+      Vector3 orientationV = Vector(x[i]).segment(indexes1::ori, 3);
+      double angle = orientationV.norm();
+      if(angle > cst::epsilonAngle)
+        R = AngleAxis(angle, orientationV / angle).toRotationMatrix();
+      else
+        R = Matrix3::Identity();
+      g = R.transpose() * Vector3::UnitZ();
+      g.normalize();
     }
 
-
-    std::cout << "computation time: " << duration/kmax << ". ";
-    std::cout << "Verticality estimation error (degrees): " << dx* 180 / M_PI;
-
-    if (dx* 180 / M_PI < 1)
+    Vector3 gh;
     {
-        std::cout<<" Test succeeded " <<std::endl;
-        return 0;
+      Matrix3 Rh;
+      Quaternion orientation(Vector(xh[i]).segment<4>(indexes2::ori));
+      Rh = orientation.toRotationMatrix();
+      gh = Rh.transpose() * Vector3::UnitZ();
+      gh.normalize();
     }
-    else
-    {
-        std::cout<<" Test failed " <<std::endl;
-        return 1;
-    }
-    std::cout << "computation time: " << duration << std::endl;
 
+    dx = acos(double(g.transpose() * gh));
+
+    f << i << " \t " << dx * 180 / M_PI << " \t\t\t " << g.transpose() << " \t\t\t " << gh.transpose() << std::endl;
+  }
+
+  std::cout << "computation time: " << duration / kmax << ". ";
+  std::cout << "Verticality estimation error (degrees): " << dx * 180 / M_PI;
+
+  if(dx * 180 / M_PI < 1)
+  {
+    std::cout << " Test succeeded " << std::endl;
     return 0;
+  }
+  else
+  {
+    std::cout << " Test failed " << std::endl;
+    return 1;
+  }
+  std::cout << "computation time: " << duration << std::endl;
+
+  return 0;
 }
 
 int main()
 {
-    return test();
-
+  return test();
 }

--- a/unit-testings/imu-test.cpp
+++ b/unit-testings/imu-test.cpp
@@ -1,8 +1,8 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
-#include <state-observation/noise/gaussian-white-noise.hpp>
 #include <state-observation/examples/imu-attitude-trajectory-reconstruction.hpp>
+#include <state-observation/noise/gaussian-white-noise.hpp>
 
 using namespace stateObservation;
 
@@ -10,184 +10,169 @@ typedef kine::indexes<kine::rotationVector> indexes;
 
 int test()
 {
-    /// The number of samples
-    const Index kmax=10000;
+  /// The number of samples
+  const Index kmax = 10000;
 
-    ///sampling period
-    const double dt=1e-3;
+  /// sampling period
+  const double dt = 1e-3;
 
-    ///Sizes of the states for the state, the measurement, and the input vector
-    const unsigned stateSize=18;
-    const unsigned measurementSize=6;
-    //const unsigned inputSize=6;
+  /// Sizes of the states for the state, the measurement, and the input vector
+  const unsigned stateSize = 18;
+  const unsigned measurementSize = 6;
+  // const unsigned inputSize=6;
 
-    ///The array containing all the states, the measurements and the inputs
-    IndexedVectorArray x;
-    IndexedVectorArray y;
-    IndexedVectorArray u;
+  /// The array containing all the states, the measurements and the inputs
+  IndexedVectorArray x;
+  IndexedVectorArray y;
+  IndexedVectorArray u;
 
-    ///The covariance matrix of the process noise and the measurement noise
-    Matrix q;
-    Matrix r;
+  /// The covariance matrix of the process noise and the measurement noise
+  Matrix q;
+  Matrix r;
 
+  {
+    /// simulation of the signal
+    /// the IMU dynamical system functor
+    IMUDynamicalSystem imu;
+
+    /// The process noise initialization
+    Matrix q1 = Matrix::Identity(stateSize, stateSize) * 0.001;
+    GaussianWhiteNoise processNoise(imu.getStateSize());
+    processNoise.setStandardDeviation(q1);
+    imu.setProcessNoise(&processNoise);
+    q = q1 * q1.transpose();
+
+    /// The measurement noise initialization
+    Matrix r1 = Matrix::Identity(measurementSize, measurementSize) * 0.01;
+    GaussianWhiteNoise MeasurementNoise(imu.getMeasurementSize());
+    MeasurementNoise.setStandardDeviation(r1);
+    imu.setMeasurementNoise(&MeasurementNoise);
+    r = r1 * r1.transpose();
+
+    /// the simulator initalization
+    DynamicalSystemSimulator sim;
+    sim.setDynamicsFunctor(&imu);
+
+    /// initialization of the state vector
+    Vector x0 = Vector::Zero(stateSize, 1);
+    sim.setState(x0, 0);
+
+    /// construction of the input
+    /// the input is constant over 10 time samples
+    for(Index i = 0; i < kmax / 10; ++i)
     {
-        ///simulation of the signal
-        /// the IMU dynamical system functor
-        IMUDynamicalSystem imu;
+      Vector uk = Vector::Zero(imu.getInputSize(), 1);
+      double id = double(i);
 
-        ///The process noise initialization
-        Matrix q1=Matrix::Identity(stateSize,stateSize)*0.001;
-        GaussianWhiteNoise processNoise(imu.getStateSize());
-        processNoise.setStandardDeviation(q1);
-        imu.setProcessNoise( & processNoise );
-        q=q1*q1.transpose();
+      uk[0] = 0.4 * sin(M_PI / 10 * id);
+      uk[1] = 0.6 * sin(M_PI / 12 * id);
+      uk[2] = 0.2 * sin(M_PI / 5 * id);
 
-        ///The measurement noise initialization
-        Matrix r1=Matrix::Identity(measurementSize,measurementSize)*0.01;
-        GaussianWhiteNoise MeasurementNoise(imu.getMeasurementSize());
-        MeasurementNoise.setStandardDeviation(r1);
-        imu.setMeasurementNoise( & MeasurementNoise );
-        r=r1*r1.transpose();
+      uk[3] = 10 * sin(M_PI / 12 * id);
+      uk[4] = 0.07 * sin(M_PI / 15 * id);
+      uk[5] = 0.05 * sin(M_PI / 5 * id);
 
-        ///the simulator initalization
-        DynamicalSystemSimulator sim;
-        sim.setDynamicsFunctor(&imu);
+      /// filling the 10 time samples of the constant input
+      for(int j = 0; j < 10; ++j)
+      {
+        u.setValue(uk, i * 10 + j);
+      }
 
-        ///initialization of the state vector
-        Vector x0=Vector::Zero(stateSize,1);
-        sim.setState(x0,0);
-
-        ///construction of the input
-        /// the input is constant over 10 time samples
-        for (Index i=0;i<kmax/10;++i)
-        {
-            Vector uk=Vector::Zero(imu.getInputSize(),1);
-            double id = double(i);
-
-            uk[0]=0.4 * sin(M_PI/10*id);
-            uk[1]=0.6 * sin(M_PI/12*id);
-            uk[2]=0.2 * sin(M_PI/5*id);
-
-            uk[3]=10  * sin(M_PI/12*id);
-            uk[4]=0.07  * sin(M_PI/15*id);
-            uk[5]=0.05 * sin(M_PI/5*id);
-
-            ///filling the 10 time samples of the constant input
-            for (int j=0;j<10;++j)
-            {
-                u.setValue(uk,i*10+j);
-            }
-
-            ///give the input to the simulator
-            ///we only need to give one value and the
-            ///simulator takes automatically the appropriate value
-            sim.setInput(uk,10*i);
-
-        }
-
-        ///set the sampling perdiod to the functor
-        imu.setSamplingPeriod(dt);
-
-        ///launched the simulation to the time kmax+1
-        sim.simulateDynamicsTo(kmax+1);
-
-        ///extract the array of measurements and states
-        y = sim.getMeasurementArray(1,kmax);
-        x = sim.getStateArray(1,kmax);
+      /// give the input to the simulator
+      /// we only need to give one value and the
+      /// simulator takes automatically the appropriate value
+      sim.setInput(uk, 10 * i);
     }
 
-    ///initialization of the extended Kalman filter
-    ExtendedKalmanFilter filter(stateSize, measurementSize, measurementSize, false);
+    /// set the sampling perdiod to the functor
+    imu.setSamplingPeriod(dt);
 
-    ///the initalization of a random estimation of the initial state
-    Vector xh0=Vector::Random(stateSize,1)*3.14;
-    xh0[indexes::ori]=3.14;
+    /// launched the simulation to the time kmax+1
+    sim.simulateDynamicsTo(kmax + 1);
 
+    /// extract the array of measurements and states
+    y = sim.getMeasurementArray(1, kmax);
+    x = sim.getStateArray(1, kmax);
+  }
 
-    ///computation and initialization of the covariance matrix of the initial state
-    Matrix p=Matrix::Zero(stateSize,stateSize);
-    for (Index i=0;i<filter.getStateSize();++i)
+  /// initialization of the extended Kalman filter
+  ExtendedKalmanFilter filter(stateSize, measurementSize, measurementSize, false);
+
+  /// the initalization of a random estimation of the initial state
+  Vector xh0 = Vector::Random(stateSize, 1) * 3.14;
+  xh0[indexes::ori] = 3.14;
+
+  /// computation and initialization of the covariance matrix of the initial state
+  Matrix p = Matrix::Zero(stateSize, stateSize);
+  for(Index i = 0; i < filter.getStateSize(); ++i)
+  {
+    p(i, i) = xh0[i];
+  }
+  p = p * p.transpose();
+
+  tools::SimplestStopwatch timer;
+  timer.start();
+
+  IndexedVectorArray xh = examples::imuAttitudeTrajectoryReconstruction(y, u, xh0, p, q, r, dt);
+
+  double duration = timer.stop();
+
+  /// file of output
+  std::ofstream f;
+  f.open("trajectory.dat");
+
+  double dx;
+
+  for(TimeIndex i = y.getFirstIndex(); i < y.getNextIndex(); ++i)
+  {
+    /// display part, useless
+    Vector3 g;
     {
-        p(i,i)=xh0[i];
-    }
-    p=p*p.transpose();
-
-    tools::SimplestStopwatch timer;
-    timer.start();
-
-    IndexedVectorArray xh = examples::imuAttitudeTrajectoryReconstruction
-                                                    (y, u, xh0, p, q, r, dt);
-
-    double duration = timer.stop();
-
-
-
-    ///file of output
-    std::ofstream f;
-    f.open("trajectory.dat");
-
-    double dx;
-
-
-
-    for (TimeIndex i=y.getFirstIndex();i<y.getNextIndex();++i)
-    {
-        ///display part, useless
-        Vector3 g;
-        {
-            Matrix3 R;
-            Vector3 orientationV=Vector(x[i]).segment(indexes::ori,3);
-            double angle=orientationV.norm();
-            if (angle > cst::epsilonAngle)
-                R = AngleAxis(angle, orientationV/angle).toRotationMatrix();
-            else
-                R = Matrix3::Identity();
-            g=R.transpose()*Vector3::UnitZ();
-            g.normalize();
-        }
-
-        Vector3 gh;
-        {
-            Matrix3 Rh;
-            Vector3 orientationV=Vector(xh[i]).segment(indexes::ori,3);
-            double angle=orientationV.norm();
-            if (angle > cst::epsilonAngle)
-                Rh = AngleAxis(angle, orientationV/angle).toRotationMatrix();
-            else
-                Rh = Matrix3::Identity();
-            gh=Rh.transpose()*Vector3::UnitZ();
-            gh.normalize();
-        }
-
-        dx= acos(double(g.transpose()*gh));
-
-
-        f << i<< " \t "<<  dx * 180 / M_PI << " \t\t\t "
-        << g.transpose() << " \t\t\t " << gh.transpose() << std::endl;
-
+      Matrix3 R;
+      Vector3 orientationV = Vector(x[i]).segment(indexes::ori, 3);
+      double angle = orientationV.norm();
+      if(angle > cst::epsilonAngle)
+        R = AngleAxis(angle, orientationV / angle).toRotationMatrix();
+      else
+        R = Matrix3::Identity();
+      g = R.transpose() * Vector3::UnitZ();
+      g.normalize();
     }
 
-
-    std::cout << "computation time: " << duration/kmax << ". ";
-    std::cout << "Verticality estimation error (degrees): " << dx* 180 / M_PI;
-
-
-    if (dx* 180 / M_PI < 1)
+    Vector3 gh;
     {
-        std::cout<<" Test succeeded"<< std::endl;
-        return 0;
-    }
-    else
-    {
-        std::cout<<" Test failed"<< std::endl;
-        return 1;
+      Matrix3 Rh;
+      Vector3 orientationV = Vector(xh[i]).segment(indexes::ori, 3);
+      double angle = orientationV.norm();
+      if(angle > cst::epsilonAngle)
+        Rh = AngleAxis(angle, orientationV / angle).toRotationMatrix();
+      else
+        Rh = Matrix3::Identity();
+      gh = Rh.transpose() * Vector3::UnitZ();
+      gh.normalize();
     }
 
+    dx = acos(double(g.transpose() * gh));
 
+    f << i << " \t " << dx * 180 / M_PI << " \t\t\t " << g.transpose() << " \t\t\t " << gh.transpose() << std::endl;
+  }
+
+  std::cout << "computation time: " << duration / kmax << ". ";
+  std::cout << "Verticality estimation error (degrees): " << dx * 180 / M_PI;
+
+  if(dx * 180 / M_PI < 1)
+  {
+    std::cout << " Test succeeded" << std::endl;
+    return 0;
+  }
+  else
+  {
+    std::cout << " Test failed" << std::endl;
+    return 1;
+  }
 }
 
 int main()
 {
-    return test();
-
+  return test();
 }

--- a/unit-testings/other-tests.cpp
+++ b/unit-testings/other-tests.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include <state-observation/tools/definitions.hpp>
 #include <state-observation/tools/rigid-body-kinematics.hpp>
@@ -10,150 +10,139 @@ const double dt = 5e-3;
 
 int homoMatrixDerivationTestFromFile(char * homo, char * vel, const std::string & prefix)
 {
-    IndexedMatrixArray velocities;
-    velocities.readFromFile(vel,6);
-    IndexedMatrixArray homoMatrices;
-    homoMatrices.readFromFile(homo,4,4);
+  IndexedMatrixArray velocities;
+  velocities.readFromFile(vel, 6);
+  IndexedMatrixArray homoMatrices;
+  homoMatrices.readFromFile(homo, 4, 4);
 
-    IndexedMatrixArray computedVelocities;
+  IndexedMatrixArray computedVelocities;
 
-    std::ofstream f,f1,f2;
-    f.open((prefix + "output.dat").c_str());
-    f1.open((prefix + "computed.dat").c_str());
-    f2.open((prefix + "real.dat").c_str());
+  std::ofstream f, f1, f2;
+  f.open((prefix + "output.dat").c_str());
+  f1.open((prefix + "computed.dat").c_str());
+  f2.open((prefix + "real.dat").c_str());
 
-    for (TimeIndex i=homoMatrices.getFirstIndex();i<homoMatrices.getLastIndex();++i)
+  for(TimeIndex i = homoMatrices.getFirstIndex(); i < homoMatrices.getLastIndex(); ++i)
+  {
+    computedVelocities.setValue(kine::derivateHomogeneousMatrixFD(homoMatrices[i], homoMatrices[i + 1], dt), i);
+
+    f << i << " \t ";
+    for(long j = 0; j < computedVelocities[i].rows(); ++j)
     {
-        computedVelocities.setValue(kine::derivateHomogeneousMatrixFD(
-                            homoMatrices[i],homoMatrices[i+1],dt),i);
-
-
-        f << i << " \t " ;
-        for (long j=0; j<computedVelocities[i].rows() ; ++j)
-        {
-            f << " " <<computedVelocities[i](j) - velocities[i](j);
-
-        }
-
-        f<<std::endl;
-
-        f1 << i << " \t "<< computedVelocities[i].transpose()<<std::endl;
-        f2 << i << " \t "<< velocities[i].transpose() << std::endl;
+      f << " " << computedVelocities[i](j) - velocities[i](j);
     }
 
-    return 0;
+    f << std::endl;
+
+    f1 << i << " \t " << computedVelocities[i].transpose() << std::endl;
+    f2 << i << " \t " << velocities[i].transpose() << std::endl;
+  }
+
+  return 0;
 }
 
-int invertMatrixTest()//tested OK
+int invertMatrixTest() // tested OK
 {
-    stateObservation::Quaternion q (stateObservation::Vector4::Random());
+  stateObservation::Quaternion q(stateObservation::Vector4::Random());
 
-    q.normalize();
+  q.normalize();
 
-    Matrix3 R1(q.matrix());
+  Matrix3 R1(q.matrix());
 
-    Matrix4 h(Matrix4::Identity());
+  Matrix4 h(Matrix4::Identity());
 
-    h.block(0,0,3,3) = R1;
-    h.block(0,3,3,1) =Vector3::Random();
+  h.block(0, 0, 3, 3) = R1;
+  h.block(0, 3, 3, 1) = Vector3::Random();
 
-    Matrix4 hi = kine::invertHomoMatrix(h);
+  Matrix4 hi = kine::invertHomoMatrix(h);
 
-    std::cout<<h<<std::endl<<std::endl;
-    std::cout<<hi<<std::endl<<std::endl;
-    std::cout<<h.inverse()<<std::endl<<std::endl;
-    std::cout<<hi*h<<std::endl<<std::endl;
-    return 0;
-
+  std::cout << h << std::endl << std::endl;
+  std::cout << hi << std::endl << std::endl;
+  std::cout << h.inverse() << std::endl << std::endl;
+  std::cout << hi * h << std::endl << std::endl;
+  return 0;
 }
 
-int transformationTest()//tested ok
+int transformationTest() // tested ok
 {
 
-    Vector6 v2= Vector6::Random();
-    Matrix4 m=kine::vector6ToHomogeneousMatrix(v2);
+  Vector6 v2 = Vector6::Random();
+  Matrix4 m = kine::vector6ToHomogeneousMatrix(v2);
 
-    std::cout<< v2.transpose() <<std::endl<<std::endl;
-    std::cout<< m <<std::endl<<std::endl;
-    std::cout<< kine::homogeneousMatrixToVector6(m) <<std::endl<<std::endl;
-    std::cout<< kine::vector6ToHomogeneousMatrix(
-                kine::homogeneousMatrixToVector6(m)) <<std::endl<<std::endl;
+  std::cout << v2.transpose() << std::endl << std::endl;
+  std::cout << m << std::endl << std::endl;
+  std::cout << kine::homogeneousMatrixToVector6(m) << std::endl << std::endl;
+  std::cout << kine::vector6ToHomogeneousMatrix(kine::homogeneousMatrixToVector6(m)) << std::endl << std::endl;
 
-
-    return 0;
+  return 0;
 }
 
 int testHomoDerivation()
 {
-    Vector6 p = Vector6::Random();
-    Matrix4 m = kine::vector6ToHomogeneousMatrix(p);
+  Vector6 p = Vector6::Random();
+  Matrix4 m = kine::vector6ToHomogeneousMatrix(p);
 
-    Vector6 v = Vector6::Random();
+  Vector6 v = Vector6::Random();
 
-    Vector6 p2;
+  Vector6 p2;
 
-    p2.head(3) =  p.head(3) + dt * v.head(3);
+  p2.head(3) = p.head(3) + dt * v.head(3);
 
-    AngleAxis aa (Quaternion( kine::rotationVectorToAngleAxis
-                                                    (v.tail(3)*dt) )
-                                * m.block(0,0,3,3));
+  AngleAxis aa(Quaternion(kine::rotationVectorToAngleAxis(v.tail(3) * dt)) * m.block(0, 0, 3, 3));
 
-    p2.tail(3) = aa.axis()* aa.angle();
+  p2.tail(3) = aa.axis() * aa.angle();
 
-    Matrix4 m2 = kine::vector6ToHomogeneousMatrix(p2);
+  Matrix4 m2 = kine::vector6ToHomogeneousMatrix(p2);
 
-    std::cout<< kine::derivateHomogeneousMatrixFD(m,m2,dt).transpose()
-                                                <<std::endl<<std::endl;
+  std::cout << kine::derivateHomogeneousMatrixFD(m, m2, dt).transpose() << std::endl << std::endl;
 
-    std::cout<< v.transpose() <<std::endl<<std::endl;
-    return 0;
+  std::cout << v.transpose() << std::endl << std::endl;
+  return 0;
 }
 
 int testVector6Derivation()
 {
-    Vector6 p = Vector6::Random();
-    Matrix4 m = kine::vector6ToHomogeneousMatrix(p);
+  Vector6 p = Vector6::Random();
+  Matrix4 m = kine::vector6ToHomogeneousMatrix(p);
 
-    Vector6 v = Vector6::Random();
+  Vector6 v = Vector6::Random();
 
-    Vector6 p2;
+  Vector6 p2;
 
-    p2.head(3) =  p.head(3) + dt * v.head(3);
+  p2.head(3) = p.head(3) + dt * v.head(3);
 
-    AngleAxis aa (Quaternion( kine::rotationVectorToAngleAxis
-                                                    (v.tail(3)*dt) )
-                                * m.block(0,0,3,3));
+  AngleAxis aa(Quaternion(kine::rotationVectorToAngleAxis(v.tail(3) * dt)) * m.block(0, 0, 3, 3));
 
-    p2.tail(3) = aa.axis()* aa.angle();
+  p2.tail(3) = aa.axis() * aa.angle();
 
-    std::cout<< kine::derivatePoseThetaUFD(p,p2,dt).transpose()
-                                                <<std::endl<<std::endl;
+  std::cout << kine::derivatePoseThetaUFD(p, p2, dt).transpose() << std::endl << std::endl;
 
-    std::cout<< v.transpose() <<std::endl<<std::endl;
+  std::cout << v.transpose() << std::endl << std::endl;
 
-    return 0;
-
+  return 0;
 }
 
 int main()
 {
-    homoMatrixDerivationTestFromFile(const_cast<char *>("/tmp/featurecompensateR_ref-position.dat"),
-                const_cast<char *>("/tmp/featurecompensateR_ref-velocity.dat"), const_cast<char *>("reference"));
+  homoMatrixDerivationTestFromFile(const_cast<char *>("/tmp/featurecompensateR_ref-position.dat"),
+                                   const_cast<char *>("/tmp/featurecompensateR_ref-velocity.dat"),
+                                   const_cast<char *>("reference"));
 
-    homoMatrixDerivationTestFromFile(const_cast<char *>("/tmp/tranformation_right-gMl.dat"),
-                const_cast<char *>("/tmp/tranformation_right-gVl.dat") , const_cast<char *>("flexInverse"));
+  homoMatrixDerivationTestFromFile(const_cast<char *>("/tmp/tranformation_right-gMl.dat"),
+                                   const_cast<char *>("/tmp/tranformation_right-gVl.dat"),
+                                   const_cast<char *>("flexInverse"));
 
-    homoMatrixDerivationTestFromFile(const_cast<char *>("/tmp/flextimator-flexTransformationMatrix.dat"),
-                const_cast<char *>("/tmp/flextimator-flexVelocityVector.dat" ), const_cast<char *>("flex"));
+  homoMatrixDerivationTestFromFile(const_cast<char *>("/tmp/flextimator-flexTransformationMatrix.dat"),
+                                   const_cast<char *>("/tmp/flextimator-flexVelocityVector.dat"),
+                                   const_cast<char *>("flex"));
 
+  // invertMatrixTest();
 
-    //invertMatrixTest();
+  // transformationTest();
 
-    //transformationTest();
+  testHomoDerivation();
 
-    testHomoDerivation();
+  testVector6Derivation();
 
-    testVector6Derivation();
-
-    return 0;
+  return 0;
 }

--- a/unit-testings/simple-flex-estimation-test.cpp
+++ b/unit-testings/simple-flex-estimation-test.cpp
@@ -1,208 +1,194 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
-#include <state-observation/noise/gaussian-white-noise.hpp>
-#include <state-observation/examples/offline-ekf-flexibility-estimation.hpp>
 #include <state-observation/dynamical-system/dynamical-system-simulator.hpp>
+#include <state-observation/examples/offline-ekf-flexibility-estimation.hpp>
+#include <state-observation/noise/gaussian-white-noise.hpp>
 #include <state-observation/tools/miscellaneous-algorithms.hpp>
-
 
 using namespace stateObservation;
 
 typedef kine::indexes<kine::rotationVector> indexes;
 
-
 int test()
 {
-    /// The number of samples
-    const Index kmax=1000;
+  /// The number of samples
+  const Index kmax = 1000;
 
-    ///sampling period
-    const double dt=5e-3;
+  /// sampling period
+  const double dt = 5e-3;
 
-    ///Sizes of the states for the state, the measurement, and the input vector
-    const unsigned stateSize=18;
-    //const unsigned measurementSize=6;
-    const unsigned inputSize=15;
+  /// Sizes of the states for the state, the measurement, and the input vector
+  const unsigned stateSize = 18;
+  // const unsigned measurementSize=6;
+  const unsigned inputSize = 15;
 
-    ///The array containing all the states, the measurements and the inputs
-    IndexedVectorArray x;
-    IndexedVectorArray y;
-    IndexedVectorArray u;
-    IndexedVectorArray z;
+  /// The array containing all the states, the measurements and the inputs
+  IndexedVectorArray x;
+  IndexedVectorArray y;
+  IndexedVectorArray u;
+  IndexedVectorArray z;
 
-    IndexedVectorArray ino;
-    IndexedVectorArray prediMea;
+  IndexedVectorArray ino;
+  IndexedVectorArray prediMea;
 
-    ///Contact vector
-    Vector3 contact(-1,0,0);
+  /// Contact vector
+  Vector3 contact(-1, 0, 0);
 
-    ///Generation
+  /// Generation
+  {
+    Quaternion q(Quaternion::Identity());
+    Vector3 odoti(Vector3::Zero());
+    Vector3 oi(Vector3::Zero());
+    Vector3 pos;
+    Vector3 vel;
+    Vector3 acc;
+    kine::fixedPointRotationToTranslation(q.matrix(), oi, odoti, contact, pos, vel, acc);
+    AngleAxis aa(q);
+
+    Vector Xi(Vector::Zero(stateSize, 1));
+    Xi.segment(indexes::pos, 3) = pos;
+    Xi.segment(indexes::ori, 3) = aa.angle() * aa.axis();
+    Xi.segment(indexes::linVel, 3) = vel;
+    Xi.segment(indexes::angVel, 3) = oi;
+    Xi.segment(indexes::linAcc, 3) = acc;
+    Xi.segment(indexes::angAcc, 3) = odoti;
+    x.setValue(Xi, 0);
+
+    Quaternion qCtrl(Quaternion::Identity());
+    Vector3 odotCtrl(Vector3::Zero());
+    Vector3 oCtrl(Vector3::Zero());
+    Vector3 posCtrl(contact);
+    Vector3 velCtrl(Vector3::Zero());
+    Vector3 accCtrl(Vector3::Zero());
+
+    Quaternion qImu(q * qCtrl);
+    Vector3 oImu(Vector3::Zero());
+    Vector3 posImu(q.matrix() * posCtrl + pos);
+    Vector3 velImu(Vector3::Zero());
+    Vector3 accImu(Vector3::Zero());
+
+    AccelerometerGyrometer imu;
+
+    for(Index i = 1; i < kmax; ++i)
     {
-        Quaternion q(Quaternion::Identity());
-        Vector3 odoti(Vector3::Zero());
-        Vector3 oi(Vector3::Zero());
-        Vector3 pos;
-        Vector3 vel;
-        Vector3 acc;
-        kine::fixedPointRotationToTranslation
-                (q.matrix() , oi, odoti,
-                contact, pos, vel, acc);
-        AngleAxis aa(q);
+      q = kine::rotationVectorToAngleAxis(oi * dt) * q;
+      aa = q;
+      oi += odoti * dt;
+      double id = double(i);
+      odoti << 0.1 * sin(0.007 * id), 0.2 * sin(0.03 * id), 0.25 * sin(0.02 * id);
 
-        Vector Xi (Vector::Zero(stateSize,1));
-        Xi.segment(indexes::pos,3) = pos;
-        Xi.segment(indexes::ori,3) = aa.angle()*aa.axis();
-        Xi.segment(indexes::linVel,3) = vel;
-        Xi.segment(indexes::angVel,3) = oi;
-        Xi.segment(indexes::linAcc,3) = acc;
-        Xi.segment(indexes::angAcc,3) = odoti;
-        x.setValue(Xi,0);
+      kine::fixedPointRotationToTranslation(q.matrix(), oi, odoti, contact, pos, vel, acc);
 
+      Xi.segment(indexes::pos, 3) = pos;
+      Xi.segment(indexes::ori, 3) = aa.angle() * aa.axis();
+      Xi.segment(indexes::linVel, 3) = vel;
+      Xi.segment(indexes::angVel, 3) = oi;
+      Xi.segment(indexes::linAcc, 3) = acc;
+      Xi.segment(indexes::angAcc, 3) = odoti;
 
-        Quaternion qCtrl(Quaternion::Identity());
-        Vector3 odotCtrl(Vector3::Zero());
-        Vector3 oCtrl(Vector3::Zero());
-        Vector3 posCtrl(contact);
-        Vector3 velCtrl(Vector3::Zero());
-        Vector3 accCtrl(Vector3::Zero());
+      x.setValue(Xi, i);
 
-        Quaternion qImu(q*qCtrl);
-        Vector3 oImu(Vector3::Zero());
-        Vector3 posImu(q.matrix()*posCtrl+pos);
-        Vector3 velImu(Vector3::Zero());
-        Vector3 accImu(Vector3::Zero());
+      qCtrl = kine::rotationVectorToAngleAxis(oCtrl * dt) * qCtrl;
+      AngleAxis aaCtrl(qCtrl);
+      oCtrl += odotCtrl * dt;
 
+      odotCtrl << 0.15 * sin(0.008 * id), 0.1 * sin(0.023 * id), 0.2 * sin(0.025 * id);
+      posCtrl += velCtrl * dt;
+      velCtrl += accCtrl * dt;
+      accCtrl << 0.12 * sin(0.018 * id), 0.08 * sin(0.035 * id), 0.3 * sin(0.027 * id);
 
+      Vector Ui(Vector::Zero(inputSize, 1));
+      Ui.segment(indexes::pos, 3) = posCtrl;
+      Ui.segment(indexes::ori, 3) = aaCtrl.angle() * aaCtrl.axis();
+      Ui.segment(indexes::linVel, 3) = velCtrl;
+      Ui.segment(indexes::angVel, 3) = oCtrl;
+      Ui.segment(indexes::linAcc, 3) = accCtrl;
+      u.setValue(Ui, i);
 
-        AccelerometerGyrometer imu;
+      Quaternion newqImu(q * qCtrl);
+      Vector3 newPosImu(q.matrix() * posCtrl + pos);
+      Vector3 newVelImu(tools::derivate(posImu, newPosImu, dt));
 
-        for (Index i=1; i<kmax; ++i)
-        {
-            q = kine::rotationVectorToAngleAxis(oi*dt)*q;
-            aa=q;
-            oi+=odoti*dt;
-            double id = double(i);
-            odoti << 0.1*sin(0.007*id),  0.2*sin(0.03*id),  0.25*sin(0.02*id);
+      accImu = tools::derivate(velImu, newVelImu, dt);
+      velImu = newVelImu;
+      posImu = newPosImu;
 
-            kine::fixedPointRotationToTranslation(q.matrix() , oi, odoti,
-                                                        contact, pos, vel, acc);
+      oImu = kine::derivateRotationFD(qImu, newqImu, dt);
+      qImu = newqImu;
 
+      Vector Ximu(Vector::Zero(10, 1));
+      Ximu.head<4>() = qImu.coeffs();
+      Ximu.segment(4, 3) = accImu;
+      Ximu.segment(7, 3) = oImu;
 
-            Xi.segment(indexes::pos,3) = pos;
-            Xi.segment(indexes::ori,3) = aa.angle()*aa.axis();
-            Xi.segment(indexes::linVel,3) = vel;
-            Xi.segment(indexes::angVel,3) = oi;
-            Xi.segment(indexes::linAcc,3) = acc;
-            Xi.segment(indexes::angAcc,3) = odoti;
+      imu.setState(Ximu, i);
+      z.setValue(Ximu, i);
+      y.setValue(imu.getMeasurements(), i);
+    }
+  }
 
-            x.setValue(Xi,i);
+  /// the initalization of an estimation of the initial state
+  Vector xh0 = Vector::Zero(stateSize, 1);
 
-            qCtrl = kine::rotationVectorToAngleAxis(oCtrl*dt)*qCtrl;
-            AngleAxis aaCtrl(qCtrl);
-            oCtrl+=odotCtrl*dt;
+  std::vector<Vector3, Eigen::aligned_allocator<Vector3>> contactPositions;
 
-            odotCtrl << 0.15*sin(0.008*id), 0.1*sin(0.023*id), 0.2*sin(0.025*id);
-            posCtrl += velCtrl*dt;
-            velCtrl += accCtrl*dt;
-            accCtrl << 0.12*sin(0.018*id), 0.08*sin(0.035*id), 0.3*sin(0.027*id);
+  contactPositions.push_back(contact);
 
-            Vector Ui (Vector::Zero(inputSize,1));
-            Ui.segment(indexes::pos,3) = posCtrl;
-            Ui.segment(indexes::ori,3) = aaCtrl.angle()*aaCtrl.axis();
-            Ui.segment(indexes::linVel,3) = velCtrl;
-            Ui.segment(indexes::angVel,3) = oCtrl;
-            Ui.segment(indexes::linAcc,3) = accCtrl;
-            u.setValue(Ui,i);
+  stateObservation::IndexedVectorArray xh =
+      stateObservation::examples::offlineEKFFlexibilityEstimation(y, u, xh0, 1, contactPositions, dt, &ino, &prediMea);
 
-            Quaternion newqImu(q*qCtrl);
-            Vector3 newPosImu(q.matrix()*posCtrl+pos);
-            Vector3 newVelImu(tools::derivate(posImu,newPosImu,dt));
+  double error = 0;
 
-            accImu = tools::derivate(velImu,newVelImu,dt);
-            velImu = newVelImu;
-            posImu = newPosImu;
-
-            oImu = kine::derivateRotationFD(qImu, newqImu, dt);
-            qImu = newqImu;
-
-            Vector Ximu(Vector::Zero(10,1));
-            Ximu.head<4>()=qImu.coeffs();
-            Ximu.segment(4,3)=accImu;
-            Ximu.segment(7,3)=oImu;
-
-            imu.setState(Ximu,i);
-            z.setValue(Ximu,i);
-            y.setValue(imu.getMeasurements(),i);
-
-        }
+  /// the reconstruction of the state
+  for(TimeIndex i = y.getFirstIndex(); i < y.getNextIndex(); ++i)
+  {
+    Vector3 g;
+    {
+      Matrix3 R;
+      Vector3 orientationV = Vector(x[i]).segment(indexes::ori, 3);
+      double angle = orientationV.norm();
+      if(angle > cst::epsilonAngle)
+        R = AngleAxis(angle, orientationV / angle).toRotationMatrix();
+      else
+        R = Matrix3::Identity();
+      g = R.transpose() * Vector3::UnitZ();
+      g.normalize();
     }
 
-    ///the initalization of an estimation of the initial state
-    Vector xh0=Vector::Zero(stateSize,1);
-
-    std::vector<Vector3, Eigen::aligned_allocator<Vector3> > contactPositions;
-
-    contactPositions.push_back(contact);
-
-
-    stateObservation::IndexedVectorArray xh=
-        stateObservation::examples::offlineEKFFlexibilityEstimation
-            (y,u,xh0,1,contactPositions,dt,&ino, &prediMea);
-
-    double error=0;
-
-    ///the reconstruction of the state
-    for (TimeIndex i=y.getFirstIndex();i<y.getNextIndex();++i)
+    Vector3 gh;
     {
-        Vector3 g;
-        {
-            Matrix3 R;
-            Vector3 orientationV=Vector(x[i]).segment(indexes::ori,3);
-            double angle=orientationV.norm();
-            if (angle > cst::epsilonAngle)
-                R = AngleAxis(angle, orientationV/angle).toRotationMatrix();
-            else
-                R = Matrix3::Identity();
-            g=R.transpose()*Vector3::UnitZ();
-            g.normalize();
-        }
+      Matrix3 Rh;
 
-        Vector3 gh;
-        {
-            Matrix3 Rh;
-
-            Vector3 orientationV=Vector(xh[i]).segment(indexes::ori,3);
-            double angle=orientationV.norm();
-            if (angle > cst::epsilonAngle)
-                Rh = AngleAxis(angle, orientationV/angle).toRotationMatrix();
-            else
-                Rh = Matrix3::Identity();
-            gh=Rh.transpose()*Vector3::UnitZ();
-            gh.normalize();
-        }
-
-        error = acos(double(g.transpose()*gh)) * 180 / M_PI;
+      Vector3 orientationV = Vector(xh[i]).segment(indexes::ori, 3);
+      double angle = orientationV.norm();
+      if(angle > cst::epsilonAngle)
+        Rh = AngleAxis(angle, orientationV / angle).toRotationMatrix();
+      else
+        Rh = Matrix3::Identity();
+      gh = Rh.transpose() * Vector3::UnitZ();
+      gh.normalize();
     }
 
-    std::cout << "Error " << error << ", test: " ;
+    error = acos(double(g.transpose() * gh)) * 180 / M_PI;
+  }
 
-    if (error > 2.)
-    {
-        std::cout << "FAILED !!!!!!!";
-        return 1;
-    }
-    else
-    {
-        std::cout << "SUCCEEDED !!!!!!!";
-        return 0;
-    }
+  std::cout << "Error " << error << ", test: ";
+
+  if(error > 2.)
+  {
+    std::cout << "FAILED !!!!!!!";
+    return 1;
+  }
+  else
+  {
+    std::cout << "SUCCEEDED !!!!!!!";
+    return 0;
+  }
 }
 
 int main()
 {
 
-
-    return test();
-
+  return test();
 }

--- a/unit-testings/test-kinetics-observer.cpp
+++ b/unit-testings/test-kinetics-observer.cpp
@@ -9,1039 +9,1010 @@ using namespace kine;
 int testOrientation(int errcode)
 {
 
-    Vector4 q_i;
+  Vector4 q_i;
+
+  tools::ProbabilityLawSimulation s;
 
-    tools::ProbabilityLawSimulation s;
+  /// random orientation
+  q_i = s.getGaussianVector(Matrix4::Identity(), Vector4::Zero(), 4);
+  q_i.normalize();
 
-    ///random orientation
-    q_i = s.getGaussianVector(Matrix4::Identity(),Vector4::Zero(),4);
-    q_i.normalize();
+  /// several representations of the orientation
+  Quaternion q(q_i);
+  AngleAxis aa(q);
+  Matrix3 M(q.toRotationMatrix());
 
-    ///several representations of the orientation
-    Quaternion q(q_i);
-    AngleAxis aa(q);
-    Matrix3 M(q.toRotationMatrix());
+  double err = 0.;
 
-    double err=0.;
+  std::cout << "Orientation test started " << err << std::endl;
 
-    std::cout<<"Orientation test started " <<  err << std::endl;
+  {
+    kine::Orientation ori1;
+    ori1 = q;
+    Matrix3 M1 = ori1;
 
+    err +=
+        (Quaternion(ori1.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm() + (M1 - M).norm();
+    std::cout << "Assignment operaton test 1 (Quaternion) done. Current error " << err << std::endl;
+  }
 
-    {
-        kine::Orientation ori1;
-        ori1 = q;
-        Matrix3 M1 = ori1;
+  {
+    kine::Orientation ori2;
+    ori2 = M;
 
-        err +=  (Quaternion(ori1.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
-                 + (M1 - M).norm();
-        std::cout<<"Assignment operaton test 1 (Quaternion) done. Current error " <<  err << std::endl;
-    }
+    err += (Quaternion(ori2.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
+           + (ori2.matrix3() - M).norm();
+    std::cout << "Assignment operaton test 2 (Matrix3) done. Current error " << err << std::endl;
+  }
 
-    {
-        kine::Orientation ori2;
-        ori2 = M;
-
-        err +=  (Quaternion(ori2.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
-                + (ori2.matrix3() - M).norm();
-        std::cout<<"Assignment operaton test 2 (Matrix3) done. Current error " <<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori3;
-        ori3 = aa;
-
-        err +=   (Quaternion(ori3.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
-                 + (ori3.matrix3()-M).norm() ;
-        std::cout<<"Assignment operaton test 3 (AngleAxis) done. Current error " <<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori4;
-        ori4 = Vector3(aa.angle()*aa.axis());
-
-        err +=  (Quaternion(ori4.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
-                + (ori4.matrix3()-M).norm() ;
-        std::cout<<"Assignment operaton test 3 (Vector3) done. Current error " <<  err << std::endl;
-    }
-
-
-    {
-        kine::Orientation ori1(q);
-        Matrix3 M1 = ori1;
-
-        err +=  (Quaternion(ori1.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
-                 + (M1 - M).norm();
-        std::cout<<"Cast operaton test 1 (Matrix3) done. Current error " <<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori2(M);
-
-        err +=  (Quaternion(ori2.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
-                + (ori2.matrix3() - M).norm();
-        std::cout<<"copy constructor test 1 (Matrix3) done. Current error " <<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori3(aa);
-
-        err +=   (Quaternion(ori3.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
-                 + (ori3.matrix3()-M).norm() ;
-        std::cout<<"copy constructor test 2 (AngleAxis) done. Current error " <<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori4(Vector3(aa.angle()*aa.axis()));
-
-        err +=  (Quaternion(ori4.toVector4()).toRotationMatrix() - M).norm()
-                + (ori4.matrix3()-M).norm() ;
-        std::cout<<"copy constructor test 3 (AngleAxis) done. Current error " <<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori4(q,M);
-
-        err +=  (Quaternion(ori4.toVector4()).toRotationMatrix() - M).norm()
-                + (ori4.matrix3()-M).norm() ;
-        std::cout<<"Constructor test 1 (Quaternion, Matrix3) done. Current error " <<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori4;
-        ori4.setRandom();
-        ori4 = M;
-
-        err +=  (Quaternion(ori4.toVector4()).toRotationMatrix() - M).norm()
-                + (ori4.matrix3()-M).norm() ;
-        std::cout<<"Update Assignement operator test 1 (Matrix3) done. Current error " <<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori4;
-        ori4.setRandom();
-        ori4 = q;
-
-        err +=  (Quaternion(ori4.toVector4()).toRotationMatrix() - M).norm()
-                + (ori4.matrix3()-M).norm() ;
-        std::cout<<"Update Assignement operator test 2 (Quaternion) done. Current error " <<  err << std::endl;
-    }
-
-
-
-    {
-        kine::Orientation ori1(q);
-
-        kine::Orientation ori2 = ori1.inverse();
-        kine::Orientation ori3 = ori2.inverse();
-
-        Matrix3 M3 = ori1;
-
-        err +=  (Quaternion(ori3.toVector4()).toRotationMatrix() - M).norm()
-                 + (M3 - M).norm();
-        std::cout<<"Inverse operator test 1 done. Current error " <<  err << std::endl;
-    }
-
-
-    {
-
-        kine::Orientation ori0(q);
-        kine::Orientation ori1(M);
-        ori1=ori1.inverse();
-        const kine::Orientation & ori2=ori0;
-        const kine::Orientation & ori3=ori1;
-
-        kine::Orientation ori00 = ori0*ori1;
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori01 = ori1*ori0;
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori02 = ori0*ori3;
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori03 = ori3*ori0;
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori04 = ori2*ori1;
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori05 = ori1*ori2;
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori06 = ori2*ori3;
-        kine::Orientation ori07 = ori3*ori2;
-
-
-        kine::Orientation ori10 (ori0,ori1);
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori11 (ori1,ori0);
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori12 (ori0,ori3);
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori13 (ori3,ori0);
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori14 (ori2,ori1);
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori15 (ori1,ori2);
-        ori0=q;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori16 (ori2,ori3);
-        kine::Orientation ori17 (ori3,ori2);
-
-        err += (ori00.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  1 done. Current error "<<  err << std::endl;
-        err += (ori01.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  2 done. Current error "<<  err << std::endl;
-        err += (ori02.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  3 done. Current error "<<  err << std::endl;
-        err += (ori03.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  4 done. Current error "<<  err << std::endl;
-        err += (ori04.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  5 done. Current error "<<  err << std::endl;
-        err += (ori05.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  6 done. Current error "<<  err << std::endl;
-        err += (ori06.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  7 done. Current error "<<  err << std::endl;
-        err += (ori07.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  8 done. Current error "<<  err << std::endl;
-        err += (ori10.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  9 done. Current error "<<  err << std::endl;
-        err += (ori11.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  10 done. Current error "<<  err << std::endl;
-        err += (ori12.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  11 done. Current error "<<  err << std::endl;
-        err += (ori13.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  12 done. Current error "<<  err << std::endl;
-        err += (ori14.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  13 done. Current error "<<  err << std::endl;
-        err += (ori15.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  14 done. Current error "<<  err << std::endl;
-        err += (ori16.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  15 done. Current error "<<  err << std::endl;
-        err += (ori17.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  16 done. Current error "<<  err << std::endl;
-    }
-
-    {
-
-        kine::Orientation ori0(q);
-        kine::Orientation ori1(q);
-        ori1=ori1.inverse();
-        const kine::Orientation & ori2=ori0;
-        const kine::Orientation & ori3=ori1;
-
-        kine::Orientation ori00 = ori0*ori1;
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori01 = ori1*ori0;
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori02 = ori0*ori3;
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori03 = ori3*ori0;
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori04 = ori2*ori1;
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori05 = ori1*ori2;
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori06 = ori2*ori3;
-        kine::Orientation ori07 = ori3*ori2;
-
-
-        kine::Orientation ori10 (ori0,ori1);
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori11 (ori1,ori0);
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori12 (ori0,ori3);
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori13 (ori3,ori0);
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori14 (ori2,ori1);
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori15 (ori1,ori2);
-        ori0=q;ori1=q;ori1=ori1.inverse();
-        kine::Orientation ori16 (ori2,ori3);
-        kine::Orientation ori17 (ori3,ori2);
-
-        err += (ori00.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  17 done. Current error "<<  err << std::endl;
-        err += (ori01.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  18 done. Current error "<<  err << std::endl;
-        err += (ori02.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  19 done. Current error "<<  err << std::endl;
-        err += (ori03.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  20 done. Current error "<<  err << std::endl;
-        err += (ori04.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  21 done. Current error "<<  err << std::endl;
-        err += (ori05.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  22 done. Current error "<<  err << std::endl;
-        err += (ori06.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  23 done. Current error "<<  err << std::endl;
-        err += (ori07.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  24 done. Current error "<<  err << std::endl;
-        err += (ori10.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  25 done. Current error "<<  err << std::endl;
-        err += (ori11.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  26 done. Current error "<<  err << std::endl;
-        err += (ori12.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  27 done. Current error "<<  err << std::endl;
-        err += (ori13.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  28 done. Current error "<<  err << std::endl;
-        err += (ori14.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  29 done. Current error "<<  err << std::endl;
-        err += (ori15.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  30 done. Current error "<<  err << std::endl;
-        err += (ori16.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  31 done. Current error "<<  err << std::endl;
-        err += (ori17.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  32 done. Current error "<<  err << std::endl;
-    }
-
-    {
-
-        kine::Orientation ori0(M);
-        kine::Orientation ori1(M);
-        ori1=ori1.inverse();
-        const kine::Orientation & ori2=ori0;
-        const kine::Orientation & ori3=ori1;
-
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori00 = ori0*ori1;
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori01 = ori1*ori0;
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori02 = ori0*ori3;
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori03 = ori3*ori0;
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori04 = ori2*ori1;
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori05 = ori1*ori2;
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori06 = ori2*ori3;
-        kine::Orientation ori07 = ori3*ori2;
-
-
-        kine::Orientation ori10 (ori0,ori1);
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori11 (ori1,ori0);
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori12 (ori0,ori3);
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori13 (ori3,ori0);
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori14 (ori2,ori1);
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori15 (ori1,ori2);
-        ori0=M;ori1=M;ori1=ori1.inverse();
-        kine::Orientation ori16 (ori2,ori3);
-        kine::Orientation ori17 (ori3,ori2);
-
-        err += (ori00.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  33 done. Current error "<<  err << std::endl;
-        err += (ori01.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  34 done. Current error "<<  err << std::endl;
-        err += (ori02.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  35 done. Current error "<<  err << std::endl;
-        err += (ori03.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  36 done. Current error "<<  err << std::endl;
-        err += (ori04.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  37 done. Current error "<<  err << std::endl;
-        err += (ori05.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  38 done. Current error "<<  err << std::endl;
-        err += (ori06.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  39 done. Current error "<<  err << std::endl;
-        err += (ori07.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  40 done. Current error "<<  err << std::endl;
-        err += (ori10.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  41 done. Current error "<<  err << std::endl;
-        err += (ori11.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  42 done. Current error "<<  err << std::endl;
-        err += (ori12.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  43 done. Current error "<<  err << std::endl;
-        err += (ori13.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  44 done. Current error "<<  err << std::endl;
-        err += (ori14.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  45 done. Current error "<<  err << std::endl;
-        err += (ori15.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  46 done. Current error "<<  err << std::endl;
-        err += (ori16.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  47 done. Current error "<<  err << std::endl;
-        err += (ori17.matrix3() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  48 done. Current error "<<  err << std::endl;
-    }
-
-    {
-        kine::Orientation ori1(q);
-        kine::Orientation ori2(M);
-
-        kine::Orientation ori3 = ori2.inverse()*ori1;
-
-        err +=  (Quaternion(ori3.toVector4()).toRotationMatrix() - Matrix3::Identity()).norm();
-        std::cout<<"Multiplication test  49 done. Current error "<<  err << std::endl;
-    }
-
-    {
-        Vector3 v1 = Vector3::Random()*0.1;
-        kine::Orientation ori1(M);
-        kine::Orientation ori2(ori1);
-        ori2.integrate(v1);
-
-        Vector3 v2 = ori1.differentiate(ori2) ;
-
-        err +=  (v1- v2).norm();
-        std::cout<<"Integration/differentiation test 1 done. Current error "<<  err << std::endl;
-    }
-
-    {
-        Vector3 v1;
-        kine::Orientation ori1;
-        kine::Orientation ori2;
-
-        ori1.setRandom();
-        ori2.setRandom();
-
-        v1 = ori2.differentiate(ori1);
-        kine::Orientation oris = ori2.integrate(v1);
-
-        err += oris.differentiate(ori1).norm();
-        std::cout << "Integration/differentiation test 2 done. Current error " << err << std::endl;
-    }
-
-    if (err>1e-13)
-    {
-        return errcode;
-    }
-    return 0;
+  {
+    kine::Orientation ori3;
+    ori3 = aa;
+
+    err += (Quaternion(ori3.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
+           + (ori3.matrix3() - M).norm();
+    std::cout << "Assignment operaton test 3 (AngleAxis) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori4;
+    ori4 = Vector3(aa.angle() * aa.axis());
+
+    err += (Quaternion(ori4.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
+           + (ori4.matrix3() - M).norm();
+    std::cout << "Assignment operaton test 3 (Vector3) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori1(q);
+    Matrix3 M1 = ori1;
+
+    err +=
+        (Quaternion(ori1.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm() + (M1 - M).norm();
+    std::cout << "Cast operaton test 1 (Matrix3) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori2(M);
+
+    err += (Quaternion(ori2.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
+           + (ori2.matrix3() - M).norm();
+    std::cout << "copy constructor test 1 (Matrix3) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori3(aa);
+
+    err += (Quaternion(ori3.toVector4()).toRotationMatrix() - Quaternion(q_i).toRotationMatrix()).norm()
+           + (ori3.matrix3() - M).norm();
+    std::cout << "copy constructor test 2 (AngleAxis) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori4(Vector3(aa.angle() * aa.axis()));
+
+    err += (Quaternion(ori4.toVector4()).toRotationMatrix() - M).norm() + (ori4.matrix3() - M).norm();
+    std::cout << "copy constructor test 3 (AngleAxis) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori4(q, M);
+
+    err += (Quaternion(ori4.toVector4()).toRotationMatrix() - M).norm() + (ori4.matrix3() - M).norm();
+    std::cout << "Constructor test 1 (Quaternion, Matrix3) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori4;
+    ori4.setRandom();
+    ori4 = M;
+
+    err += (Quaternion(ori4.toVector4()).toRotationMatrix() - M).norm() + (ori4.matrix3() - M).norm();
+    std::cout << "Update Assignement operator test 1 (Matrix3) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori4;
+    ori4.setRandom();
+    ori4 = q;
+
+    err += (Quaternion(ori4.toVector4()).toRotationMatrix() - M).norm() + (ori4.matrix3() - M).norm();
+    std::cout << "Update Assignement operator test 2 (Quaternion) done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori1(q);
+
+    kine::Orientation ori2 = ori1.inverse();
+    kine::Orientation ori3 = ori2.inverse();
+
+    Matrix3 M3 = ori1;
+
+    err += (Quaternion(ori3.toVector4()).toRotationMatrix() - M).norm() + (M3 - M).norm();
+    std::cout << "Inverse operator test 1 done. Current error " << err << std::endl;
+  }
+
+  {
+
+    kine::Orientation ori0(q);
+    kine::Orientation ori1(M);
+    ori1 = ori1.inverse();
+    const kine::Orientation & ori2 = ori0;
+    const kine::Orientation & ori3 = ori1;
+
+    kine::Orientation ori00 = ori0 * ori1;
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori01 = ori1 * ori0;
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori02 = ori0 * ori3;
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori03 = ori3 * ori0;
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori04 = ori2 * ori1;
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori05 = ori1 * ori2;
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori06 = ori2 * ori3;
+    kine::Orientation ori07 = ori3 * ori2;
+
+    kine::Orientation ori10(ori0, ori1);
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori11(ori1, ori0);
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori12(ori0, ori3);
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori13(ori3, ori0);
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori14(ori2, ori1);
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori15(ori1, ori2);
+    ori0 = q;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori16(ori2, ori3);
+    kine::Orientation ori17(ori3, ori2);
+
+    err += (ori00.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  1 done. Current error " << err << std::endl;
+    err += (ori01.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  2 done. Current error " << err << std::endl;
+    err += (ori02.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  3 done. Current error " << err << std::endl;
+    err += (ori03.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  4 done. Current error " << err << std::endl;
+    err += (ori04.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  5 done. Current error " << err << std::endl;
+    err += (ori05.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  6 done. Current error " << err << std::endl;
+    err += (ori06.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  7 done. Current error " << err << std::endl;
+    err += (ori07.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  8 done. Current error " << err << std::endl;
+    err += (ori10.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  9 done. Current error " << err << std::endl;
+    err += (ori11.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  10 done. Current error " << err << std::endl;
+    err += (ori12.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  11 done. Current error " << err << std::endl;
+    err += (ori13.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  12 done. Current error " << err << std::endl;
+    err += (ori14.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  13 done. Current error " << err << std::endl;
+    err += (ori15.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  14 done. Current error " << err << std::endl;
+    err += (ori16.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  15 done. Current error " << err << std::endl;
+    err += (ori17.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  16 done. Current error " << err << std::endl;
+  }
+
+  {
+
+    kine::Orientation ori0(q);
+    kine::Orientation ori1(q);
+    ori1 = ori1.inverse();
+    const kine::Orientation & ori2 = ori0;
+    const kine::Orientation & ori3 = ori1;
+
+    kine::Orientation ori00 = ori0 * ori1;
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori01 = ori1 * ori0;
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori02 = ori0 * ori3;
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori03 = ori3 * ori0;
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori04 = ori2 * ori1;
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori05 = ori1 * ori2;
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori06 = ori2 * ori3;
+    kine::Orientation ori07 = ori3 * ori2;
+
+    kine::Orientation ori10(ori0, ori1);
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori11(ori1, ori0);
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori12(ori0, ori3);
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori13(ori3, ori0);
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori14(ori2, ori1);
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori15(ori1, ori2);
+    ori0 = q;
+    ori1 = q;
+    ori1 = ori1.inverse();
+    kine::Orientation ori16(ori2, ori3);
+    kine::Orientation ori17(ori3, ori2);
+
+    err += (ori00.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  17 done. Current error " << err << std::endl;
+    err += (ori01.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  18 done. Current error " << err << std::endl;
+    err += (ori02.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  19 done. Current error " << err << std::endl;
+    err += (ori03.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  20 done. Current error " << err << std::endl;
+    err += (ori04.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  21 done. Current error " << err << std::endl;
+    err += (ori05.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  22 done. Current error " << err << std::endl;
+    err += (ori06.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  23 done. Current error " << err << std::endl;
+    err += (ori07.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  24 done. Current error " << err << std::endl;
+    err += (ori10.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  25 done. Current error " << err << std::endl;
+    err += (ori11.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  26 done. Current error " << err << std::endl;
+    err += (ori12.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  27 done. Current error " << err << std::endl;
+    err += (ori13.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  28 done. Current error " << err << std::endl;
+    err += (ori14.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  29 done. Current error " << err << std::endl;
+    err += (ori15.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  30 done. Current error " << err << std::endl;
+    err += (ori16.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  31 done. Current error " << err << std::endl;
+    err += (ori17.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  32 done. Current error " << err << std::endl;
+  }
+
+  {
+
+    kine::Orientation ori0(M);
+    kine::Orientation ori1(M);
+    ori1 = ori1.inverse();
+    const kine::Orientation & ori2 = ori0;
+    const kine::Orientation & ori3 = ori1;
+
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori00 = ori0 * ori1;
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori01 = ori1 * ori0;
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori02 = ori0 * ori3;
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori03 = ori3 * ori0;
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori04 = ori2 * ori1;
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori05 = ori1 * ori2;
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori06 = ori2 * ori3;
+    kine::Orientation ori07 = ori3 * ori2;
+
+    kine::Orientation ori10(ori0, ori1);
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori11(ori1, ori0);
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori12(ori0, ori3);
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori13(ori3, ori0);
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori14(ori2, ori1);
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori15(ori1, ori2);
+    ori0 = M;
+    ori1 = M;
+    ori1 = ori1.inverse();
+    kine::Orientation ori16(ori2, ori3);
+    kine::Orientation ori17(ori3, ori2);
+
+    err += (ori00.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  33 done. Current error " << err << std::endl;
+    err += (ori01.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  34 done. Current error " << err << std::endl;
+    err += (ori02.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  35 done. Current error " << err << std::endl;
+    err += (ori03.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  36 done. Current error " << err << std::endl;
+    err += (ori04.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  37 done. Current error " << err << std::endl;
+    err += (ori05.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  38 done. Current error " << err << std::endl;
+    err += (ori06.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  39 done. Current error " << err << std::endl;
+    err += (ori07.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  40 done. Current error " << err << std::endl;
+    err += (ori10.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  41 done. Current error " << err << std::endl;
+    err += (ori11.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  42 done. Current error " << err << std::endl;
+    err += (ori12.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  43 done. Current error " << err << std::endl;
+    err += (ori13.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  44 done. Current error " << err << std::endl;
+    err += (ori14.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  45 done. Current error " << err << std::endl;
+    err += (ori15.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  46 done. Current error " << err << std::endl;
+    err += (ori16.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  47 done. Current error " << err << std::endl;
+    err += (ori17.matrix3() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  48 done. Current error " << err << std::endl;
+  }
+
+  {
+    kine::Orientation ori1(q);
+    kine::Orientation ori2(M);
+
+    kine::Orientation ori3 = ori2.inverse() * ori1;
+
+    err += (Quaternion(ori3.toVector4()).toRotationMatrix() - Matrix3::Identity()).norm();
+    std::cout << "Multiplication test  49 done. Current error " << err << std::endl;
+  }
+
+  {
+    Vector3 v1 = Vector3::Random() * 0.1;
+    kine::Orientation ori1(M);
+    kine::Orientation ori2(ori1);
+    ori2.integrate(v1);
+
+    Vector3 v2 = ori1.differentiate(ori2);
+
+    err += (v1 - v2).norm();
+    std::cout << "Integration/differentiation test 1 done. Current error " << err << std::endl;
+  }
+
+  {
+    Vector3 v1;
+    kine::Orientation ori1;
+    kine::Orientation ori2;
+
+    ori1.setRandom();
+    ori2.setRandom();
+
+    v1 = ori2.differentiate(ori1);
+    kine::Orientation oris = ori2.integrate(v1);
+
+    err += oris.differentiate(ori1).norm();
+    std::cout << "Integration/differentiation test 2 done. Current error " << err << std::endl;
+  }
+
+  if(err > 1e-13)
+  {
+    return errcode;
+  }
+  return 0;
 }
 
-int testKinematics (int errcode)
+int testKinematics(int errcode)
 {
 
-    std::cout << "Kinematics test started" <<std::endl;
-    typedef kine::Kinematics::Flags Flags;
+  std::cout << "Kinematics test started" << std::endl;
+  typedef kine::Kinematics::Flags Flags;
 
+  kine::Kinematics k0;
+  kine::Kinematics k1;
 
-    kine::Kinematics k0;
-    kine::Kinematics k1;
+  Flags::Byte flag0 = BOOST_BINARY(000000);
+  Flags::Byte flag1 = BOOST_BINARY(000000);
 
+  kine::Kinematics k, l, k2;
 
+  int count = int(pow(2, 6) * pow(2, 6));
+  double err = 0;
+  double threshold = 1e-30 * count;
 
+  for(int i = 0; i < count; i++)
+  {
+    Vector3 pos0 = Vector3::Random();
+    kine::Orientation ori0 = kine::Orientation::randomRotation();
+    Vector3 linvel0 = Vector3::Random();
+    Vector3 angvel0 = Vector3::Random();
+    Vector3 linacc0 = Vector3::Random();
+    Vector3 angacc0 = Vector3::Random();
 
-    Flags::Byte flag0 = BOOST_BINARY(000000);
-    Flags::Byte flag1 = BOOST_BINARY(000000);
+    Vector3 pos1 = Vector3::Random();
+    kine::Orientation ori1 = kine::Orientation::randomRotation();
+    Vector3 linvel1 = Vector3::Random();
+    Vector3 angvel1 = Vector3::Random();
+    Vector3 linacc1 = Vector3::Random();
+    Vector3 angacc1 = Vector3::Random();
 
+    k0.reset();
+    k1.reset();
 
-    kine::Kinematics k,l,k2;
-
-
-    int count = int(pow(2,6)*pow(2,6));
-    double err=0;
-    double threshold=1e-30*count;
-
-    for (int i = 0; i < count; i++)
+    if(flag0 & Flags::position)
     {
-        Vector3 pos0 = Vector3::Random();
-        kine::Orientation ori0 = kine::Orientation::randomRotation();
-        Vector3 linvel0 = Vector3::Random();
-        Vector3 angvel0 = Vector3::Random();
-        Vector3 linacc0 = Vector3::Random();
-        Vector3 angacc0 = Vector3::Random();
-
-        Vector3 pos1 = Vector3::Random();
-        kine::Orientation ori1= kine::Orientation::randomRotation();
-        Vector3 linvel1 = Vector3::Random();
-        Vector3 angvel1 = Vector3::Random();
-        Vector3 linacc1 = Vector3::Random();
-        Vector3 angacc1 = Vector3::Random();
-
-        k0.reset();
-        k1.reset();
-
-        if (flag0 & Flags::position)
-        {
-            k0.position = pos0;
-        }
-        if (true) ///the orientation has to be set
-        {
-            k0.orientation = ori0;
-        }
-        if (flag0 & Flags::linVel)
-        {
-            k0.linVel = linvel0;
-        }
-        if (flag0 & Flags::angVel)
-        {
-            k0.angVel = angvel0;
-        }
-        if (flag0 & Flags::linAcc)
-        {
-            k0.linAcc = linacc0;
-        }
-        if (flag0 & Flags::angAcc)
-        {
-            k0.angAcc = angacc0;
-        }
-
-        if (flag1 & Flags::position)
-        {
-            k1.position = pos1;
-        }
-        if (! k1.position.isSet() || flag1 & Flags::orientation)///the orientation has to be set
-        {
-            k1.orientation = ori1;
-        }
-        if (flag1 & Flags::linVel)
-        {
-            k1.linVel = linvel1;
-        }
-        if (flag1 & Flags::angVel)
-        {
-            k1.angVel = angvel1;
-        }
-        if (flag1 & Flags::linAcc)
-        {
-            k1.linAcc = linacc1;
-        }
-        if (flag1 & Flags::angAcc)
-        {
-            k1.angAcc = angacc1;
-        }
-
-        if ((flag0 = (flag0+1) & Flags::all)==0) ///update the flags to span all the possibilties
-            flag1 = (flag1+1) & Flags::all;
-
-        k2=k1;
-        if (!k1.orientation.isSet())
-        {
-            k2.orientation.setZeroRotation();
-        }
-
-        k = ((k0
-            * k2)
-            * k2.getInverse() )
-            * k0.getInverse();
-
-        if (k.position.isSet())
-        {
-            err += k.position().squaredNorm();
-        }
-        if (k.orientation.isSet())
-        {
-            err += k.orientation.toRotationVector().squaredNorm();
-        }
-        if (k.linVel.isSet())
-        {
-            err +=  k.linVel().squaredNorm();
-        }
-        if (k.angVel.isSet())
-        {
-            err += k.angVel().squaredNorm();
-        }
-        if (k.linAcc.isSet())
-        {
-            err += k.linAcc().squaredNorm();
-        }
-        if (k.angAcc.isSet())
-        {
-            err += k.angAcc().squaredNorm();
-        }
+      k0.position = pos0;
+    }
+    if(true) /// the orientation has to be set
+    {
+      k0.orientation = ori0;
+    }
+    if(flag0 & Flags::linVel)
+    {
+      k0.linVel = linvel0;
+    }
+    if(flag0 & Flags::angVel)
+    {
+      k0.angVel = angvel0;
+    }
+    if(flag0 & Flags::linAcc)
+    {
+      k0.linAcc = linacc0;
+    }
+    if(flag0 & Flags::angAcc)
+    {
+      k0.angAcc = angacc0;
     }
 
-    std::cout << "Error 1 : " << err <<std::endl;
-
-     if (err>threshold )
+    if(flag1 & Flags::position)
     {
-        std::cout << "Error too large : " << err <<std::endl;
-        return errcode;
+      k1.position = pos1;
+    }
+    if(!k1.position.isSet() || flag1 & Flags::orientation) /// the orientation has to be set
+    {
+      k1.orientation = ori1;
+    }
+    if(flag1 & Flags::linVel)
+    {
+      k1.linVel = linvel1;
+    }
+    if(flag1 & Flags::angVel)
+    {
+      k1.angVel = angvel1;
+    }
+    if(flag1 & Flags::linAcc)
+    {
+      k1.linAcc = linacc1;
+    }
+    if(flag1 & Flags::angAcc)
+    {
+      k1.angAcc = angacc1;
     }
 
-    err =0;
+    if((flag0 = (flag0 + 1) & Flags::all) == 0) /// update the flags to span all the possibilties
+      flag1 = (flag1 + 1) & Flags::all;
 
-    threshold = 1e-19*count;
-
-
-
-    flag0 = BOOST_BINARY(000000);
-    flag1 = BOOST_BINARY(000000);
-
-
-    for (int i = 0; i < count; i++)
+    k2 = k1;
+    if(!k1.orientation.isSet())
     {
-        Vector3 pos0 = Vector3::Random();
-        kine::Orientation ori0 = kine::Orientation::randomRotation();
-        Vector3 linvel0 = Vector3::Random();
-        Vector3 angvel0 = Vector3::Random();
-        Vector3 linacc0 = Vector3::Random();
-        Vector3 angacc0 = Vector3::Random();
-
-        k.reset();
-        k.position = pos0;
-        k.orientation = ori0;
-        k.linVel = linvel0;
-        k.angVel = angvel0;
-        k.linAcc = linacc0;
-        k.angAcc = angacc0;
-
-        l = k;
-
-        double dt = 0.001;
-        k.integrate(dt);
-
-
-        k0.reset();
-        k1.reset();
-
-        if (flag0 & Flags::position)
-        {
-            k0.position = l.position;
-        }
-        if (flag0 & Flags::orientation)
-        {
-            k0.orientation = l.orientation;
-        }
-        if (flag0 & Flags::linVel)
-        {
-            k0.linVel = l.linVel;
-        }
-        if (flag0 & Flags::angVel)
-        {
-            k0.angVel = l.angVel;
-        }
-        if (flag0 & Flags::linAcc)
-        {
-            k0.linAcc = l.linAcc;
-        }
-        if (flag0 & Flags::angAcc)
-        {
-            k0.angAcc = l.angAcc;
-        }
-
-        if (flag1 & Flags::position)
-        {
-            k1.position = k.position;
-        }
-        if (flag1 & Flags::orientation)
-        {
-            k1.orientation = k.orientation;
-        }
-        if (flag1 & Flags::linVel)
-        {
-            k1.linVel = k.linVel;
-        }
-        if (flag1 & Flags::angVel)
-        {
-            k1.angVel = k.angVel;
-        }
-        if (flag1 & Flags::linAcc)
-        {
-            k1.linAcc = k.linAcc;
-        }
-        if (flag1 & Flags::angAcc)
-        {
-            k1.angAcc = k.angAcc;
-        }
-
-
-        if ((flag0 = (flag0+1) & Flags::all)==0) ///update the flags to span all the possibilties
-            flag1 = (flag1+1) & Flags::all;
-
-        kine::Kinematics::Flags::Byte flag =BOOST_BINARY(000000);
-
-        if (k1.position.isSet() ||
-            (k0.position.isSet() && k0.linVel.isSet() && k0.linAcc.isSet())
-           )
-        {
-            flag = flag | kine::Kinematics::Flags::position;
-        }
-        if (k1.orientation.isSet() ||
-            (k0.orientation.isSet() && k0.angVel.isSet() && k0.angAcc.isSet())
-            )
-        {
-            flag = flag | kine::Kinematics::Flags::orientation;
-        }
-        if (k1.linVel.isSet() ||
-            (k0.position.isSet() && k1.position.isSet()) ||
-            (k0.linAcc.isSet() && k0.linVel.isSet())
-            )
-        {
-            flag = flag | kine::Kinematics::Flags::linVel;
-        }
-        if (k1.angVel.isSet() ||
-            (k0.orientation.isSet() && k1.orientation.isSet()) ||
-            (k0.angVel.isSet() && k0.angAcc.isSet())
-           )
-        {
-            flag = flag | kine::Kinematics::Flags::angVel;
-        }
-        if (k1.linAcc.isSet() ||
-             (k0.linVel.isSet() && k1.linVel.isSet())||
-             (k0.linVel.isSet() && k0.position.isSet() && k1.position.isSet())
-            )
-        {
-            flag = flag | kine::Kinematics::Flags::linAcc;
-        }
-        if (k1.angAcc.isSet()||
-            (k0.angVel.isSet() && k1.angVel.isSet()) ||
-            (k0.angVel.isSet() && k0.orientation.isSet() && k1.orientation.isSet())
-            )
-        {
-            flag = flag | kine::Kinematics::Flags::angAcc;
-        }
-
-
-        k0.update(k1,dt,flag);
-
-        if (k0.position.isSet())
-        {
-            err += (k.position()-k0.position()).squaredNorm();
-        }
-        if (k0.orientation.isSet())
-        {
-            err += (k.orientation.differentiate(k0.orientation)).squaredNorm();
-        }
-        if (k0.linVel.isSet())
-        {
-            if ((k.linVel()-k0.linVel()).squaredNorm()<1e-10)
-            {
-                err +=  (k.linVel()-k0.linVel()).squaredNorm();
-            }
-            else
-            {
-                err += ((k.position()-l.position())/dt-k0.linVel()).squaredNorm();
-            }
-        }
-        if (k0.angVel.isSet())
-        {
-            if ((k.angVel()-k0.angVel()).squaredNorm()<1e-10)
-            {
-                err +=  (k.angVel()-k0.angVel()).squaredNorm();
-            }
-            else
-            {
-                err += (l.orientation.differentiate(k.orientation)/dt-k0.angVel()).squaredNorm();
-            }
-        }
-        if (k0.linAcc.isSet())
-        {
-            if ((k.linAcc()-k0.linAcc()).squaredNorm() < 1e-10)
-            {
-                err +=(k.linAcc()-k0.linAcc()).squaredNorm();
-            }
-            else
-            {
-                err +=(k.linAcc()-2*k0.linAcc()).squaredNorm();
-            }
-        }
-        if (k0.angAcc.isSet())
-        {
-            if ((k.angAcc()-k0.angAcc()).squaredNorm()< 1e-10)
-            {
-                err +=(k.angAcc()-k0.angAcc()).squaredNorm();
-            }
-            else
-            {
-                 err +=(k.angAcc()-2*k0.angAcc()).squaredNorm();
-            }
-        }
-
-//        std::cout<< i<<" "<<err << std::endl;
-
-        if (err>threshold )
-        {
-            break;
-        }
-
+      k2.orientation.setZeroRotation();
     }
 
-    std::cout << "Error 2 : " << err <<std::endl;
+    k = ((k0 * k2) * k2.getInverse()) * k0.getInverse();
 
-    if (err>threshold )
+    if(k.position.isSet())
     {
-        std::cout << "Error too large !" <<std::endl;
-        return errcode;
+      err += k.position().squaredNorm();
+    }
+    if(k.orientation.isSet())
+    {
+      err += k.orientation.toRotationVector().squaredNorm();
+    }
+    if(k.linVel.isSet())
+    {
+      err += k.linVel().squaredNorm();
+    }
+    if(k.angVel.isSet())
+    {
+      err += k.angVel().squaredNorm();
+    }
+    if(k.linAcc.isSet())
+    {
+      err += k.linAcc().squaredNorm();
+    }
+    if(k.angAcc.isSet())
+    {
+      err += k.angAcc().squaredNorm();
+    }
+  }
+
+  std::cout << "Error 1 : " << err << std::endl;
+
+  if(err > threshold)
+  {
+    std::cout << "Error too large : " << err << std::endl;
+    return errcode;
+  }
+
+  err = 0;
+
+  threshold = 1e-19 * count;
+
+  flag0 = BOOST_BINARY(000000);
+  flag1 = BOOST_BINARY(000000);
+
+  for(int i = 0; i < count; i++)
+  {
+    Vector3 pos0 = Vector3::Random();
+    kine::Orientation ori0 = kine::Orientation::randomRotation();
+    Vector3 linvel0 = Vector3::Random();
+    Vector3 angvel0 = Vector3::Random();
+    Vector3 linacc0 = Vector3::Random();
+    Vector3 angacc0 = Vector3::Random();
+
+    k.reset();
+    k.position = pos0;
+    k.orientation = ori0;
+    k.linVel = linvel0;
+    k.angVel = angvel0;
+    k.linAcc = linacc0;
+    k.angAcc = angacc0;
+
+    l = k;
+
+    double dt = 0.001;
+    k.integrate(dt);
+
+    k0.reset();
+    k1.reset();
+
+    if(flag0 & Flags::position)
+    {
+      k0.position = l.position;
+    }
+    if(flag0 & Flags::orientation)
+    {
+      k0.orientation = l.orientation;
+    }
+    if(flag0 & Flags::linVel)
+    {
+      k0.linVel = l.linVel;
+    }
+    if(flag0 & Flags::angVel)
+    {
+      k0.angVel = l.angVel;
+    }
+    if(flag0 & Flags::linAcc)
+    {
+      k0.linAcc = l.linAcc;
+    }
+    if(flag0 & Flags::angAcc)
+    {
+      k0.angAcc = l.angAcc;
     }
 
+    if(flag1 & Flags::position)
+    {
+      k1.position = k.position;
+    }
+    if(flag1 & Flags::orientation)
+    {
+      k1.orientation = k.orientation;
+    }
+    if(flag1 & Flags::linVel)
+    {
+      k1.linVel = k.linVel;
+    }
+    if(flag1 & Flags::angVel)
+    {
+      k1.angVel = k.angVel;
+    }
+    if(flag1 & Flags::linAcc)
+    {
+      k1.linAcc = k.linAcc;
+    }
+    if(flag1 & Flags::angAcc)
+    {
+      k1.angAcc = k.angAcc;
+    }
 
-    return 0;
+    if((flag0 = (flag0 + 1) & Flags::all) == 0) /// update the flags to span all the possibilties
+      flag1 = (flag1 + 1) & Flags::all;
+
+    kine::Kinematics::Flags::Byte flag = BOOST_BINARY(000000);
+
+    if(k1.position.isSet() || (k0.position.isSet() && k0.linVel.isSet() && k0.linAcc.isSet()))
+    {
+      flag = flag | kine::Kinematics::Flags::position;
+    }
+    if(k1.orientation.isSet() || (k0.orientation.isSet() && k0.angVel.isSet() && k0.angAcc.isSet()))
+    {
+      flag = flag | kine::Kinematics::Flags::orientation;
+    }
+    if(k1.linVel.isSet() || (k0.position.isSet() && k1.position.isSet()) || (k0.linAcc.isSet() && k0.linVel.isSet()))
+    {
+      flag = flag | kine::Kinematics::Flags::linVel;
+    }
+    if(k1.angVel.isSet() || (k0.orientation.isSet() && k1.orientation.isSet())
+       || (k0.angVel.isSet() && k0.angAcc.isSet()))
+    {
+      flag = flag | kine::Kinematics::Flags::angVel;
+    }
+    if(k1.linAcc.isSet() || (k0.linVel.isSet() && k1.linVel.isSet())
+       || (k0.linVel.isSet() && k0.position.isSet() && k1.position.isSet()))
+    {
+      flag = flag | kine::Kinematics::Flags::linAcc;
+    }
+    if(k1.angAcc.isSet() || (k0.angVel.isSet() && k1.angVel.isSet())
+       || (k0.angVel.isSet() && k0.orientation.isSet() && k1.orientation.isSet()))
+    {
+      flag = flag | kine::Kinematics::Flags::angAcc;
+    }
+
+    k0.update(k1, dt, flag);
+
+    if(k0.position.isSet())
+    {
+      err += (k.position() - k0.position()).squaredNorm();
+    }
+    if(k0.orientation.isSet())
+    {
+      err += (k.orientation.differentiate(k0.orientation)).squaredNorm();
+    }
+    if(k0.linVel.isSet())
+    {
+      if((k.linVel() - k0.linVel()).squaredNorm() < 1e-10)
+      {
+        err += (k.linVel() - k0.linVel()).squaredNorm();
+      }
+      else
+      {
+        err += ((k.position() - l.position()) / dt - k0.linVel()).squaredNorm();
+      }
+    }
+    if(k0.angVel.isSet())
+    {
+      if((k.angVel() - k0.angVel()).squaredNorm() < 1e-10)
+      {
+        err += (k.angVel() - k0.angVel()).squaredNorm();
+      }
+      else
+      {
+        err += (l.orientation.differentiate(k.orientation) / dt - k0.angVel()).squaredNorm();
+      }
+    }
+    if(k0.linAcc.isSet())
+    {
+      if((k.linAcc() - k0.linAcc()).squaredNorm() < 1e-10)
+      {
+        err += (k.linAcc() - k0.linAcc()).squaredNorm();
+      }
+      else
+      {
+        err += (k.linAcc() - 2 * k0.linAcc()).squaredNorm();
+      }
+    }
+    if(k0.angAcc.isSet())
+    {
+      if((k.angAcc() - k0.angAcc()).squaredNorm() < 1e-10)
+      {
+        err += (k.angAcc() - k0.angAcc()).squaredNorm();
+      }
+      else
+      {
+        err += (k.angAcc() - 2 * k0.angAcc()).squaredNorm();
+      }
+    }
+
+    //        std::cout<< i<<" "<<err << std::endl;
+
+    if(err > threshold)
+    {
+      break;
+    }
+  }
+
+  std::cout << "Error 2 : " << err << std::endl;
+
+  if(err > threshold)
+  {
+    std::cout << "Error too large !" << std::endl;
+    return errcode;
+  }
+
+  return 0;
 }
 
 int testKineticsObserverCodeAccessor(int errorcode)
 {
-    double error =0;
-    double dt = 0.001;
+  double error = 0;
+  double dt = 0.001;
 
-    double mass = 100;
-    KineticsObserver o(4,2);
+  double mass = 100;
+  KineticsObserver o(4, 2);
 
-    Vector x0(o.getStateSize());
-    x0.setZero();
-    Vector xf(x0);
-    Vector xs(x0);
+  Vector x0(o.getStateSize());
+  x0.setZero();
+  Vector xf(x0);
+  Vector xs(x0);
 
-    o.setSamplingTime(dt);
+  o.setSamplingTime(dt);
 
-    Kinematics stateKine;
+  Kinematics stateKine;
 
-    stateKine.position.set() << 0.1,0,0.7;
-    stateKine.orientation =  Vector3(0,0,0);
-    stateKine.linVel.set().setZero();
-    stateKine.angVel.set().setZero();
+  stateKine.position.set() << 0.1, 0, 0.7;
+  stateKine.orientation = Vector3(0, 0, 0);
+  stateKine.linVel.set().setZero();
+  stateKine.angVel.set().setZero();
 
-    o.setStateVector(x0);
+  o.setStateVector(x0);
 
-    o.setStateKinematics(stateKine);
-    o.setGyroBias(Vector3(1,2,3));
+  o.setStateKinematics(stateKine);
+  o.setGyroBias(Vector3(1, 2, 3));
 
-    Vector6 wrench;
-    wrench << 4,5,6,7,8,9;
+  Vector6 wrench;
+  wrench << 4, 5, 6, 7, 8, 9;
 
-    o.setStateUnmodeledWrench(wrench);
+  o.setStateUnmodeledWrench(wrench);
 
-    Vector x = o.getStateVector();
-    stateObservation::TimeIndex index = o.getStateVectorSampleTime();
+  Vector x = o.getStateVector();
+  stateObservation::TimeIndex index = o.getStateVectorSampleTime();
 
-    Kinematics contactKine;
-    contactKine.position.set()<<0,0.1,0;
-    contactKine.orientation.setZeroRotation();
+  Kinematics contactKine;
+  contactKine.position.set() << 0, 0.1, 0;
+  contactKine.orientation.setZeroRotation();
 
-    o.addContact(contactKine,0);
+  o.addContact(contactKine, 0);
 
-    Matrix3 linStiffness,angStiffness,linDamping,angDamping;
-    linStiffness.setZero();
-    linStiffness.diagonal().setConstant(50000);
+  Matrix3 linStiffness, angStiffness, linDamping, angDamping;
+  linStiffness.setZero();
+  linStiffness.diagonal().setConstant(50000);
 
-    angStiffness.setZero();
-    angStiffness.diagonal().setConstant(400);
+  angStiffness.setZero();
+  angStiffness.diagonal().setConstant(400);
 
-    linDamping.setZero();
-    linDamping.diagonal().setConstant(500);
+  linDamping.setZero();
+  linDamping.diagonal().setConstant(500);
 
-    angDamping.setZero();
-    angDamping.diagonal().setConstant(20);
+  angDamping.setZero();
+  angDamping.diagonal().setConstant(20);
 
-    contactKine.position.set()<<0,-0.1,0;
-    o.addContact(contactKine,linStiffness,linDamping,angStiffness,angDamping,3);
+  contactKine.position.set() << 0, -0.1, 0;
+  o.addContact(contactKine, linStiffness, linDamping, angStiffness, angDamping, 3);
 
-    Matrix12 initialCov, processCov;
+  Matrix12 initialCov, processCov;
 
-    initialCov.setZero();
-    initialCov.diagonal().setConstant(0.01);
-    processCov.setZero();
-    processCov.diagonal().setConstant(0.0001);
+  initialCov.setZero();
+  initialCov.diagonal().setConstant(0.01);
+  processCov.setZero();
+  processCov.diagonal().setConstant(0.0001);
 
-    contactKine.position.set()<< 1,0.1,0;
-    int i = o.addContact(contactKine,initialCov,processCov,-1);
+  contactKine.position.set() << 1, 0.1, 0;
+  int i = o.addContact(contactKine, initialCov, processCov, -1);
 
-    (void)i; ///avoid warning in release mode
-    assert(i==1);
+  (void)i; /// avoid warning in release mode
+  assert(i == 1);
 
-    contactKine.position.set() << 1,-0.1,0;
-    o.addContact(contactKine,initialCov,processCov,linDamping,
-                        linStiffness,angStiffness,angDamping,2);
+  contactKine.position.set() << 1, -0.1, 0;
+  o.addContact(contactKine, initialCov, processCov, linDamping, linStiffness, angStiffness, angDamping, 2);
 
+  std::cout << index << " " << x.transpose() << std::endl;
 
+  o.update();
 
-    std::cout << index << " " << x.transpose() << std::endl;
+  Kinematics k = o.getKinematics();
 
-    o.update();
+  std::cout << k;
 
-    Kinematics k = o.getKinematics();
+  Kinematics l = o.getKinematicsOf(k);
 
-    std::cout << k;
+  std::cout << l;
 
-    Kinematics l = o.getKinematicsOf(k);
+  std::cout << o.kineIndex() << " " << o.posIndex() << " " << o.oriIndex() << " " << o.linVelIndex() << " "
+            << o.angVelIndex() << " " << o.gyroBiasIndex(0) << " " << o.gyroBiasIndex(1) << " "
+            << o.unmodeledWrenchIndex() << " " << o.unmodeledForceIndex() << " " << o.unmodeledTorqueIndex() << " "
+            << o.contactsIndex() << " " << o.contactIndex(0) << " " << o.contactKineIndex(0) << " "
+            << o.contactPosIndex(0) << " " << o.contactOriIndex(0) << " " << o.contactForceIndex(0) << " "
+            << o.contactTorqueIndex(0) << " " << o.contactWrenchIndex(0) << " " <<
 
-    std::cout << l;
+      o.contactIndex(1) << " " << o.contactKineIndex(1) << " " << o.contactPosIndex(1) << " " << o.contactOriIndex(1)
+            << " " << o.contactForceIndex(1) << " " << o.contactTorqueIndex(1) << " " << o.contactWrenchIndex(1) << " "
+            <<
 
-    std::cout << o.kineIndex() << " " <<
-     o.posIndex() << " " <<
-     o.oriIndex() << " " <<
-     o.linVelIndex() << " " <<
-     o.angVelIndex() << " " <<
-     o.gyroBiasIndex(0) << " " <<
-     o.gyroBiasIndex(1) << " " <<
-     o.unmodeledWrenchIndex() << " " <<
-     o.unmodeledForceIndex() << " " <<
-     o.unmodeledTorqueIndex() << " " <<
-     o.contactsIndex() << " " <<
-     o.contactIndex(0) << " " <<
-     o.contactKineIndex(0) << " " <<
-     o.contactPosIndex(0) << " " <<
-     o.contactOriIndex(0) << " " <<
-     o.contactForceIndex(0) << " " <<
-     o.contactTorqueIndex(0) << " " <<
-     o.contactWrenchIndex(0) << " " <<
+      o.contactIndex(2) << " " << o.contactKineIndex(2) << " " << o.contactPosIndex(2) << " " << o.contactOriIndex(2)
+            << " " << o.contactForceIndex(2) << " " << o.contactTorqueIndex(2) << " " << o.contactWrenchIndex(2) << " "
+            <<
 
-     o.contactIndex(1) << " " <<
-     o.contactKineIndex(1) << " " <<
-     o.contactPosIndex(1) << " " <<
-     o.contactOriIndex(1) << " " <<
-     o.contactForceIndex(1) << " " <<
-     o.contactTorqueIndex(1) << " " <<
-     o.contactWrenchIndex(1) << " " <<
+      o.contactIndex(3) << " " << o.contactKineIndex(3) << " " << o.contactPosIndex(3) << " " << o.contactOriIndex(3)
+            << " " << o.contactForceIndex(3) << " " << o.contactTorqueIndex(3) << " " << o.contactWrenchIndex(3) << " "
+            << std::endl;
 
-     o.contactIndex(2) << " " <<
-     o.contactKineIndex(2) << " " <<
-     o.contactPosIndex(2) << " " <<
-     o.contactOriIndex(2) << " " <<
-     o.contactForceIndex(2) << " " <<
-     o.contactTorqueIndex(2) << " " <<
-     o.contactWrenchIndex(2) << " " <<
+  std::cout << o.kineIndexTangent() << " " << o.posIndexTangent() << " " << o.oriIndexTangent() << " "
+            << o.linVelIndexTangent() << " " << o.angVelIndexTangent() << " " << o.gyroBiasIndexTangent(0) << " "
+            << o.gyroBiasIndexTangent(1) << " " << o.unmodeledWrenchIndexTangent() << " "
+            << o.unmodeledForceIndexTangent() << " " << o.unmodeledTorqueIndexTangent() << " "
+            << o.contactsIndexTangent() << " " <<
 
-     o.contactIndex(3) << " " <<
-     o.contactKineIndex(3) << " " <<
-     o.contactPosIndex(3) << " " <<
-     o.contactOriIndex(3) << " " <<
-     o.contactForceIndex(3) << " " <<
-     o.contactTorqueIndex(3) << " " <<
-     o.contactWrenchIndex(3) << " " << std::endl;
+      o.contactIndexTangent(0) << " " << o.contactKineIndexTangent(0) << " " << o.contactPosIndexTangent(0) << " "
+            << o.contactOriIndexTangent(0) << " " << o.contactForceIndexTangent(0) << " "
+            << o.contactTorqueIndexTangent(0) << " " << o.contactWrenchIndexTangent(0) << " " <<
 
+      o.contactIndexTangent(1) << " " << o.contactKineIndexTangent(1) << " " << o.contactPosIndexTangent(1) << " "
+            << o.contactOriIndexTangent(1) << " " << o.contactForceIndexTangent(1) << " "
+            << o.contactTorqueIndexTangent(1) << " " << o.contactWrenchIndexTangent(1) << " " <<
 
-    std::cout << o.kineIndexTangent() << " " <<
-     o.posIndexTangent() << " " <<
-     o.oriIndexTangent() << " " <<
-     o.linVelIndexTangent() << " " <<
-     o.angVelIndexTangent() << " " <<
-     o.gyroBiasIndexTangent(0) << " " <<
-     o.gyroBiasIndexTangent(1) << " " <<
-     o.unmodeledWrenchIndexTangent() << " " <<
-     o.unmodeledForceIndexTangent() << " " <<
-     o.unmodeledTorqueIndexTangent() << " " <<
-     o.contactsIndexTangent() << " " <<
+      o.contactIndexTangent(2) << " " << o.contactKineIndexTangent(2) << " " << o.contactPosIndexTangent(2) << " "
+            << o.contactOriIndexTangent(2) << " " << o.contactForceIndexTangent(2) << " "
+            << o.contactTorqueIndexTangent(2) << " " << o.contactWrenchIndexTangent(2) << " " <<
 
-     o.contactIndexTangent( 0 ) << " " <<
-     o.contactKineIndexTangent( 0 ) << " " <<
-     o.contactPosIndexTangent( 0 ) << " " <<
-     o.contactOriIndexTangent( 0 ) << " " <<
-     o.contactForceIndexTangent( 0 ) << " " <<
-     o.contactTorqueIndexTangent( 0 ) << " " <<
-     o.contactWrenchIndexTangent( 0 ) << " " <<
+      o.contactIndexTangent(3) << " " << o.contactKineIndexTangent(3) << " " << o.contactPosIndexTangent(3) << " "
+            << o.contactOriIndexTangent(3) << " " << o.contactForceIndexTangent(3) << " "
+            << o.contactTorqueIndexTangent(3) << " " << o.contactWrenchIndexTangent(3) << " " << std::endl;
 
-     o.contactIndexTangent( 1 ) << " " <<
-     o.contactKineIndexTangent( 1 ) << " " <<
-     o.contactPosIndexTangent( 1 ) << " " <<
-     o.contactOriIndexTangent( 1 ) << " " <<
-     o.contactForceIndexTangent( 1 ) << " " <<
-     o.contactTorqueIndexTangent( 1 ) << " " <<
-     o.contactWrenchIndexTangent( 1 ) << " " <<
+  o.setWithUnmodeledWrench(true);
+  o.setWithAccelerationEstimation(true);
+  o.setWithGyroBias(true);
 
-     o.contactIndexTangent( 2 ) << " " <<
-     o.contactKineIndexTangent( 2 ) << " " <<
-     o.contactPosIndexTangent( 2 ) << " " <<
-     o.contactOriIndexTangent( 2 ) << " " <<
-     o.contactForceIndexTangent( 2 ) << " " <<
-     o.contactTorqueIndexTangent( 2 ) << " " <<
-     o.contactWrenchIndexTangent( 2 ) << " " <<
+  Matrix3 acceleroCov, gyroCov;
 
-     o.contactIndexTangent( 3 ) << " " <<
-     o.contactKineIndexTangent( 3 ) << " " <<
-     o.contactPosIndexTangent( 3 ) << " " <<
-     o.contactOriIndexTangent( 3 ) << " " <<
-     o.contactForceIndexTangent( 3 ) << " " <<
-     o.contactTorqueIndexTangent( 3 ) << " " <<
-     o.contactWrenchIndexTangent( 3 ) << " " << std::endl;
+  acceleroCov = Matrix3::Identity() * 1e-4;
+  gyroCov = Matrix3::Identity() * 1e-8;
 
-    o.setWithUnmodeledWrench(true);
-    o.setWithAccelerationEstimation(true );
-    o.setWithGyroBias(true);
+  o.setIMUDefaultCovarianceMatrix(acceleroCov, gyroCov);
 
-    Matrix3 acceleroCov, gyroCov;
+  Matrix6 wrenchCov;
 
-    acceleroCov =  Matrix3::Identity()*1e-4;
-    gyroCov = Matrix3::Identity()*1e-8;
+  wrenchCov << Matrix3::Identity() * 1e-0, Matrix3::Zero(), Matrix3::Zero(), Matrix3::Identity() * 1e-4;
 
-    o.setIMUDefaultCovarianceMatrix(acceleroCov,gyroCov);
+  o.setContactWrenchSensorDefaultCovarianceMatrix(wrenchCov);
 
-    Matrix6 wrenchCov;
+  o.setMass(mass);
 
-    wrenchCov <<   Matrix3::Identity()*1e-0,        Matrix3::Zero(),
-                   Matrix3::Zero(),                 Matrix3::Identity()*1e-4;
+  Vector state1 = o.getEKF().stateVectorRandom();
+  Vector state2 = o.getEKF().stateVectorRandom();
+  Vector statediff;
+  o.stateDifference(state1, state2, statediff);
+  Vector state3;
+  o.stateSum(state2, statediff, state3);
 
-    o.setContactWrenchSensorDefaultCovarianceMatrix(wrenchCov);
+  std::cout << state1.transpose() << std::endl;
+  std::cout << state3.transpose() << std::endl;
 
-    o.setMass(mass);
+  Matrix statecomp(state1.size(), 2);
 
-    Vector state1 = o.getEKF().stateVectorRandom();
-    Vector state2 = o.getEKF().stateVectorRandom();
-    Vector statediff ;
-    o.stateDifference(state1, state2, statediff );
-    Vector state3;
-    o.stateSum(state2, statediff,state3);
+  statecomp << state1, state3;
 
-    std::cout << state1.transpose() <<std::endl;
-    std::cout << state3.transpose() <<std::endl;
+  std::cout << statecomp << std::endl;
 
-    Matrix statecomp(state1.size(),2);
+  std::cout << "Sum error" << (error = o.stateDifference(state1, state3).norm()) << std::endl;
 
-    statecomp << state1, 
-                state3 ;
+  state2 = o.getEKF().stateVectorRandom();
+  statediff = o.getEKF().stateTangentVectorRandom();
 
+  Vector statediff_bis;
+  o.stateSum(state2, statediff, state1);
+  o.stateDifference(state1, state2, statediff_bis);
 
-    std::cout << statecomp <<std::endl;
+  std::cout << statediff.transpose() << std::endl;
+  std::cout << statediff_bis.transpose() << std::endl;
 
-    std::cout <<  "Sum error" <<(error = o.stateDifference(state1 , state3).norm()) << std::endl;
+  Matrix statecompdiff(statediff.size(), 2);
 
-    state2 = o.getEKF().stateVectorRandom();
-    statediff = o.getEKF().stateTangentVectorRandom();
-  
+  statecompdiff << statediff, statediff_bis;
 
-    Vector statediff_bis;
-    o.stateSum(state2,statediff,state1);
-    o.stateDifference(state1,state2,statediff_bis);
+  std::cout << statecompdiff << std::endl;
 
-    std::cout << statediff.transpose() <<std::endl;
-    std::cout << statediff_bis.transpose() <<std::endl;
+  std::cout << "DIff error" << (error += (statediff - statediff_bis).norm()) << std::endl;
 
-    Matrix statecompdiff(statediff.size(),2);
-
-    statecompdiff << statediff, 
-                statediff_bis;
-
-    std::cout << statecompdiff <<std::endl;
-
-    std::cout << "DIff error" << (error += (statediff - statediff_bis).norm()) << std::endl;
-
-    if (error > 1e-8)
-    {
+  if(error > 1e-8)
+  {
     //    return errorcode;
-    }
+  }
 
-    o.clearContacts();
+  o.clearContacts();
 
-    return 0;
+  return 0;
 }
 
 int main()
 {
-    int returnVal;
+  int returnVal;
 
-    if ((returnVal = testOrientation(1))) /// it is not an equality check
-    {
-        std::cout<< "Orientation test failed, code : 1" <<std::endl;
-        return returnVal;
-    }
-    else
-    {
-        std::cout << "Orientation test succeeded" << std::endl;
-    }
+  if((returnVal = testOrientation(1))) /// it is not an equality check
+  {
+    std::cout << "Orientation test failed, code : 1" << std::endl;
+    return returnVal;
+  }
+  else
+  {
+    std::cout << "Orientation test succeeded" << std::endl;
+  }
 
+  if((returnVal = testKinematics(2))) /// it is not an equality check
+  {
+    std::cout << "Kinematics test failed, code : 2" << std::endl;
+    return returnVal;
+  }
+  else
+  {
+    std::cout << "Kinematics test succeeded" << std::endl;
+  }
 
+  if((returnVal = testKineticsObserverCodeAccessor(3)))
+  {
+    std::cout << "Kinetics Observer test failed, code : 3" << std::endl;
+    return returnVal;
+  }
+  else
+  {
+    std::cout << "Kinetics Observer test succeeded" << std::endl;
+  }
 
-    if ((returnVal = testKinematics(2))) /// it is not an equality check
-    {
-        std::cout<< "Kinematics test failed, code : 2" <<std::endl;
-        return returnVal;
-    }
-    else
-    {
-        std::cout << "Kinematics test succeeded" << std::endl;
-    }
-
-    if ((returnVal = testKineticsObserverCodeAccessor(3)))
-    {
-        std::cout<< "Kinetics Observer test failed, code : 3" <<std::endl;
-        return returnVal;
-    }
-    else
-    {
-        std::cout << "Kinetics Observer test succeeded" << std::endl;
-    }
-
-
-
-
-    std::cout<< "test succeeded" <<std::endl;
-    return 0;
+  std::cout << "test succeeded" << std::endl;
+  return 0;
 }

--- a/unit-testings/test_model-base-ekf-flex-estimator-imu.cpp
+++ b/unit-testings/test_model-base-ekf-flex-estimator-imu.cpp
@@ -25,9 +25,15 @@ int test()
   Matrix Cov;
   Cov.resize(6, 6);
   double unitCov = 1e-2;
-  Cov << unitCov, 0, 0, 0, 0, 0, 0, unitCov, 0, 0, 0, 0, 0, 0, unitCov, 0, 0, 0, 0, 0, 0, unitCov, 0, 0, 0, 0, 0, 0,
-      unitCov, 0, 0, 0, 0, 0, 0, unitCov;
-
+  // clang-format off
+  Cov <<  unitCov, 0, 0, 0, 0, 0,
+          0, unitCov, 0, 0, 0, 0,
+          0, 0, unitCov, 0, 0, 0,
+          0, 0, 0, unitCov, 0, 0,
+          0, 0, 0, 0, unitCov, 0,
+          0, 0, 0, 0, 0, unitCov;
+  // clang-format on
+  
   /// Initializations
   // Dimensions
   const Index kinit = 0;
@@ -42,11 +48,56 @@ int test()
 
   // Input initialization
   Vector u0 = Vector::Zero(inputSize - 6 * contactNbr, 1);
-  u0 << 0.0135673, 0.001536, 0.80771, -2.63605e-06, -1.09258e-08, 5.71759e-08, 2.71345, 0.3072, 161.542, 48.1348,
-      46.9498, 1.76068, -0.0863332, -0.594871, -0.0402246, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.098, -6.23712e-11,
-      1.1174, 1.58984e-22, -5.43636e-21, 3.9598e-22, -2.99589e-06, -1.24742e-08, -4.7647e-18, 3.17968e-20, -1.08727e-18,
-      7.91959e-20, -0.000299589, -1.24742e-06, -4.7647e-16, 0, 0, 0, 0, 0,
-      0; /// external forces and moments
+  // clang-format off
+  u0 <<  0.0135673,
+         0.001536,
+         0.80771,
+         -2.63605e-06,
+         -1.09258e-08,
+         5.71759e-08,
+         2.71345,
+         0.3072,
+         161.542,
+         48.1348,
+         46.9498,
+         1.76068,
+         -0.0863332,
+         -0.594871,
+         -0.0402246,
+         0,
+         0,
+         0,
+         0,
+         0,
+         0,
+         0,
+         0,
+         0,
+         0,
+         0,
+         0,
+         -0.098,
+         -6.23712e-11,
+         1.1174,
+         1.58984e-22,
+         -5.43636e-21,
+         3.9598e-22,
+         -2.99589e-06,
+         -1.24742e-08,
+         -4.7647e-18,
+         3.17968e-20,
+         -1.08727e-18,
+         7.91959e-20,
+         -0.000299589,
+         -1.24742e-06,
+         -4.7647e-16,
+         0,
+         0,
+         0,
+         0,
+         0,
+         0; ///external forces and moments
+  // clang-format on
 
   stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU est;
   est.setSamplingPeriod(dt);

--- a/unit-testings/test_model-base-ekf-flex-estimator-imu.cpp
+++ b/unit-testings/test_model-base-ekf-flex-estimator-imu.cpp
@@ -33,7 +33,7 @@ int test()
           0, 0, 0, 0, unitCov, 0,
           0, 0, 0, 0, 0, unitCov;
   // clang-format on
-  
+
   /// Initializations
   // Dimensions
   const Index kinit = 0;

--- a/unit-testings/test_model-base-ekf-flex-estimator-imu.cpp
+++ b/unit-testings/test_model-base-ekf-flex-estimator-imu.cpp
@@ -1,15 +1,14 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 //#include <state-observation/noise/gaussian-white-noise.hpp>
 //#include <state-observation/examples/offline-ekf-flexibility-estimation.hpp>
 //#include <state-observation/dynamical-system/dynamical-system-simulator.hpp>
 //#include <state-observation/tools/miscellaneous-algorithms.hpp>
 
-#include <state-observation/flexibility-estimation/model-base-ekf-flex-estimator-imu.hpp>
 #include <state-observation/config.h>
+#include <state-observation/flexibility-estimation/model-base-ekf-flex-estimator-imu.hpp>
 #include <time.h>
-
 
 using namespace stateObservation;
 
@@ -17,261 +16,209 @@ typedef kine::indexes<kine::rotationVector> indexes;
 
 int test()
 {
-    std::cout << "Starting" << std::endl;
+  std::cout << "Starting" << std::endl;
 
   /// sampling period
-    const double dt=5e-3;
+  const double dt = 5e-3;
 
   /// Measurement noise covariance
-    Matrix Cov;
-    Cov.resize(6,6);
-    double unitCov = 1e-2;
-    Cov <<  unitCov,0,0,0,0,0,
-            0,unitCov,0,0,0,0,
-            0,0,unitCov,0,0,0,
-            0,0,0,unitCov,0,0,
-            0,0,0,0,unitCov,0,
-            0,0,0,0,0,unitCov;
+  Matrix Cov;
+  Cov.resize(6, 6);
+  double unitCov = 1e-2;
+  Cov << unitCov, 0, 0, 0, 0, 0, 0, unitCov, 0, 0, 0, 0, 0, 0, unitCov, 0, 0, 0, 0, 0, 0, unitCov, 0, 0, 0, 0, 0, 0,
+      unitCov, 0, 0, 0, 0, 0, 0, unitCov;
 
   /// Initializations
-    // Dimensions
-    const Index kinit=0;
-    const Index kmax=1400;
-    const unsigned measurementSize=6;
-    (void) measurementSize; ///avoid warning
-    const unsigned inputSize=60;
-    const unsigned stateSize=18;
-    (void) stateSize;
-    unsigned contactNbr = 2;
-    // State initialization => not used here because it is set in model-base-ekf-flex-estimator-imu
+  // Dimensions
+  const Index kinit = 0;
+  const Index kmax = 1400;
+  const unsigned measurementSize = 6;
+  (void)measurementSize; /// avoid warning
+  const unsigned inputSize = 60;
+  const unsigned stateSize = 18;
+  (void)stateSize;
+  unsigned contactNbr = 2;
+  // State initialization => not used here because it is set in model-base-ekf-flex-estimator-imu
 
-     // Input initialization
-    Vector u0=Vector::Zero(inputSize-6*contactNbr,1);
-    u0 <<  0.0135673,
-             0.001536,
-             0.80771,
-             -2.63605e-06,
-             -1.09258e-08,
-             5.71759e-08,
-             2.71345,
-             0.3072,
-             161.542,
-             48.1348,
-             46.9498,
-             1.76068,
-             -0.0863332,
-             -0.594871,
-             -0.0402246,
-             0,
-             0,
-             0,
-             0,
-             0,
-             0,
-             0,
-             0,
-             0,
-             0,
-             0,
-             0,
-             -0.098,
-             -6.23712e-11,
-             1.1174,
-             1.58984e-22,
-             -5.43636e-21,
-             3.9598e-22,
-             -2.99589e-06,
-             -1.24742e-08,
-             -4.7647e-18,
-             3.17968e-20,
-             -1.08727e-18,
-             7.91959e-20,
-             -0.000299589,
-             -1.24742e-06,
-             -4.7647e-16,
-             0,
-             0,
-             0,
-             0,
-             0,
-             0; ///external forces and moments
+  // Input initialization
+  Vector u0 = Vector::Zero(inputSize - 6 * contactNbr, 1);
+  u0 << 0.0135673, 0.001536, 0.80771, -2.63605e-06, -1.09258e-08, 5.71759e-08, 2.71345, 0.3072, 161.542, 48.1348,
+      46.9498, 1.76068, -0.0863332, -0.594871, -0.0402246, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.098, -6.23712e-11,
+      1.1174, 1.58984e-22, -5.43636e-21, 3.9598e-22, -2.99589e-06, -1.24742e-08, -4.7647e-18, 3.17968e-20, -1.08727e-18,
+      7.91959e-20, -0.000299589, -1.24742e-06, -4.7647e-16, 0, 0, 0, 0, 0,
+      0; /// external forces and moments
 
-    stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU est;
-    est.setSamplingPeriod(dt);
-    est.setInput(u0);
-    est.setMeasurementInput(u0);
+  stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU est;
+  est.setSamplingPeriod(dt);
+  est.setInput(u0);
+  est.setMeasurementInput(u0);
 
-    est.setRobotMass(56.8679920);
-    stateObservation::Vector3 v1; v1.setOnes();
-    v1=1000*v1;
-    est.setTorquesLimit(v1);
-    stateObservation::Vector3 v2; v2.setOnes();
-    v2=1000*v2;
-    est.setForcesLimit(v2);
-    est.setKfe(40000*Matrix3::Identity());
-    est.setKte(600*Matrix3::Identity());
-    est.setKfv(600*Matrix3::Identity());
-    est.setKtv(60*Matrix3::Identity());
+  est.setRobotMass(56.8679920);
+  stateObservation::Vector3 v1;
+  v1.setOnes();
+  v1 = 1000 * v1;
+  est.setTorquesLimit(v1);
+  stateObservation::Vector3 v2;
+  v2.setOnes();
+  v2 = 1000 * v2;
+  est.setForcesLimit(v2);
+  est.setKfe(40000 * Matrix3::Identity());
+  est.setKte(600 * Matrix3::Identity());
+  est.setKfv(600 * Matrix3::Identity());
+  est.setKtv(60 * Matrix3::Identity());
 
-   /// Definitions of input vectors
-     // Measurement
-    IndexedVectorArray y;
-    std::cout << "Loading measurements file" << std::endl;
-    y.readVectorsFromFile("inputFiles/source_measurement.dat");
-    std::cout << "Done, size " << y.size()<<  std::endl;
-     // Input
-    IndexedVectorArray u;
-     std::cout << "Loading input file" << std::endl;
-    u.readVectorsFromFile("inputFiles/source_input.dat");
-    std::cout << "Done, size " << u.size()<<  std::endl;
-      //state
-    IndexedVectorArray xRef;
-    std::cout << "Loading reference state file" << std::endl;
-    xRef.readVectorsFromFile("inputFiles/source_state.dat");
-    std::cout << "Done, size " << xRef.size()<<  std::endl;
+  /// Definitions of input vectors
+  // Measurement
+  IndexedVectorArray y;
+  std::cout << "Loading measurements file" << std::endl;
+  y.readVectorsFromFile("inputFiles/source_measurement.dat");
+  std::cout << "Done, size " << y.size() << std::endl;
+  // Input
+  IndexedVectorArray u;
+  std::cout << "Loading input file" << std::endl;
+  u.readVectorsFromFile("inputFiles/source_input.dat");
+  std::cout << "Done, size " << u.size() << std::endl;
+  // state
+  IndexedVectorArray xRef;
+  std::cout << "Loading reference state file" << std::endl;
+  xRef.readVectorsFromFile("inputFiles/source_state.dat");
+  std::cout << "Done, size " << xRef.size() << std::endl;
 
+  /// Definition of ouptut vectors
+  // State: what we want
+  IndexedVectorArray x_output;
+  // Measurement
+  IndexedVectorArray y_output;
+  // Input
+  IndexedVectorArray u_output;
 
-   /// Definition of ouptut vectors
-     // State: what we want
-    IndexedVectorArray x_output;
-     // Measurement
-    IndexedVectorArray y_output;
-     // Input
-    IndexedVectorArray u_output;
+  IndexedVectorArray deltax_output;
 
-    IndexedVectorArray deltax_output;
+  est.setMeasurementNoiseCovariance(Cov);
 
+  est.setContactsNumber(contactNbr);
 
-    est.setMeasurementNoiseCovariance(Cov);
+  Vector flexibility;
+  flexibility.resize(18);
+  Vector xdifference(flexibility);
 
-    est.setContactsNumber(contactNbr);
+  tools::SimplestStopwatch stopwatch;
+  IndexedVectorArray computationTime_output;
+  double computationTime_sum = 0;
+  Vector computeTime;
+  computeTime.resize(1);
 
+  Vector errorsum = Vector::Zero(12);
 
-    Vector flexibility;
-    flexibility.resize(18);
-    Vector xdifference(flexibility);
+  est.setContactModel(
+      stateObservation::flexibilityEstimation::ModelBaseEKFFlexEstimatorIMU::contactModel::elasticContact);
 
-    tools::SimplestStopwatch stopwatch;
-    IndexedVectorArray computationTime_output;
-    double computationTime_sum=0;
-    Vector computeTime;
-    computeTime.resize(1);
+  // for (TimeIndex k=u.getFirstIndex(); k<u.getNextIndex();++k)
+  // {
+  //   Vector uk(est.getInputSize());
+  //   uk.head<42>() = u[k].head<42>();
+  //   uk.segment<6>(42) << 0,0,0,0,0,0;
+  //   for (unsigned  i =0; i<contactNbr ;++i)
+  //   {
+  //     uk.segment<6>(42+12*i)=u[k].segment<6>(42+6*i);
+  //     uk.segment<6>(42+12*i+6)<<0,0,0,0,0,0;
+  //   }
 
-    Vector errorsum=Vector::Zero(12);
+  //   u[k]=uk;
+  // }
 
-    est.setContactModel(stateObservation::flexibilityEstimation::
-                ModelBaseEKFFlexEstimatorIMU::contactModel::elasticContact);
+  std::cout << "Beginning reconstruction " << std::endl;
+  for(Index k = kinit + 2; k < kmax; ++k)
+  {
+    est.setMeasurement(y[k]);
+    est.setMeasurementInput(u[k]);
 
-    // for (TimeIndex k=u.getFirstIndex(); k<u.getNextIndex();++k)
-    // {
-    //   Vector uk(est.getInputSize());
-    //   uk.head<42>() = u[k].head<42>();
-    //   uk.segment<6>(42) << 0,0,0,0,0,0;
-    //   for (unsigned  i =0; i<contactNbr ;++i)
-    //   {
-    //     uk.segment<6>(42+12*i)=u[k].segment<6>(42+6*i);
-    //     uk.segment<6>(42+12*i+6)<<0,0,0,0,0,0;
-    //   }
+    stopwatch.start();
 
-    //   u[k]=uk;
-    // }
+    flexibility = est.getFlexibilityVector();
 
-    std::cout << "Beginning reconstruction "<<std::endl;
-    for (Index k=kinit+2;k<kmax;++k)
+    computeTime[0] = stopwatch.stop();
+
+    xdifference = flexibility.head<12>() - xRef[k].head<12>();
+
+    x_output.setValue(flexibility, k);
+    y_output.setValue(y[k], k);
+    u_output.setValue(u[k], k);
+    deltax_output.setValue(xdifference, k);
+
+    computationTime_output.setValue(computeTime, k);
+    computationTime_sum += computeTime[0];
+  }
+
+  std::cout << "Completed " << std::endl;
+
+  computeTime[0] = computationTime_sum / (kmax - kinit - 2);
+  computationTime_output.setValue(computeTime, kmax);
+  computationTime_output.writeInFile("computationTime.dat");
+
+  /// this code is useful to generate new input files
+  // x_output.writeInFile("unit-testings/result-state.dat");
+  // y_output.writeInFile("unit-testings/result-measurement.dat");
+  // u_output.writeInFile("unit-testings/result-input.dat");
+
+  errorsum = errorsum / (kmax - kinit - 2);
+
+  Vector error(4);
+
+  typedef flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state State;
+
+  error(0) = sqrt((errorsum(State::pos) + errorsum(State::pos + 1) + errorsum(State::pos + 2)));
+  error(1) = sqrt((errorsum(State::linVel) + errorsum(State::linVel + 1) + errorsum(State::linVel + 2)));
+  error(2) = sqrt((errorsum(State::ori) + errorsum(State::ori + 1) + errorsum(State::ori + 2)));
+  error(3) = sqrt((errorsum(State::angVel) + errorsum(State::angVel + 1) + errorsum(State::angVel + 2)));
+
+  std::cout << "Mean computation time " << computeTime[0] << std::endl;
+
+  std::cout << "Mean error " << error.transpose() << std::endl;
+
+  double posgain = 40000;
+  double linvelgain = 600;
+
+  double origain = 10;
+  double angvelgain = 1;
+
+  double syntherror = posgain * error(0) + linvelgain * error(1) + origain * error(2) + angvelgain * error(3);
+
+  std::cout << "Synthetic error " << posgain * error(0) << " + " << linvelgain * error(1) << " + " << origain * error(2)
+            << " + " << angvelgain * error(3) << " = " << syntherror << std::endl;
+
+  if(syntherror == syntherror)
+  {
+    if(syntherror > 0.2)
     {
-        est.setMeasurement(y[k]);
-        est.setMeasurementInput(u[k]);
-
-        stopwatch.start();
-
-        flexibility = est.getFlexibilityVector();
-
-        computeTime[0]=stopwatch.stop();
-
-        xdifference =flexibility.head<12>()-xRef[k].head<12>();
-
-        x_output.setValue(flexibility,k);
-        y_output.setValue(y[k],k);
-        u_output.setValue(u[k],k);
-        deltax_output.setValue(xdifference,k);
-
-        computationTime_output.setValue(computeTime,k);
-        computationTime_sum+=computeTime[0];
+      std::cout << "Failed : error is too big !!" << std::endl << "The end" << std::endl;
+      return 1;
     }
-
-    std::cout << "Completed "<<std::endl;
-
-    computeTime[0]=computationTime_sum/(kmax-kinit-2);
-    computationTime_output.setValue(computeTime,kmax);
-    computationTime_output.writeInFile("computationTime.dat");
-
-    /// this code is useful to generate new input files
-    // x_output.writeInFile("unit-testings/result-state.dat");
-    // y_output.writeInFile("unit-testings/result-measurement.dat");
-    // u_output.writeInFile("unit-testings/result-input.dat");
-
-    errorsum = errorsum/(kmax-kinit-2);
-
-    Vector error(4);
-
-    typedef flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state State;
-
-    error(0) = sqrt((errorsum(State::pos) + errorsum(State::pos+1) + errorsum(State::pos+2)));
-    error(1) = sqrt((errorsum(State::linVel) + errorsum(State::linVel+1) + errorsum(State::linVel+2)));
-    error(2) = sqrt((errorsum(State::ori) + errorsum(State::ori+1) + errorsum(State::ori+2)));
-    error(3) = sqrt((errorsum(State::angVel) + errorsum(State::angVel+1) + errorsum(State::angVel+2)));
-
-    std::cout << "Mean computation time " << computeTime[0] <<std::endl;
-
-    std::cout << "Mean error " << error.transpose() <<std::endl;
-
-    double posgain = 40000;
-    double linvelgain = 600;
-
-    double origain = 10;
-    double angvelgain = 1;
-
-
-    double syntherror = posgain*error(0)+ linvelgain*error(1) + origain*error(2) + angvelgain*error(3);
-
-    std::cout << "Synthetic error " << posgain*error(0) << " + " << linvelgain*error(1)
-                          << " + " << origain*error(2) << " + " << angvelgain*error(3)
-                          << " = " << syntherror << std::endl;
-
-
-    if (syntherror == syntherror)
+  }
+  else
+  {
+    if(syntherror > 0.2)
     {
-      if (syntherror>0.2)
-      {
-        std::cout << "Failed : error is too big !!"<< std::endl <<"The end" << std::endl;
-        return 1;
-      }
+      std::cout << "Failed : NaN !!" << std::endl << "The end" << std::endl;
+      return 2;
     }
-    else
-    {
-      if (syntherror>0.2)
-      {
-        std::cout << "Failed : NaN !!"<< std::endl <<"The end" << std::endl;
-        return 2;
-      }
-    }
+  }
 
-    if (Release_BUILD)
+  if(Release_BUILD)
+  {
+    if(computeTime[0] > 2e5)
     {
-        if (computeTime[0] > 2e5)
-        {
-            std::cout << "Failed : Computation time is too long !!" << std::endl << "The end" << std::endl;
-            return 2;
-        }
+      std::cout << "Failed : Computation time is too long !!" << std::endl << "The end" << std::endl;
+      return 2;
     }
+  }
 
-    std::cout << "Succeed !!"<< std::endl <<"The end" << std::endl;
-    return 0;
+  std::cout << "Succeed !!" << std::endl << "The end" << std::endl;
+  return 0;
 }
 
 int main()
 {
 
-    return test();
-
+  return test();
 }

--- a/unit-testings/tools.hpp
+++ b/unit-testings/tools.hpp
@@ -1,30 +1,29 @@
 #ifndef OBSERVATIONTOOLSHPP
 #define OBSERVATIONTOOLSHPP
 
-#include <Eigen/Core>
 #include <boost/random.hpp>
+#include <Eigen/Core>
 
 namespace stateObserver
 {
-    namespace unitTesting
-    {
-        class Tools
-        {
-        public:
+namespace unitTesting
+{
+class Tools
+{
+public:
+  // add White Gaussian Noise to a vector
+  // having a given bias and standard deviation(std)
+  static Eigen::MatrixXd getWGNoise(const Eigen::MatrixXd & std,
+                                    const Eigen::MatrixXd & bias,
+                                    Index rows,
+                                    Index cols = 1);
 
-            //add White Gaussian Noise to a vector
-            //having a given bias and standard deviation(std)
-            static Eigen::MatrixXd getWGNoise( const Eigen::MatrixXd& std, const Eigen::MatrixXd& bias, Index rows, Index cols=1);
+protected:
+  static boost::lagged_fibonacci1279 gen_;
+};
 
-        protected:
-            static boost::lagged_fibonacci1279 gen_;
+#include "tools.hxx"
+} // namespace unitTesting
+} // namespace stateObserver
 
-        };
-
-#       include "tools.hxx"
-    }
-}
-
-
-
-#endif //OBSERVATIONTOOLSHPP
+#endif // OBSERVATIONTOOLSHPP


### PR DESCRIPTION
This PR sets up and runs clang-format scripts on the whole codebase, using the same style as `mc_rtc`.

I had a quick look through the changes, overall it looks pretty reasonable, but some maths expressions/matrix definitions might have suffered in readability in the process. @mehdi-benallegue If you notice some code that would benefit from being manually formatted, we can protect it with

```cpp
// clang-format off
...
// clang-format on
```