### PR TITLE
Properly define static constexpr members

### DIFF
--- a/include/state-observation/flexibility-estimation/imu-elastic-local-frame-dynamical-system.hpp
+++ b/include/state-observation/flexibility-estimation/imu-elastic-local-frame-dynamical-system.hpp
@@ -38,45 +38,45 @@ class STATE_OBSERVATION_DLLAPI IMUElasticLocalFrameDynamicalSystem : public stat
 public:
   struct input
   {
-    /// indexes of the different components of a vector of the input state
-    static const unsigned posCom = 0;
-    static const unsigned velCom = 3;
-    static const unsigned accCom = 6;
-    static const unsigned inertia = 9;
-    static const unsigned angMoment = 15;
-    static const unsigned dotInertia = 18;
-    static const unsigned dotAngMoment = 24;
-    static const unsigned posIMU = 27;
-    static const unsigned oriIMU = 30;
-    static const unsigned linVelIMU = 33;
-    static const unsigned angVelIMU = 36;
-    static const unsigned linAccIMU = 39;
-    static const unsigned additionalForces = 42;
-    static const unsigned contacts = 48;
+    /// indices of the different components of a vector of the input state
+    static constexpr unsigned posCom = 0;
+    static constexpr unsigned velCom = 3;
+    static constexpr unsigned accCom = 6;
+    static constexpr unsigned inertia = 9;
+    static constexpr unsigned angMoment = 15;
+    static constexpr unsigned dotInertia = 18;
+    static constexpr unsigned dotAngMoment = 24;
+    static constexpr unsigned posIMU = 27;
+    static constexpr unsigned oriIMU = 30;
+    static constexpr unsigned linVelIMU = 33;
+    static constexpr unsigned angVelIMU = 36;
+    static constexpr unsigned linAccIMU = 39;
+    static constexpr unsigned additionalForces = 42;
+    static constexpr unsigned contacts = 48;
 
-    static const unsigned sizeBase = 48;
+    static constexpr unsigned sizeBase = 48;
   };
 
   struct state
   {
-    static const unsigned pos = 0;
-    static const unsigned ori = 3;
-    static const unsigned linVel = 6;
-    static const unsigned angVel = 9;
-    static const unsigned fc = 12;
-    static const unsigned unmodeledForces = 24;
-    static const unsigned comBias = 30;
-    static const unsigned drift = 32;
+    static constexpr unsigned pos = 0;
+    static constexpr unsigned ori = 3;
+    static constexpr unsigned linVel = 6;
+    static constexpr unsigned angVel = 9;
+    static constexpr unsigned fc = 12;
+    static constexpr unsigned unmodeledForces = 24;
+    static constexpr unsigned comBias = 30;
+    static constexpr unsigned drift = 32;
 
-    static const unsigned size = 35;
+    static constexpr unsigned size = 35;
   };
 
   struct contactModel
   {
-    /// indexes of the different components of a vector of the input state
-    static const unsigned elasticContact = 1;
-    static const unsigned pendulum = 2;
-    static const unsigned none = 0;
+    /// indices of the different components of a vector of the input state
+    static constexpr unsigned elasticContact = 1;
+    static constexpr unsigned pendulum = 2;
+    static constexpr unsigned none = 0;
   };
 
   typedef Eigen::LLT<Matrix3> LLTMatrix3;
@@ -342,9 +342,9 @@ protected:
 
   Matrix3 & computeRotation_(const Vector3 & x, int i);
 
-  static const Index stateSize_ = state::size;
+  static constexpr Index stateSize_ = state::size;
   Index inputSize_;
-  static const Index measurementSizeBase_ = 6;
+  static constexpr Index measurementSizeBase_ = 6;
   unsigned nbContacts_;
   unsigned contactModel_;
 

--- a/src/imu-elastic-local-frame-dynamical-system.cpp
+++ b/src/imu-elastic-local-frame-dynamical-system.cpp
@@ -31,16 +31,14 @@ namespace flexibilityEstimation
 {
 using namespace stateObservation;
 
-/**
- * Provide the definition of the static constexpr members of
- * input/state/modelContact struct. This looks odd but is necessary pre-C++17.
- * See https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char
- * for further information.
- *
- * Note: this is no-longer necessary from C++17 onwards as "Proposal P0386 Inline Variables" introduces the ability to
- * apply the inline specifier to variables. In particular to this case constexpr implies inline for static member
- * variables. See https://wg21.link/P0386
- */
+/// Provide the definition of the static constexpr members of
+/// input/state/modelContact struct. This looks odd but is necessary pre-C++17.
+/// See https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char
+/// for further information.
+/// Note: this is no-longer necessary from C++17 onwards as "Proposal P0386 Inline Variables" introduces the ability to
+/// apply the inline specifier to variables. In particular to this case constexpr implies inline for static member
+/// variables. See https://wg21.link/P0386
+
 constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::posCom;
 constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::velCom;
 constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::accCom;

--- a/src/imu-elastic-local-frame-dynamical-system.cpp
+++ b/src/imu-elastic-local-frame-dynamical-system.cpp
@@ -31,6 +31,50 @@ namespace flexibilityEstimation
 {
 using namespace stateObservation;
 
+/**
+ * Provide the definition of the static constexpr members of
+ * input/state/modelContact struct. This looks odd but is necessary pre-C++17.
+ * See https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char
+ * for further information.
+ *
+ * Note: this is no-longer necessary from C++17 onwards as "Proposal P0386 Inline Variables" introduces the ability to
+ * apply the inline specifier to variables. In particular to this case constexpr implies inline for static member
+ * variables. See https://wg21.link/P0386
+ */
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::posCom;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::velCom;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::accCom;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::inertia;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::angMoment;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::dotInertia;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::dotAngMoment;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::posIMU;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::oriIMU;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::linVelIMU;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::angVelIMU;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::linAccIMU;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::additionalForces;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::contacts;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::input::sizeBase;
+
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::pos;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::ori;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::linVel;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::angVel;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::fc;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::unmodeledForces;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::comBias;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::drift;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::state::size;
+
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::contactModel::elasticContact;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::contactModel::pendulum;
+constexpr unsigned IMUElasticLocalFrameDynamicalSystem::contactModel::none;
+
+constexpr Index IMUElasticLocalFrameDynamicalSystem::stateSize_;
+constexpr Index IMUElasticLocalFrameDynamicalSystem::measurementSizeBase_;
+// end of static constexpr definitions
+
 IMUElasticLocalFrameDynamicalSystem::IMUElasticLocalFrameDynamicalSystem(double dt)
 : processNoise_(0x0), dt_(dt), robotMass_(hrp2::m), robotMassInv_(1 / hrp2::m), measurementSize_(measurementSizeBase_),
   withForceMeasurements_(false), withComBias_(false), withAbsolutePos_(false), withUnmodeledForces_(false),


### PR DESCRIPTION
This PR fixes an issue with the definition of `static const`/`static constexpr` member variables. I ran into this issue while trying to this from within an observer plugin in mc_rtc: it fails to load the library due to the missing symbol `stateObservation::flexibilityEstimation::IMUElasticLocalFrameDynamicalSystem::state::size` (same goes for all other `static const` variables)

This is a bit odd, but the following is only the declaration of the variable.
```cpp
// header
struct Test
{
 static constexpr double var = 3;
};
```

the definition must be provided in the implementation file, even though it does not technically provide any additional information.

```cpp
// source
constexpr double var;
```

See [this stackoverflow discussion](https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char) for further details. C++17 resolves this issue by introducing inline variables and implicitely marking the `static constexpr` variables as inline (see [P0386](https://wg21.link/P0386)).

While I'm at it I've made those `constexpr` as well ;)